### PR TITLE
Mitigations for dll load problem

### DIFF
--- a/samples/Hello/Hello.csproj
+++ b/samples/Hello/Hello.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.DurableTask.Netherite.AzureFunctions" Version="0.3.0-alpha" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.12" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.3" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
@@ -100,6 +100,12 @@ namespace DurableTask.Netherite
             EtwSource.Log.OrchestrationServiceCreated(this.ServiceInstanceId, this.StorageAccountName, this.Settings.HubName, this.Settings.WorkerId, TraceUtils.AppName, TraceUtils.ExtensionVersion);
             this.Logger.LogInformation("NetheriteOrchestrationService created, workerId={workerId}, processorCount={processorCount}, transport={transport}, storage={storage}", this.Settings.WorkerId, Environment.ProcessorCount, this.configuredTransport, this.configuredStorage);
 
+            if (this.configuredStorage == TransportConnectionString.StorageChoices.Faster)
+            {
+                // force dll load here so exceptions are observed early
+                var _ = System.Threading.Channels.Channel.CreateBounded<DateTime>(10);
+            }
+
             switch (this.configuredTransport)
             {
                 case TransportConnectionString.TransportChoices.Memory:

--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationServiceSettings.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationServiceSettings.cs
@@ -140,11 +140,6 @@ namespace DurableTask.Netherite
         public long MaxTimeMsBetweenCheckpoints { get; set; } = 60 * 1000;
 
         /// <summary>
-        /// Whether to use the Faster PSF support for handling queries.
-        /// </summary>
-        public bool UsePSFQueries { get; set; } = false;
-
-        /// <summary>
         /// Set this to a local file path to make FASTER use local files instead of blobs. Currently,
         /// this makes sense only for local testing and debugging.
         /// </summary>

--- a/src/DurableTask.Netherite/StorageProviders/Faster/FasterStorage.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/FasterStorage.cs
@@ -64,11 +64,7 @@ namespace DurableTask.Netherite.Faster
             this.partition = partition;
             this.terminationToken = errorHandler.Token;
 
-#if FASTER_SUPPORTS_PSF
-            int psfCount = partition.Settings.UsePSFQueries ? FasterKV.PSFCount : 0;
-#else
             int psfCount = 0;
-#endif
 
             this.blobManager = new BlobManager(
                 this.storageAccount,

--- a/test/PerformanceTests/PerformanceTests.csproj
+++ b/test/PerformanceTests/PerformanceTests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.5.0" />
     <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.5.5" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="4.2.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.13" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.3" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.4" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
As discussed in #55, this PR implements two mitigations while we wait for fix in Microsoft.NET.Sdk.Functions:

- Add fast fail so package load problem is immediately visible when starting the service, not just during recovery.
- For Hello sample and perf tests, use last functioning version 3.0.3 of Microsoft.NET.Sdk.Functions.