### PR TITLE
Support ETW trace collection on linux

### DIFF
--- a/src/DurableTask.Netherite.AzureFunctions/NetheriteProvider.cs
+++ b/src/DurableTask.Netherite.AzureFunctions/NetheriteProvider.cs
@@ -43,6 +43,8 @@ namespace DurableTask.Netherite.AzureFunctions
 
         public override TimeSpan MaximumDelayTime { get; set; } = TimeSpan.MaxValue;
 
+        public override string EventSourceName => "DurableTask-Netherite";
+
         /// <inheritdoc/>
         public async override Task<string> RetrieveSerializedEntityState(EntityId entityId, JsonSerializerSettings serializerSettings)
         {

--- a/src/DurableTask.Netherite/OrchestrationService/Client.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/Client.cs
@@ -144,7 +144,7 @@ namespace DurableTask.Netherite
         internal class PendingRequest : TransportAbstraction.IDurabilityOrExceptionListener
         {
             readonly long requestId;
-            readonly EventId eventId;
+            readonly EventId partitionEventId;
             readonly uint partitionId;
             readonly Client client;
             readonly (DateTime due, int id) timeoutKey;
@@ -158,11 +158,11 @@ namespace DurableTask.Netherite
 
             public string RequestId => $"{Client.GetShortId(this.client.ClientId)}-{this.requestId}"; // matches EventId
 
-            public PendingRequest(long requestId, EventId eventId, uint partitionId, Client client, DateTime due, int timeoutId)
+            public PendingRequest(long requestId, EventId partitionEventId, uint partitionId, Client client, DateTime due, int timeoutId)
             {
                 this.requestId = requestId;
                 this.partitionId = partitionId;
-                this.eventId = eventId;
+                this.partitionEventId = partitionEventId;
                 this.client = client;
                 this.timeoutKey = (due, timeoutId);
                 this.continuation = new TaskCompletionSource<ClientEvent>();
@@ -252,7 +252,7 @@ namespace DurableTask.Netherite
                 this.client.traceHelper.TraceTimerProgress($"firing ({this.timeoutKey.due:o},{this.timeoutKey.id})");
                 if (this.client.ResponseWaiters.TryRemove(this.requestId, out var pendingRequest))
                 {
-                    this.client.traceHelper.TraceRequestTimeout(pendingRequest.eventId, pendingRequest.partitionId);
+                    this.client.traceHelper.TraceRequestTimeout(pendingRequest.partitionEventId, pendingRequest.partitionId);
                     this.continuation.TrySetException(timeoutException);
                 }
             }

--- a/src/DurableTask.Netherite/Tracing/ClientTraceHelper.cs
+++ b/src/DurableTask.Netherite/Tracing/ClientTraceHelper.cs
@@ -72,22 +72,22 @@ namespace DurableTask.Netherite
             }
         }
 
-        public void TraceRequestTimeout(EventId eventId, uint partitionId)
+        public void TraceRequestTimeout(EventId partitionEventId, uint partitionId)
         {
             if (this.logLevelLimit <= LogLevel.Warning)
             {
                 if (this.logger.IsEnabled(LogLevel.Warning))
                 {
-                    this.logger.LogWarning("{client} Request {eventId} for partition {partitionId:D2} timed out", this.tracePrefix, eventId, partitionId);
+                    this.logger.LogWarning("{client} Request {eventId} for partition {partitionId:D2} timed out", this.tracePrefix, partitionEventId, partitionId);
                 }
                 if (EtwSource.Log.IsEnabled())
                 {
-                    EtwSource.Log.ClientRequestTimeout(this.account, this.taskHub, this.clientId, eventId.ToString(), (int) partitionId, TraceUtils.AppName, TraceUtils.ExtensionVersion);
+                    EtwSource.Log.ClientRequestTimeout(this.account, this.taskHub, this.clientId, partitionEventId.ToString(), (int) partitionId, TraceUtils.AppName, TraceUtils.ExtensionVersion);
                 }
             }
         }
 
-        public void TraceSend(Event @event)
+        public void TraceSend(PartitionEvent @event)
         {
             if (this.logLevelLimit <= LogLevel.Debug)
             {
@@ -97,12 +97,12 @@ namespace DurableTask.Netherite
                 }
                 if (EtwSource.Log.IsEnabled())
                 {
-                    EtwSource.Log.ClientEventSent(this.account, this.taskHub, this.clientId, @event.EventIdString, @event.ToString(), TraceUtils.AppName, TraceUtils.ExtensionVersion);
+                    EtwSource.Log.ClientSentEvent(this.account, this.taskHub, this.clientId, @event.EventIdString, @event.ToString(), TraceUtils.AppName, TraceUtils.ExtensionVersion);
                 }
             }
         }
 
