### PR TITLE
remove obsolete code for query support

### DIFF
--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationServiceSettings.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationServiceSettings.cs
@@ -140,11 +140,6 @@ namespace DurableTask.Netherite
         public long MaxTimeMsBetweenCheckpoints { get; set; } = 60 * 1000;
 
         /// <summary>
-        /// Whether to use the Faster PSF support for handling queries.
-        /// </summary>
-        public bool UsePSFQueries { get; set; } = false;
-
-        /// <summary>
         /// Set this to a local file path to make FASTER use local files instead of blobs. Currently,
         /// this makes sense only for local testing and debugging.
         /// </summary>

--- a/src/DurableTask.Netherite/StorageProviders/Faster/FasterStorage.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/FasterStorage.cs
@@ -64,11 +64,7 @@ namespace DurableTask.Netherite.Faster
             this.partition = partition;
             this.terminationToken = errorHandler.Token;
 
-#if FASTER_SUPPORTS_PSF
-            int psfCount = partition.Settings.UsePSFQueries ? FasterKV.PSFCount : 0;
-#else
             int psfCount = 0;
-#endif
 
             this.blobManager = new BlobManager(
                 this.storageAccount,


### PR DESCRIPTION
Removes dead code and unnecessary compile switches from the main branch.

We will reintroduce the new implementation for queries later.