### PR TITLE
Add eventhubs consumer test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -272,6 +272,9 @@ FakesAssemblies/
 .ntvs_analysis.dat
 node_modules/
 
+# ASP.NET
+**/[Ll]aunch[Ss]ettings.json
+
 # Visual Studio 6 build log
 *.plg
 

--- a/DurableTask.Netherite.sln
+++ b/DurableTask.Netherite.sln
@@ -35,6 +35,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{21BE
 		scripts\create-eventhubs-instances.ps1 = scripts\create-eventhubs-instances.ps1
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventProducer", "test\EventProducer\EventProducer.csproj", "{5F2A1A00-13A2-40C5-A1D6-A3518E4645E8}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventConsumer", "test\EventConsumer\EventConsumer.csproj", "{1D16A6FD-944C-49A1-8727-6236861F437A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -65,6 +69,14 @@ Global
 		{654DA6B4-2E2F-4386-BB9F-7CE5A13998DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{654DA6B4-2E2F-4386-BB9F-7CE5A13998DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{654DA6B4-2E2F-4386-BB9F-7CE5A13998DE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5F2A1A00-13A2-40C5-A1D6-A3518E4645E8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5F2A1A00-13A2-40C5-A1D6-A3518E4645E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5F2A1A00-13A2-40C5-A1D6-A3518E4645E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5F2A1A00-13A2-40C5-A1D6-A3518E4645E8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1D16A6FD-944C-49A1-8727-6236861F437A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1D16A6FD-944C-49A1-8727-6236861F437A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1D16A6FD-944C-49A1-8727-6236861F437A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1D16A6FD-944C-49A1-8727-6236861F437A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -76,6 +88,8 @@ Global
 		{1809EEF7-0772-404A-96C2-D76D80F1D191} = {4A7226CF-57BF-4CA3-A4AC-91A398A1D84B}
 		{DD1E1B3F-4FA2-4F3A-9AE1-6B2A0B864AAF} = {4A7226CF-57BF-4CA3-A4AC-91A398A1D84B}
 		{654DA6B4-2E2F-4386-BB9F-7CE5A13998DE} = {AB958467-9236-402E-833C-B8DE4841AB9F}
+		{5F2A1A00-13A2-40C5-A1D6-A3518E4645E8} = {4A7226CF-57BF-4CA3-A4AC-91A398A1D84B}
+		{1D16A6FD-944C-49A1-8727-6236861F437A} = {4A7226CF-57BF-4CA3-A4AC-91A398A1D84B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {238A9613-5411-41CF-BDEC-168CCD5C03FB}

--- a/test/EventConsumer/Event.cs
+++ b/test/EventConsumer/Event.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace EventConsumer
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using Newtonsoft.Json;
+
+    [JsonObject(MemberSerialization.OptOut)]
+    public struct Event
+    {
+        public int Partition { get; set; }
+
+        public long SeqNo { get; set; }
+
+        public byte[] Payload { get; set; }
+
+        public override string ToString()
+        {
+            return $"Event {this.Partition}.{this.SeqNo} size={this.Payload.Length}";
+        }
+    }
+}

--- a/test/EventConsumer/EventConsumer.csproj
+++ b/test/EventConsumer/EventConsumer.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.4.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.3" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\DurableTask.Netherite.AzureFunctions\DurableTask.Netherite.AzureFunctions.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="host.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/test/EventConsumer/EventHubTrigger.cs
+++ b/test/EventConsumer/EventHubTrigger.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace EventConsumer
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.EventHubs;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+    using Microsoft.Extensions.Logging;
+
+    public static class EventHubTrigger
+    {
+
+        [FunctionName("MyEventHubTrigger")]
+        public static async Task RunAsync(
+            [EventHubTrigger(TestConstants.EventHubName, Connection = "EventHubsConnection")] EventData[] eventDataSet,
+            [DurableClient] IDurableClient client,
+            ILogger log)
+        {
+            if (TestConstants.BatchSignals)
+            {
+                // we pack all the events into a byte sequence, and then
+                // send those bytes as a signals to the entity
+
+                var stream = new MemoryStream();
+                using var streamWriter = new BinaryWriter(stream);
+
+                for (int i = 0; i < eventDataSet.Length; i++)
+                {
+                    var eventData = eventDataSet[i];
+                    var sp = eventData.SystemProperties;
+                    streamWriter.Write((int) eventData.Body[0]);
+                    streamWriter.Write(eventData.SystemProperties.SequenceNumber);
+                    streamWriter.Write(eventData.Body.Count);
+                    streamWriter.Write(eventData.Body);
+                }
+
+                streamWriter.Flush();
+                await client.SignalEntityAsync(new EntityId(nameof(ReceiverEntity), "0"), nameof(ReceiverEntity.ReceiveBatch), stream.ToArray());
+            }
+            else
+            {
+                var signalTasks = new List<Task>();
+
+                // send one signal for each packet
+                for (int i = 0; i < eventDataSet.Length; i++)
+                {
+                    var eventData = eventDataSet[i];
+                    var sp = eventData.SystemProperties;
+                    byte[] payload = eventData.Body.ToArray();
+                    var evt = new Event()
+                    { 
+                        Partition = payload[0],
+                        SeqNo = eventData.SystemProperties.SequenceNumber,
+                        Payload = payload
+                    };
+                    log.LogInformation($"Sending signal for {evt}");
+                    signalTasks.Add(client.SignalEntityAsync(new EntityId(nameof(ReceiverEntity), "0"), nameof(ReceiverEntity.Receive), evt));
+                }
+
+                await Task.WhenAll(signalTasks);
+            }
+        }
+    }
+}

--- a/test/EventConsumer/ReceiverEntity.cs
+++ b/test/EventConsumer/ReceiverEntity.cs
@@ -1,0 +1,145 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace EventConsumer
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+    using Microsoft.Extensions.Logging;
+    using Newtonsoft.Json;
+
+    [JsonObject(MemberSerialization.OptIn)]
+    public class ReceiverEntity
+    {
+        ILogger logger;
+        bool objectPreviouslyUsed;
+
+        [JsonProperty]
+        public int EventCount { get; set; }
+
+        [JsonProperty]
+        public int ConstructionCount { get; set; }
+
+        [JsonProperty]
+        public int BatchCount { get; set; }
+
+        [JsonProperty]
+        public DateTime StartTime { get; set; }
+
+        [JsonProperty]
+        public Dictionary<int, long> LastReceived { get; set; }
+
+        [JsonProperty]
+        public int OutOfOrderCount { get; set; }
+
+        public ReceiverEntity(ILogger logger)
+        {
+            this.logger = logger;
+        }
+
+        public ILogger Logger { set { this.logger = value; } }
+
+        public void ReceiveBatch(byte[] bytes)
+        {
+            this.BatchCount++;
+            var stream = new MemoryStream(bytes);
+            using var reader = new BinaryReader(stream);
+            while (stream.Position < bytes.Length)
+            {
+                int partition = reader.ReadInt32();
+                long seqNo = reader.ReadInt64();
+                int length = reader.ReadInt32();
+                byte[] payload = reader.ReadBytes(length);
+                this.Receive(new Event()
+                {
+                    Partition = partition,
+                    SeqNo = seqNo,
+                    Payload = payload
+                });
+            }
+        }
+
+        public void Receive(Event evt)
+        {
+            if (this.EventCount == 0)
+            {
+                this.logger.LogWarning("Starting test");
+                this.StartTime = DateTime.UtcNow;
+                this.LastReceived = new Dictionary<int, long>();
+            }
+
+            if (this.logger.IsEnabled(LogLevel.Information))
+            {
+                this.logger.LogInformation($"Received event #{this.EventCount}: {evt}");
+            }
+
+            // test in-order delivery
+            if (this.LastReceived.TryGetValue(evt.Partition, out long lastSeqNo))
+            {
+                if (lastSeqNo + 1 != evt.SeqNo)
+                {
+                    this.logger.LogError($"out-of-order delivery: expecting seqno={lastSeqNo + 1} but received {evt}");
+                    this.OutOfOrderCount++;
+                }
+                this.LastReceived[evt.Partition] = evt.SeqNo;
+            }
+            else
+            {
+                this.LastReceived[evt.Partition] = evt.SeqNo;
+            }
+            
+            // increment counter
+            this.EventCount++;
+
+            // track how many times we have constructed this object
+            if (!this.objectPreviouslyUsed)
+            {
+                this.ConstructionCount++;
+                this.objectPreviouslyUsed = true;
+            }
+
+            if (this.EventCount == TestConstants.NumberEventsPerTest)
+            {
+                this.logger.LogWarning($"Completed test, elapsed={(DateTime.UtcNow - this.StartTime).TotalSeconds:f2}s, eventCount={this.EventCount}, batchCount={this.BatchCount} constructionCount={this.ConstructionCount} outOfOrderCount={this.OutOfOrderCount}");
+                this.EventCount = 0;
+                this.BatchCount = 0;
+                this.ConstructionCount = 0;
+                this.LastReceived = null;
+                this.OutOfOrderCount = 0;
+            }
+        }
+
+        [FunctionName(nameof(ReceiverEntity))]
+        public static Task Run([EntityTrigger] IDurableEntityContext context, ILogger logger)
+        {
+            if (TestConstants.UseClassBasedAPI)
+            {
+                return context.DispatchAsync<ReceiverEntity>(logger);
+            }
+            else
+            {
+                var state = context.GetState<ReceiverEntity>(() => new ReceiverEntity(logger));
+
+                state.Logger = logger;
+
+                switch (context.OperationName)
+                {
+                    case (nameof(ReceiverEntity.ReceiveBatch)):
+                        state.ReceiveBatch(context.GetInput<byte[]>());
+                        break;
+                    case (nameof(ReceiverEntity.Receive)):
+                        state.Receive(context.GetInput<Event>());
+                        break;
+
+                }
+
+                return Task.CompletedTask;
+            }
+        }
+    }
+}
+ 

--- a/test/EventConsumer/TestConstants.cs
+++ b/test/EventConsumer/TestConstants.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace EventConsumer
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    public class TestConstants
+    {
+        /// <summary>
+        /// The name of the Event Hub that connects the consumer and producer
+        /// </summary>
+        public const string EventHubName = "eventstest";
+
+        /// <summary>
+        /// Whether to deliver all events in the batch as a single entity signal, or as individual signals
+        /// </summary>
+        public static bool BatchSignals => true;
+
+        /// <summary>
+        /// Whether to use the class-based API, or the function-based API for entities.
+        /// </summary>
+        public static bool UseClassBasedAPI => true;
+
+        /// <summary>
+        /// The number of events to produce or consume, in one run of the test.
+        /// </summary>
+        public static int NumberEventsPerTest => 10000;
+
+        /// <summary>
+        /// The size of the random payload to attach to each event, in bytes
+        /// </summary>
+        public static long PayloadSize => 1000;
+
+        /// <summary>
+        /// The number of events to include in each batch on the producer side
+        /// </summary>
+        public static int ProducerBatchSize => 500;
+    }
+}

--- a/test/EventConsumer/host.json
+++ b/test/EventConsumer/host.json
@@ -1,0 +1,27 @@
+{
+  "version": "2.0",
+  "logging": {
+    "logLevel": {
+      "default": "Warning",
+      "Function.MyEventHubTrigger": "Warning",
+      "Function.Receiver": "Warning",
+      "DurableTask.Netherite": "Information",
+      "DurableTask.Netherite.Events": "Warning",
+      "DurableTask.Netherite.FasterStorage": "Warning",
+      "DurableTask.Netherite.EventHubsTransport": "Warning",
+      "DurableTask.Netherite.WorkItems": "Information"
+    }
+  },
+  "extensions": {
+    "durableTask": {
+      "hubName": "eventconsumer",
+      "extendedSessionsEnabled": "true",
+      "rollbackEntityOperationsOnExceptions": "true",
+      "UseGracefulShutdown": "true",
+      "storageProvider": {
+        "StorageConnectionString": "$AzureWebJobsStorage",
+        "EventHubsConnectionString": "$EventHubsConnection"
+      }
+    }
+  }
+}

--- a/test/EventConsumer/host.json
+++ b/test/EventConsumer/host.json
@@ -9,7 +9,7 @@
       "DurableTask.Netherite.Events": "Warning",
       "DurableTask.Netherite.FasterStorage": "Warning",
       "DurableTask.Netherite.EventHubsTransport": "Warning",
-      "DurableTask.Netherite.WorkItems": "Information"
+      "DurableTask.Netherite.WorkItems": "Warning"
     }
   },
   "extensions": {

--- a/test/EventConsumer/local.settings.json
+++ b/test/EventConsumer/local.settings.json
@@ -1,0 +1,8 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "Should be ignored because we have the environment variable set",
+    "EventHubsConnection": "Should be ignored because we have the environment variable set",
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet"
+  }
+}

