### PR TITLE
ETW tracing improvements

### DIFF
--- a/src/DurableTask.Netherite/StorageProviders/Faster/FasterTraceHelper.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/FasterTraceHelper.cs
@@ -41,21 +41,21 @@ namespace DurableTask.Netherite.Faster
                 this.etwLogInformation?.FasterStoreCreated(this.account, this.taskHub, this.partitionId, inputQueuePosition, latencyMs, TraceUtils.AppName, TraceUtils.ExtensionVersion);
             }
         }
-        public void FasterCheckpointStarted(Guid checkpointId, string reason, string storeStats, long commitLogPosition, long inputQueuePosition)
+        public void FasterCheckpointStarted(Guid checkpointId, string details, string storeStats, long commitLogPosition, long inputQueuePosition)
         {
             if (this.logLevelLimit <= LogLevel.Information)
             {
-                this.logger.LogInformation("Part{partition:D2} Started Checkpoint {checkpointId}, reason={reason}, storeStats={storeStats}, commitLogPosition={commitLogPosition} inputQueuePosition={inputQueuePosition}", this.partitionId, checkpointId, reason, storeStats, commitLogPosition, inputQueuePosition);
-                this.etwLogInformation?.FasterCheckpointStarted(this.account, this.taskHub, this.partitionId, checkpointId, reason, storeStats, commitLogPosition, inputQueuePosition, TraceUtils.AppName, TraceUtils.ExtensionVersion);
+                this.logger.LogInformation("Part{partition:D2} Started Checkpoint {checkpointId}, details={details}, storeStats={storeStats}, commitLogPosition={commitLogPosition} inputQueuePosition={inputQueuePosition}", this.partitionId, checkpointId, details, storeStats, commitLogPosition, inputQueuePosition);
+                this.etwLogInformation?.FasterCheckpointStarted(this.account, this.taskHub, this.partitionId, checkpointId, details, storeStats, commitLogPosition, inputQueuePosition, TraceUtils.AppName, TraceUtils.ExtensionVersion);
             }
         }
 
