### PR TITLE
Resilience Improvements for EventHubsProcessor

### DIFF
--- a/src/DurableTask.Netherite/OrchestrationService/Partition.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/Partition.cs
@@ -117,6 +117,11 @@ namespace DurableTask.Netherite
                 this.TraceHelper.TracePartitionProgress("Started", ref this.LastTransition, this.CurrentTimeMs, $"nextInputQueuePosition={inputQueuePosition}");
                 return inputQueuePosition;
             }
+            catch (OperationCanceledException) when (errorHandler.IsTerminated)
+            {
+                // this happens when startup is canceled
+                throw;
+            }
             catch (Exception e) when (!Utils.IsFatal(e))
             {
                 this.ErrorHandler.HandleError(nameof(CreateOrRestoreAsync), "Could not start partition", e, true, false);

--- a/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsProcessor.cs
+++ b/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsProcessor.cs
@@ -86,7 +86,7 @@ namespace DurableTask.Netherite.EventHubs
             this.traceHelper = new EventHubsTraceHelper(traceHelper, this.partitionId);
 
             var _ = shutdownToken.Register(
-              () => { var _ = Task.Run(this.IdempotentShutdown); },
+              () => { var _ = Task.Run(() => this.IdempotentShutdown("shutdownToken")); },
               useSynchronizationContext: false);
         }
 
@@ -95,6 +95,11 @@ namespace DurableTask.Netherite.EventHubs
             this.traceHelper.LogInformation("EventHubsProcessor {eventHubName}/{eventHubPartition} is opening", this.eventHubName, this.eventHubPartition);
             this.eventProcessorShutdown = new CancellationTokenSource();
             this.deliveryLock = new AsyncLock();
+
+            // make sure we shut down as soon as the partition is closing
+            var _ = context.CancellationToken.Register(
+              () => { var _ = Task.Run(() => this.IdempotentShutdown("context.CancellationToken")); },
+              useSynchronizationContext: false);
 
             // we kick off the start-and-retry mechanism for the partition, but don't wait for it to be fully started.
             // instead, we save the task and wait for it when we need it
@@ -164,6 +169,15 @@ namespace DurableTask.Netherite.EventHubs
             {
                 this.traceHelper.LogDebug("EventHubsProcessor {eventHubName}/{eventHubPartition} is starting partition (incarnation {incarnation})", this.eventHubName, this.eventHubPartition, c.Incarnation);
 
+                // to handle shutdown before startup completes, register a force-termination
+                using var registration = this.eventProcessorShutdown.Token.Register(
+                    () => c.ErrorHandler.HandleError(
+                        nameof(StartPartitionAsync),
+                        "EventHubsProcessor shut down before partition fully started",
+                        null,
+                        terminatePartition: true,
+                        reportAsWarning: true));
+
                 // start this partition (which may include waiting for the lease to become available)
                 c.Partition = this.host.AddPartition(this.partitionId, this.sender);
                 c.NextPacketToReceive = await c.Partition.CreateOrRestoreAsync(c.ErrorHandler, this.parameters.StartPositions[this.partitionId]).ConfigureAwait(false);
@@ -198,19 +212,19 @@ namespace DurableTask.Netherite.EventHubs
             return c;
         }
 
-        async Task IdempotentShutdown()
+        async Task IdempotentShutdown(string reason)
         {
             async Task ShutdownAsync()
             {
-                this.traceHelper.LogInformation("EventHubsProcessor {eventHubName}/{eventHubPartition} is shutting down", this.eventHubName, this.eventHubPartition);
+                this.traceHelper.LogInformation("EventHubsProcessor {eventHubName}/{eventHubPartition} is shutting down (reason: {reason})", this.eventHubName, this.eventHubPartition, reason);
 
                 this.eventProcessorShutdown.Cancel(); // stops reincarnations
 
-                PartitionIncarnation current = await this.currentIncarnation.ConfigureAwait(false);
+                PartitionIncarnation current = await this.currentIncarnation;
 
                 while (current != null && current.ErrorHandler.IsTerminated)
                 {
-                    current = await current.Next.ConfigureAwait(false);
+                    current = await current.Next;
                 }
 
                 if (current == null)
@@ -242,7 +256,7 @@ namespace DurableTask.Netherite.EventHubs
         {
             this.traceHelper.LogInformation("EventHubsProcessor {eventHubName}/{eventHubPartition} is closing", this.eventHubName, this.eventHubPartition);
 
-            await this.IdempotentShutdown();
+            await this.IdempotentShutdown("CloseAsync");
 
             await this.SaveEventHubsReceiverCheckpoint(context).ConfigureAwait(false);
 
@@ -269,23 +283,34 @@ namespace DurableTask.Netherite.EventHubs
                     this.traceHelper.LogWarning("EventHubsProcessor {eventHubName}/{eventHubPartition} failed to checkpoint receive position: {e}", this.eventHubName, this.eventHubPartition, e);
                 }
             }
-        } 
+        }
 
         Task IEventProcessor.ProcessErrorAsync(PartitionContext context, Exception exception)
         {
-            LogLevel GetLogLevel()
-            {
-                switch (exception)
-                {
-                    case ReceiverDisconnectedException: // occur when partitions are being rebalanced by EventProcessorHost
-                        return LogLevel.Information;
 
-                    default:
-                        return LogLevel.Warning;
-                }
+            LogLevel logLevel;
+
+            switch (exception)
+            {
+                case ReceiverDisconnectedException: 
+
+                    // occurs when partitions are being rebalanced by EventProcessorHost
+                    logLevel = LogLevel.Information;
+
+                    // since this processor is no longer going to receive events, let's shut it down
+                    // one would expect that this is redundant with EventProcessHost calling close
+                    // but empirically we have observed that the latter does not always happen in this situation
+                    Task.Run(() => this.IdempotentShutdown("Receiver was disconnected"));
+
+                    break;
+
+                default:
+                    logLevel = LogLevel.Warning;
+                    break;
             }
 
-            this.traceHelper.Log(GetLogLevel(), "EventHubsProcessor {eventHubName}/{eventHubPartition} received internal error indication from EventProcessorHost: {exception}", this.eventHubName, this.eventHubPartition, exception);
+
+            this.traceHelper.Log(logLevel, "EventHubsProcessor {eventHubName}/{eventHubPartition} received internal error indication from EventProcessorHost: {exception}", this.eventHubName, this.eventHubPartition, exception);
 
             return Task.CompletedTask;
         }
@@ -303,7 +328,7 @@ namespace DurableTask.Netherite.EventHubs
 
             if (current == null)
             {
-                this.traceHelper.LogError("EventHubsProcessor {eventHubName}/{eventHubPartition} received packets for closed processor", this.eventHubName, this.eventHubPartition);
+                this.traceHelper.LogWarning("EventHubsProcessor {eventHubName}/{eventHubPartition} received packets for closed processor, discarded", this.eventHubName, this.eventHubPartition);
                 return;
             }
 


### PR DESCRIPTION
Addresses #61.

Two parts to this fix:

1.  Fix bug where shutting down the eventprocessor during startup leads to a state where the partition is not properly terminated and forever tries to acquire the lease.

2. Shut down EventProcessor *immediately* when seeing a ReceiverDisconnectedException; don't wait for EventHubs libary to close the processor. This is intended to fix situations where EventHubs never closes the partitions, or takes too long to close it.