--- a/test/EventProducer/EventProducer.csproj
+++ b/test/EventProducer/EventProducer.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.EventHubs" Version="4.3.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EventConsumer\EventConsumer.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/EventProducer/Program.cs
+++ b/test/EventProducer/Program.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace EventProducer
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.EventHubs;
+    using EventConsumer;
+
+    class Program
+    {
+        // Run this locally, prior to starting the function up, to fill the selected EventHub or AzureStorage queue
+        // with the events for the test. Then start function app to consume the events.
+
+        // When running function app multiple times, clear AzureStorage:
+        // - EventHubs: clear the blobs in 
+        //      azure-webjobs-eventhub/XXX.servicebus.windows.net/YYY
+        //      where XXX = eventhubs namespace, YYY = eventhub 
+        //   This means that events are consumed from the EventHub beginning again on next start.
+        //   This also means that you only need to run Generate.exe once to fill up the EventHub
+        //     (because it does not remove messages (immediately, anyway.. it eventually ages them out)).
+
+        const string NoPrompt = "NoPrompt";
+        static async Task Main(string[] args)
+        {
+            var connectionStringName = "EventHubsConnection";
+
+            bool getConnectionString(out string connStr)
+            {
+                connStr = Environment.GetEnvironmentVariable(connectionStringName);
+                return !string.IsNullOrWhiteSpace(connStr);
+            }
+
+            if (!getConnectionString(out string connectionString))
+            {
+                Console.Error.WriteLine($"ConnectionStringName environment variable {connectionStringName} was not found or did not contain a valid connection string");
+                return;
+            }
+
+            await GenerateEventsInEventHub(
+                connectionString, 
+                numEvents: TestConstants.NumberEventsPerTest, 
+                messageSize: TestConstants.PayloadSize, 
+                batchSize: TestConstants.ProducerBatchSize);
+ 
+            //Console.WriteLine("; press any key to exit\n");
+            //Console.ReadKey();
+        }
+
+        static async Task GenerateEventsInEventHub(string connectionString, int numEvents, long messageSize, int batchSize)
+        {
+            Console.WriteLine($"Generating {numEvents} EventHub events");
+
+            var connectionStringBuilder = new EventHubsConnectionStringBuilder(connectionString)
+            {
+                EntityPath = TestConstants.EventHubName,
+            };
+            var ehc = EventHubClient.CreateFromConnectionString(connectionStringBuilder.ToString());
+
+            async Task SendEventsAsync(int offset, int events, string partitionId)
+            {
+                var partitionSender = ehc.CreatePartitionSender(partitionId);
+                var eventBatch = new List<EventData>(100);
+                for (int x = 0; x < events; x++)
+                {
+                    byte[] payload = new byte[messageSize];
+                    (new Random()).NextBytes(payload);
+                    payload[0] = byte.Parse(partitionId);
+                    var e = new EventData(payload);
+                    eventBatch.Add(e);
+
+                    if (x % batchSize == (batchSize - 1))
+                    {
+                        await partitionSender.SendAsync(eventBatch);
+                        Console.WriteLine($"Sent {x + 1} events to partition {partitionId}");
+                        eventBatch = new List<EventData>(100);
+                    }
+                }
+                if (eventBatch.Count > 0)
+                {
+                    await partitionSender.SendAsync(eventBatch);
+                    Console.WriteLine($"Sent {events} events to partition {partitionId}");
+                }
+            }
+
+            var ehInfo = ehc.GetRuntimeInformationAsync().GetAwaiter().GetResult();
+            Console.WriteLine($"Sending {numEvents} events to {ehInfo.PartitionCount} partitions...");
+
+            var partitionTasks = new List<Task>();
+            var remaining = numEvents;
+            for (int i = ehInfo.PartitionCount; i >= 1; i--)
+            {
+                var portion = remaining / i;
+                remaining -= portion;
+                partitionTasks.Add(SendEventsAsync(remaining, portion, ehInfo.PartitionIds[i - 1]));
+            }
+
+            await Task.WhenAll(partitionTasks);
+
+            Console.WriteLine($"Generated all {numEvents} EventHub events.");
+        }
+    }
+}


### PR DESCRIPTION
Adds a new performance test that consumes events from an event hub, using a trigger, and processes them on an entity.