-        public void FasterCheckpointPersisted(Guid checkpointId, string reason, long commitLogPosition, long inputQueuePosition, long latencyMs)
+        public void FasterCheckpointPersisted(Guid checkpointId, string details, long commitLogPosition, long inputQueuePosition, long latencyMs)
         {
             if (this.logLevelLimit <= LogLevel.Information)
             {
-                this.logger.LogInformation("Part{partition:D2} Persisted Checkpoint {checkpointId}, reason={reason}, commitLogPosition={commitLogPosition} inputQueuePosition={inputQueuePosition} latencyMs={latencyMs}", this.partitionId, checkpointId, reason, commitLogPosition, inputQueuePosition, latencyMs);
-                this.etwLogInformation?.FasterCheckpointPersisted(this.account, this.taskHub, this.partitionId, checkpointId, reason, commitLogPosition, inputQueuePosition, latencyMs, TraceUtils.AppName, TraceUtils.ExtensionVersion);
+                this.logger.LogInformation("Part{partition:D2} Persisted Checkpoint {checkpointId}, details={details}, commitLogPosition={commitLogPosition} inputQueuePosition={inputQueuePosition} latencyMs={latencyMs}", this.partitionId, checkpointId, details, commitLogPosition, inputQueuePosition, latencyMs);
+                this.etwLogInformation?.FasterCheckpointPersisted(this.account, this.taskHub, this.partitionId, checkpointId, details, commitLogPosition, inputQueuePosition, latencyMs, TraceUtils.AppName, TraceUtils.ExtensionVersion);
             }
 
             if (latencyMs > 10000)

--- a/src/DurableTask.Netherite/Tracing/EtwSource.cs
+++ b/src/DurableTask.Netherite/Tracing/EtwSource.cs
@@ -358,38 +358,38 @@ namespace DurableTask.Netherite
         // ----- EventHubs Transport
 
         [Event(270, Level = EventLevel.Informational, Version = 1)]
-        public void EventHubsInformation(string Account, string TaskHub, string EventHubsNamespace, string Details, string AppName, string ExtensionVersion)
+        public void EventHubsInformation(string Account, string TaskHub, string EventHubsNamespace, string PartitionId, string Details, string AppName, string ExtensionVersion)
         {
             SetCurrentThreadActivityId(serviceInstanceId);
-            this.WriteEvent(270, Account, TaskHub, EventHubsNamespace, Details, AppName, ExtensionVersion);
+            this.WriteEvent(270, Account, TaskHub, EventHubsNamespace, PartitionId, Details, AppName, ExtensionVersion);
         }
 
         [Event(271, Level = EventLevel.Warning, Version = 1)]
-        public void EventHubsWarning(string Account, string TaskHub, string EventHubsNamespace, string Details, string AppName, string ExtensionVersion)
+        public void EventHubsWarning(string Account, string TaskHub, string EventHubsNamespace, string PartitionId, string Details, string AppName, string ExtensionVersion)
         {
             SetCurrentThreadActivityId(serviceInstanceId);
-            this.WriteEvent(271, Account, TaskHub, EventHubsNamespace, Details, AppName, ExtensionVersion);
+            this.WriteEvent(271, Account, TaskHub, EventHubsNamespace, PartitionId, Details, AppName, ExtensionVersion);
         }
 
         [Event(272, Level = EventLevel.Error, Version = 1)]
-        public void EventHubsError(string Account, string TaskHub, string EventHubsNamespace, string Details, string AppName, string ExtensionVersion)
+        public void EventHubsError(string Account, string TaskHub, string EventHubsNamespace, string PartitionId, string Details, string AppName, string ExtensionVersion)
         {
             SetCurrentThreadActivityId(serviceInstanceId);
-            this.WriteEvent(272, Account, TaskHub, EventHubsNamespace, Details, AppName, ExtensionVersion);
+            this.WriteEvent(272, Account, TaskHub, EventHubsNamespace, PartitionId, Details, AppName, ExtensionVersion);
         }
 
         [Event(273, Level = EventLevel.Verbose, Version = 1)]
-        public void EventHubsDebug(string Account, string TaskHub, string EventHubsNamespace, string Details, string AppName, string ExtensionVersion)
+        public void EventHubsDebug(string Account, string TaskHub, string EventHubsNamespace, string PartitionId, string Details, string AppName, string ExtensionVersion)
         {
             SetCurrentThreadActivityId(serviceInstanceId);
-            this.WriteEvent(273, Account, TaskHub, EventHubsNamespace, Details, AppName, ExtensionVersion);
+            this.WriteEvent(273, Account, TaskHub, EventHubsNamespace, PartitionId, Details, AppName, ExtensionVersion);
         }
 
         [Event(274, Level = EventLevel.Verbose, Version = 1)]
-        public void EventHubsTrace(string Account, string TaskHub, string EventHubsNamespace, string Details, string AppName, string ExtensionVersion)
+        public void EventHubsTrace(string Account, string TaskHub, string EventHubsNamespace, string PartitionId, string Details, string AppName, string ExtensionVersion)
         {
             SetCurrentThreadActivityId(serviceInstanceId);
-            this.WriteEvent(274, Account, TaskHub, EventHubsNamespace, Details, AppName, ExtensionVersion);
+            this.WriteEvent(274, Account, TaskHub, EventHubsNamespace, PartitionId, Details, AppName, ExtensionVersion);
         }
     }
 }

--- a/src/DurableTask.Netherite/Tracing/EtwSource.cs
+++ b/src/DurableTask.Netherite/Tracing/EtwSource.cs
@@ -235,10 +235,10 @@ namespace DurableTask.Netherite
         }
 
         [Event(247, Level = EventLevel.Verbose, Version = 1)]
-        public void BatchWorkerProgress(string Account, string TaskHub, int PartitionId, string Worker, int BatchSize, double Latency, string NextBatch, string AppName, string ExtensionVersion)
+        public void BatchWorkerProgress(string Account, string TaskHub, int PartitionId, string Worker, int BatchSize, double LatencyMs, string NextBatch, string AppName, string ExtensionVersion)
         {
             SetCurrentThreadActivityId(serviceInstanceId);
-            this.WriteEvent(247, Account, TaskHub, PartitionId, Worker, BatchSize, Latency, NextBatch, AppName, ExtensionVersion);
+            this.WriteEvent(247, Account, TaskHub, PartitionId, Worker, BatchSize, LatencyMs, NextBatch, AppName, ExtensionVersion);
         }
 
         // ----- Faster Storage

--- a/src/DurableTask.Netherite/Tracing/EtwSource.cs
+++ b/src/DurableTask.Netherite/Tracing/EtwSource.cs
@@ -251,17 +251,17 @@ namespace DurableTask.Netherite
         }
 
         [Event(251, Level = EventLevel.Informational, Version = 1)]