-        public void TraceReceive(Event @event)
+        public void TraceReceive(ClientEvent @event)
         {
             if (this.logLevelLimit <= LogLevel.Debug)
             {
@@ -112,7 +112,7 @@ namespace DurableTask.Netherite
                 }
                 if (EtwSource.Log.IsEnabled())
                 {
-                    EtwSource.Log.ClientEventReceived(this.account, this.taskHub, this.clientId, @event.EventIdString, @event.ToString(), TraceUtils.AppName, TraceUtils.ExtensionVersion);
+                    EtwSource.Log.ClientReceivedEvent(this.account, this.taskHub, this.clientId, @event.EventIdString, @event.ToString(), TraceUtils.AppName, TraceUtils.ExtensionVersion);
                 }
             }
         }

--- a/src/DurableTask.Netherite/Tracing/EtwSource.cs
+++ b/src/DurableTask.Netherite/Tracing/EtwSource.cs
@@ -105,10 +105,10 @@ namespace DurableTask.Netherite
         }
 
         [Event(217, Level = EventLevel.Warning, Version = 1)]
-        public void ClientRequestTimeout(string Account, string TaskHub, Guid ClientId, string EventId, int PartitionId, string AppName, string ExtensionVersion)
+        public void ClientRequestTimeout(string Account, string TaskHub, Guid ClientId, string PartitionEventId, int PartitionId, string AppName, string ExtensionVersion)
         {
             SetCurrentThreadActivityId(serviceInstanceId);
-            this.WriteEvent(217, Account, TaskHub, ClientId, EventId, PartitionId, AppName, ExtensionVersion);
+            this.WriteEvent(217, Account, TaskHub, ClientId, PartitionEventId, PartitionId, AppName, ExtensionVersion);
         }
 
         // ----- specific events relating to DurableTask concepts (TaskMessage, OrchestrationWorkItem, Instance)
@@ -170,61 +170,61 @@ namespace DurableTask.Netherite
         }
 
         [Event(228, Level = EventLevel.Verbose, Version = 1)]
-        public void InstanceStatusFetched(string Account, string TaskHub, int PartitionId, string InstanceId, string ExecutionId, string status, string EventId, double LatencyMs, string AppName, string ExtensionVersion)
+        public void InstanceStatusFetched(string Account, string TaskHub, int PartitionId, string InstanceId, string ExecutionId, string status, string PartitionEventId, double LatencyMs, string AppName, string ExtensionVersion)
         {
             SetCurrentThreadActivityId(serviceInstanceId);
-            this.WriteEvent(228, Account, TaskHub, PartitionId, InstanceId, ExecutionId, status, EventId, LatencyMs, AppName, ExtensionVersion);
+            this.WriteEvent(228, Account, TaskHub, PartitionId, InstanceId, ExecutionId, status, PartitionEventId, LatencyMs, AppName, ExtensionVersion);
         }
 
         [Event(229, Level = EventLevel.Verbose, Version = 1)]
-        public void InstanceHistoryFetched(string Account, string TaskHub, int PartitionId, string InstanceId, string ExecutionId, int EventCount, int Episode, string EventId, double LatencyMs, string AppName, string ExtensionVersion)
+        public void InstanceHistoryFetched(string Account, string TaskHub, int PartitionId, string InstanceId, string ExecutionId, int EventCount, int Episode, string PartitionEventId, double LatencyMs, string AppName, string ExtensionVersion)
         {
             SetCurrentThreadActivityId(serviceInstanceId);
-            this.WriteEvent(229, Account, TaskHub, PartitionId, InstanceId, ExecutionId, EventCount, Episode, EventId, LatencyMs, AppName, ExtensionVersion);
+            this.WriteEvent(229, Account, TaskHub, PartitionId, InstanceId, ExecutionId, EventCount, Episode, PartitionEventId, LatencyMs, AppName, ExtensionVersion);
         }
 
         // ----- general event processing and statistics
 
         [Event(240, Level = EventLevel.Informational, Version = 1)]
-        public void PartitionEventProcessed(string Account, string TaskHub, int PartitionId, long CommitLogPosition, string Category, string EventId, string EventInfo, long NextCommitLogPosition, long NextInputQueuePosition, double QueueLatencyMs, double FetchLatencyMs, double LatencyMs, bool IsReplaying, string AppName, string ExtensionVersion)
+        public void PartitionEventProcessed(string Account, string TaskHub, int PartitionId, long CommitLogPosition, string Category, string PartitionEventId, string EventInfo, long NextCommitLogPosition, long NextInputQueuePosition, double QueueLatencyMs, double FetchLatencyMs, double LatencyMs, bool IsReplaying, string AppName, string ExtensionVersion)
         {
             SetCurrentThreadActivityId(serviceInstanceId);
-            this.WriteEvent(240, Account, TaskHub, PartitionId, CommitLogPosition, Category, EventId, EventInfo, NextCommitLogPosition, NextInputQueuePosition, QueueLatencyMs, FetchLatencyMs, LatencyMs, IsReplaying, AppName, ExtensionVersion);
+            this.WriteEvent(240, Account, TaskHub, PartitionId, CommitLogPosition, Category, PartitionEventId, EventInfo, NextCommitLogPosition, NextInputQueuePosition, QueueLatencyMs, FetchLatencyMs, LatencyMs, IsReplaying, AppName, ExtensionVersion);
         }
 
         [Event(241, Level = EventLevel.Verbose, Version = 1)]
