### PR TITLE
implement faster partition shutdown

### DIFF
--- a/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsTransport.cs
+++ b/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsTransport.cs
@@ -214,8 +214,8 @@ namespace DurableTask.Netherite.EventHubs
         async Task ITaskHub.StopAsync(bool isForced)
         {
             this.traceHelper.LogInformation("Shutting down EventHubsBackend");
-            this.traceHelper.LogDebug("Stopping client event loop");
-            this.shutdownSource.Cancel();
+            this.shutdownSource.Cancel(); // initiates shutdown of client and of all partitions
+
             this.traceHelper.LogDebug("Stopping client");
             await this.client.StopAsync().ConfigureAwait(false);
             this.traceHelper.LogDebug("Unregistering event processor");
@@ -239,7 +239,7 @@ namespace DurableTask.Netherite.EventHubs
 
         IEventProcessor IEventProcessorFactory.CreateEventProcessor(PartitionContext partitionContext)
         {
-            var processor = new EventHubsProcessor(this.host, this, this.parameters, partitionContext, this.settings, this.traceHelper);
+            var processor = new EventHubsProcessor(this.host, this, this.parameters, partitionContext, this.settings, this.traceHelper, this.shutdownSource.Token);
             return processor;
         }
 


### PR DESCRIPTION
To address #11.

When EventProcessorHost is shutdown (such as when stopping function app or when scaling down), now we do immediately initiate shutdown of all partitions.

That way, when EventProcessorHost finally decides to stop the processors, the work is already done.