-        public void FasterCheckpointStarted(string Account, string TaskHub, int PartitionId, Guid CheckpointId, string Reason, string StoreStats, long CommitLogPosition, long InputQueuePosition, string AppName, string ExtensionVersion)
+        public void FasterCheckpointStarted(string Account, string TaskHub, int PartitionId, Guid CheckpointId, string Details, string StoreStats, long CommitLogPosition, long InputQueuePosition, string AppName, string ExtensionVersion)
         {
             SetCurrentThreadActivityId(serviceInstanceId);
-            this.WriteEvent(251, Account, TaskHub, PartitionId, CheckpointId, Reason, StoreStats, CommitLogPosition, InputQueuePosition, AppName, ExtensionVersion);
+            this.WriteEvent(251, Account, TaskHub, PartitionId, CheckpointId, Details, StoreStats, CommitLogPosition, InputQueuePosition, AppName, ExtensionVersion);
         }
 
         [Event(252, Level = EventLevel.Informational, Version = 1)]
-        public void FasterCheckpointPersisted(string Account, string TaskHub, int PartitionId, Guid CheckpointId, string Reason, long CommitLogPosition, long InputQueuePosition, long LatencyMs, string AppName, string ExtensionVersion)
+        public void FasterCheckpointPersisted(string Account, string TaskHub, int PartitionId, Guid CheckpointId, string Details, long CommitLogPosition, long InputQueuePosition, long LatencyMs, string AppName, string ExtensionVersion)
         {
             SetCurrentThreadActivityId(serviceInstanceId);
-            this.WriteEvent(252, Account, TaskHub, PartitionId, CheckpointId, Reason, CommitLogPosition, InputQueuePosition, LatencyMs, AppName, ExtensionVersion);
+            this.WriteEvent(252, Account, TaskHub, PartitionId, CheckpointId, Details, CommitLogPosition, InputQueuePosition, LatencyMs, AppName, ExtensionVersion);
         }
 
         [Event(253, Level = EventLevel.Verbose, Version = 1)]

--- a/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsProcessor.cs
+++ b/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsProcessor.cs
@@ -273,7 +273,20 @@ namespace DurableTask.Netherite.EventHubs
 
         Task IEventProcessor.ProcessErrorAsync(PartitionContext context, Exception exception)
         {
-            this.traceHelper.LogWarning("EventHubsProcessor {eventHubName}/{eventHubPartition} received internal error indication from EventProcessorHost: {exception}", this.eventHubName, this.eventHubPartition, exception);
+            LogLevel GetLogLevel()
+            {
+                switch (exception)
+                {
+                    case ReceiverDisconnectedException: // occur when partitions are being rebalanced by EventProcessorHost
+                        return LogLevel.Information;
+
+                    default:
+                        return LogLevel.Warning;
+                }
+            }
+
+            this.traceHelper.Log(GetLogLevel(), "EventHubsProcessor {eventHubName}/{eventHubPartition} received internal error indication from EventProcessorHost: {exception}", this.eventHubName, this.eventHubPartition, exception);
+
             return Task.CompletedTask;
         }
 

--- a/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsProcessor.cs
+++ b/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsProcessor.cs
@@ -70,7 +70,7 @@ namespace DurableTask.Netherite.EventHubs
             TaskhubParameters parameters,
             PartitionContext partitionContext,
             NetheriteOrchestrationServiceSettings settings,