-        public void PartitionEventDetail(string Account, string TaskHub, int PartitionId, long CommitLogPosition, string EventId, string Details, string AppName, string ExtensionVersion)
+        public void PartitionEventDetail(string Account, string TaskHub, int PartitionId, long CommitLogPosition, string PartitionEventId, string Details, string AppName, string ExtensionVersion)
         {
             SetCurrentThreadActivityId(serviceInstanceId);
-            this.WriteEvent(241, Account, TaskHub, PartitionId, CommitLogPosition, EventId, Details, AppName, ExtensionVersion);
+            this.WriteEvent(241, Account, TaskHub, PartitionId, CommitLogPosition, PartitionEventId, Details, AppName, ExtensionVersion);
         }
 
         [Event(242, Level = EventLevel.Warning, Version = 1)]
-        public void PartitionEventWarning(string Account, string TaskHub, int PartitionId, long CommitLogPosition, string EventId, string Details, string AppName, string ExtensionVersion)
+        public void PartitionEventWarning(string Account, string TaskHub, int PartitionId, long CommitLogPosition, string PartitionEventId, string Details, string AppName, string ExtensionVersion)
         {
             SetCurrentThreadActivityId(serviceInstanceId);
-            this.WriteEvent(242, Account, TaskHub, PartitionId, CommitLogPosition, EventId, Details, AppName, ExtensionVersion);
+            this.WriteEvent(242, Account, TaskHub, PartitionId, CommitLogPosition, PartitionEventId, Details, AppName, ExtensionVersion);
         }
 
         [Event(243, Level = EventLevel.Verbose, Version = 1)]
-        public void ClientEventReceived(string Account, string TaskHub, Guid ClientId, string EventId, string EventInfo, string AppName, string ExtensionVersion)
+        public void ClientReceivedEvent(string Account, string TaskHub, Guid ClientId, string PartitionEventId, string EventInfo, string AppName, string ExtensionVersion)
         {
             SetCurrentThreadActivityId(serviceInstanceId);
-            this.WriteEvent(243, Account, TaskHub, ClientId, EventId, EventInfo, AppName, ExtensionVersion);
+            this.WriteEvent(243, Account, TaskHub, ClientId, PartitionEventId, EventInfo, AppName, ExtensionVersion);
         }
 
         [Event(244, Level = EventLevel.Verbose, Version = 1)]
-        public void ClientEventSent(string Account, string TaskHub, Guid ClientId, string EventId, string EventInfo, string AppName, string ExtensionVersion)
+        public void ClientSentEvent(string Account, string TaskHub, Guid ClientId, string PartitionEventId, string EventInfo, string AppName, string ExtensionVersion)
         {
             SetCurrentThreadActivityId(serviceInstanceId);
-            this.WriteEvent(244, Account, TaskHub, ClientId, EventId, EventInfo, AppName, ExtensionVersion);
+            this.WriteEvent(244, Account, TaskHub, ClientId, PartitionEventId, EventInfo, AppName, ExtensionVersion);
         }
 
         [Event(245, Level = EventLevel.Warning, Version = 1)]
-        public void PartitionOffloadDecision(string Account, string TaskHub, int PartitionId, long CommitLogPosition, string EventId, int ReportedLocalLoad, int Pending, int Backlog, int Remotes, string ReportedRemoteLoad, string AppName, string ExtensionVersion)
+        public void PartitionOffloadDecision(string Account, string TaskHub, int PartitionId, long CommitLogPosition, string PartitionEventId, int ReportedLocalLoad, int Pending, int Backlog, int Remotes, string ReportedRemoteLoad, string AppName, string ExtensionVersion)
         {
             SetCurrentThreadActivityId(serviceInstanceId);
-            this.WriteEvent(245, Account, TaskHub, PartitionId, CommitLogPosition, EventId, ReportedLocalLoad, Pending, Backlog, Remotes, ReportedRemoteLoad, AppName, ExtensionVersion);
+            this.WriteEvent(245, Account, TaskHub, PartitionId, CommitLogPosition, PartitionEventId, ReportedLocalLoad, Pending, Backlog, Remotes, ReportedRemoteLoad, AppName, ExtensionVersion);
         }
 
         [Event(246, Level = EventLevel.Informational, Version = 1)]


### PR DESCRIPTION
Overrides EventSourceName override to durability provider.

Renames "eventId" fields in EtwSource to "partitionEventId" to avoid name clashes.