-            EventHubsTraceHelper logger,
+            EventHubsTraceHelper traceHelper,
             CancellationToken shutdownToken)
         {
             this.host = host;
@@ -83,7 +83,7 @@ namespace DurableTask.Netherite.EventHubs
             this.eventHubPartition = this.partitionContext.PartitionId;
             this.taskHubGuid = parameters.TaskhubGuid.ToByteArray();
             this.partitionId = uint.Parse(this.eventHubPartition);
-            this.traceHelper = logger;
+            this.traceHelper = new EventHubsTraceHelper(traceHelper, this.partitionId);
 
             var _ = shutdownToken.Register(
               () => { var _ = Task.Run(this.IdempotentShutdown); },

--- a/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsTraceHelper.cs
+++ b/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsTraceHelper.cs
@@ -12,18 +12,30 @@ namespace DurableTask.Netherite.EventHubs
     class EventHubsTraceHelper : ILogger
     {
         readonly ILogger logger;
+        readonly string partitionId;
         readonly string account;
         readonly string taskHub;
         readonly string eventHubsNamespace;
         readonly LogLevel logLevelLimit;
 
-        public EventHubsTraceHelper(ILoggerFactory loggerFactory, LogLevel logLevelLimit, string storageAccountName, string taskHubName, string eventHubsNamespace)
+        public static ILogger CreateLogger(ILoggerFactory loggerFactory)
         {
-            this.logger = loggerFactory.CreateLogger($"{NetheriteOrchestrationService.LoggerCategoryName}.EventHubsTransport");
+            return loggerFactory.CreateLogger($"{NetheriteOrchestrationService.LoggerCategoryName}.EventHubsTransport");
+        }
+
+        public EventHubsTraceHelper(ILogger logger, LogLevel logLevelLimit, uint? partitionId, string storageAccountName, string taskHubName, string eventHubsNamespace)
+        {
+            this.logger = logger;
+            this.partitionId = partitionId?.ToString() ?? string.Empty;
             this.account = storageAccountName;
             this.taskHub = taskHubName;
             this.eventHubsNamespace = eventHubsNamespace;
             this.logLevelLimit = logLevelLimit;
+        }
+
+        public EventHubsTraceHelper(EventHubsTraceHelper traceHelper, uint partitionId)
+            : this(traceHelper.logger, traceHelper.logLevelLimit, partitionId, traceHelper.account, traceHelper.taskHub, traceHelper.eventHubsNamespace)
+        { 
         }
 
         public bool IsEnabled(LogLevel logLevel) => logLevel >= this.logLevelLimit;
@@ -53,24 +65,24 @@ namespace DurableTask.Netherite.EventHubs
                     switch (logLevel)
                     {
                         case LogLevel.Trace:
-                            EtwSource.Log.EventHubsTrace(this.account, this.taskHub, this.eventHubsNamespace, details, TraceUtils.AppName, TraceUtils.ExtensionVersion);
+                            EtwSource.Log.EventHubsTrace(this.account, this.taskHub, this.eventHubsNamespace, this.partitionId, details, TraceUtils.AppName, TraceUtils.ExtensionVersion);
                             break;
 
                         case LogLevel.Debug:
-                            EtwSource.Log.EventHubsDebug(this.account, this.taskHub, this.eventHubsNamespace, details, TraceUtils.AppName, TraceUtils.ExtensionVersion);
+                            EtwSource.Log.EventHubsDebug(this.account, this.taskHub, this.eventHubsNamespace, this.partitionId, details, TraceUtils.AppName, TraceUtils.ExtensionVersion);
                             break;
 
                         case LogLevel.Information:
-                            EtwSource.Log.EventHubsInformation(this.account, this.taskHub, this.eventHubsNamespace, details, TraceUtils.AppName, TraceUtils.ExtensionVersion);
+                            EtwSource.Log.EventHubsInformation(this.account, this.taskHub, this.eventHubsNamespace, this.partitionId, details, TraceUtils.AppName, TraceUtils.ExtensionVersion);
                             break;
 
                         case LogLevel.Warning:
-                            EtwSource.Log.EventHubsWarning(this.account, this.taskHub, this.eventHubsNamespace, details, TraceUtils.AppName, TraceUtils.ExtensionVersion);
+                            EtwSource.Log.EventHubsWarning(this.account, this.taskHub, this.eventHubsNamespace, this.partitionId, details, TraceUtils.AppName, TraceUtils.ExtensionVersion);
                             break;
 
                         case LogLevel.Error:
                         case LogLevel.Critical:
-                            EtwSource.Log.EventHubsError(this.account, this.taskHub, this.eventHubsNamespace, details, TraceUtils.AppName, TraceUtils.ExtensionVersion);
+                            EtwSource.Log.EventHubsError(this.account, this.taskHub, this.eventHubsNamespace, this.partitionId, details, TraceUtils.AppName, TraceUtils.ExtensionVersion);
                             break;
 
                         default:

--- a/src/DurableTask.Netherite/Util/BatchWorker.cs
+++ b/src/DurableTask.Netherite/Util/BatchWorker.cs
@@ -143,7 +143,7 @@ namespace DurableTask.Netherite
             {
                 int? nextBatch = this.GetNextBatch();
 
-                if (previousBatch.HasValue)
+                if (previousBatch.HasValue && previousBatch.Value > 0)
                 {
                     this.traceHelper?.BatchWorkerProgress(this.Name, previousBatch.Value, this.stopwatch.Elapsed.TotalMilliseconds, nextBatch);
                 }


### PR DESCRIPTION
Several minor improvements to simplify analytics:

- do not trace batchworker work cycles when the batch is empty
- use 'Details' instead of 'Reason' for checkpoint events
- include partition id in EventHubs traces
- use LatencyMs instead of Latency for batch worker tracing
- Do not emit warnings for ReceiverDisconnectedExceptions observed inside EventProcessorHost
