### PR TITLE
Revise Checkpoint Heuristics

### DIFF
--- a/src/DurableTask.Netherite/Abstractions/ITaskHub.cs
+++ b/src/DurableTask.Netherite/Abstractions/ITaskHub.cs
@@ -37,8 +37,7 @@ namespace DurableTask.Netherite
         /// <summary>
         /// Stops the transport backend.
         /// </summary>
-        /// <param name="isForced">Whether to shut down as quickly as possible, or gracefully.</param>
         /// <returns>After the transport backend has stopped.</returns>
-        Task StopAsync(bool isForced);
+        Task StopAsync();
     }
 }

--- a/src/DurableTask.Netherite/Abstractions/TransportAbstraction.cs
+++ b/src/DurableTask.Netherite/Abstractions/TransportAbstraction.cs
@@ -80,9 +80,9 @@ namespace DurableTask.Netherite
             /// <summary>
             /// Clean shutdown: stop processing, save partition state to storage, and release ownership.
             /// </summary>
-            /// <param name="isForced">True if the shutdown should happen as quickly as possible.</param>
+            /// <param name="quickly">True if the shutdown should happen as quickly as possible.</param>
             /// <returns>When all steps have completed and termination is performed.</returns>
-            Task StopAsync(bool isForced);
+            Task StopAsync(bool quickly);
 
             /// <summary>
             /// Queues a single event for processing on this partition.

--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
@@ -312,12 +312,12 @@ namespace DurableTask.Netherite
         }
 
         /// <inheritdoc />
-        public async Task StopAsync(bool isForced)
+        public async Task StopAsync(bool quickly)
         {
             try
             {
 
-                this.Logger.LogInformation("NetheriteOrchestrationService stopping, workerId={workerId} isForced={isForced}", this.Settings.WorkerId, isForced);
+                this.Logger.LogInformation("NetheriteOrchestrationService stopping, workerId={workerId} quickly={quickly}", this.Settings.WorkerId, quickly);
 
                 if (!this.Settings.KeepServiceRunning && this.serviceShutdownSource != null)
                 {
@@ -325,7 +325,7 @@ namespace DurableTask.Netherite
                     this.serviceShutdownSource.Dispose();
                     this.serviceShutdownSource = null;
 
-                    await this.taskHub.StopAsync(isForced).ConfigureAwait(false);
+                    await this.taskHub.StopAsync().ConfigureAwait(false);
 
                     this.ActivityWorkItemQueue.Dispose();
                     this.OrchestrationWorkItemQueue.Dispose();
@@ -347,7 +347,7 @@ namespace DurableTask.Netherite
         public Task StopAsync() => ((IOrchestrationService)this).StopAsync(false);
 
         /// <inheritdoc/>
-        public void Dispose() => this.taskHub.StopAsync(true);
+        public void Dispose() => this.taskHub.StopAsync();
 
         /// <summary>
         /// Computes the partition for the given instance.

--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationServiceSettings.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationServiceSettings.cs
@@ -137,7 +137,7 @@ namespace DurableTask.Netherite
         /// <summary>
         /// A limit on how long to wait between state checkpoints, in milliseconds. The default is 60s.
         /// </summary>
-        public long MaxTimeMsBetweenCheckpoints { get; set; } = 60 * 1000;
+        public long IdleCheckpointFrequencyMs { get; set; } = 60 * 1000;
 
         /// <summary>
         /// Set this to a local file path to make FASTER use local files instead of blobs. Currently,

--- a/src/DurableTask.Netherite/OrchestrationService/Partition.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/Partition.cs
@@ -149,13 +149,13 @@ namespace DurableTask.Netherite
             }
         }
 
-        public async Task StopAsync(bool isForced)
+        public async Task StopAsync(bool quickly)
         {
             if (!this.ErrorHandler.IsTerminated)
             {
-                this.TraceHelper.TracePartitionProgress("Stopping", ref this.LastTransition, this.CurrentTimeMs, $"isForced={isForced}");
+                this.TraceHelper.TracePartitionProgress("Stopping", ref this.LastTransition, this.CurrentTimeMs, $"quickly={quickly}");
 
-                bool takeCheckpoint = this.Settings.TakeStateCheckpointWhenStoppingPartition && !isForced;
+                bool takeCheckpoint = this.Settings.TakeStateCheckpointWhenStoppingPartition && !quickly;
 
                 // for a clean shutdown we try to save some of the latest progress to storage and then release the lease
                 bool clean = true;

--- a/src/DurableTask.Netherite/StorageProviders/Faster/AzureBlobs/BlobManager.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/AzureBlobs/BlobManager.cs
@@ -534,7 +534,11 @@ namespace DurableTask.Netherite.Faster
                     }
                     continue;
                 }
-                catch (Exception e)
+                catch (OperationCanceledException) when (this.PartitionErrorHandler.IsTerminated)
+                {
+                    throw; // o.k. during termination or shutdown
+                }
+                catch (Exception e) when (!Utils.IsFatal(e))
                 {
                     this.PartitionErrorHandler.HandleError(nameof(AcquireOwnership), "Could not acquire partition lease", e, true, false);
                     throw;
@@ -567,11 +571,11 @@ namespace DurableTask.Netherite.Faster
 
                 this.leaseTimer = nextLeaseTimer;
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (this.PartitionErrorHandler.IsTerminated)
             {
-                // o.k. during termination or shutdown
+                throw; // o.k. during termination or shutdown
             }
-            catch (Exception)
+            catch (Exception e) when (!Utils.IsFatal(e))
             {
                 this.TraceHelper.LeaseLost(this.leaseTimer.Elapsed.TotalSeconds, nameof(RenewLeaseTask));
                 throw;

--- a/src/DurableTask.Netherite/StorageProviders/Faster/FasterStorage.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/FasterStorage.cs
@@ -142,6 +142,10 @@ namespace DurableTask.Netherite.Faster
 
                     this.TraceHelper.FasterCheckpointLoaded(this.storeWorker.CommitLogPosition, this.storeWorker.InputQueuePosition, this.store.StoreStats.Get(), stopwatch.ElapsedMilliseconds);
                 }
+                catch(OperationCanceledException) when (this.partition.ErrorHandler.IsTerminated)
+                {
+                    throw; // normal if recovery was canceled
+                }
                 catch (Exception e)
                 {
                     this.TraceHelper.FasterStorageError("loading checkpoint", e);
@@ -159,6 +163,10 @@ namespace DurableTask.Netherite.Faster
                         // replay log as the store checkpoint lags behind the log
                         await this.storeWorker.ReplayCommitLog(this.logWorker).ConfigureAwait(false);
                     }
+                }
+                catch (OperationCanceledException) when (this.partition.ErrorHandler.IsTerminated)
+                {
+                    throw; // normal if recovery was canceled
                 }
                 catch (Exception e)
                 {

--- a/src/DurableTask.Netherite/StorageProviders/Faster/StoreWorker.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/StoreWorker.cs
@@ -33,7 +33,7 @@ namespace DurableTask.Netherite.Faster
         long lastCheckpointedInputQueuePosition;
         long lastCheckpointedCommitLogPosition;
         long numberEventsSinceLastCheckpoint;
-        long timeOfNextCheckpoint;
+        long timeOfNextIdleCheckpoint;
 
         // periodic load publishing
         PartitionLoadInfo loadInfo;
@@ -101,7 +101,7 @@ namespace DurableTask.Netherite.Faster
             this.lastCheckpointedCommitLogPosition = this.CommitLogPosition;
             this.lastCheckpointedInputQueuePosition = this.InputQueuePosition;
             this.numberEventsSinceLastCheckpoint = 0;
-            this.ScheduleNextCheckpointTime();
+            this.ScheduleNextIdleCheckpointTime();
         }
 
         internal async ValueTask TakeFullCheckpointAsync(string reason)
@@ -128,7 +128,7 @@ namespace DurableTask.Netherite.Faster
                 this.traceHelper.FasterProgress($"Checkpoint skipped: {reason}");
             }
 
-            this.ScheduleNextCheckpointTime();
+            this.ScheduleNextIdleCheckpointTime();
         }
 
         public async Task CancelAndShutdown()
@@ -211,7 +211,7 @@ namespace DurableTask.Netherite.Faster
             None,
             CommitLogBytes,
             EventCount,
-            TimeElapsed
+            Idle
         }
 
         bool CheckpointDue(out CheckpointTrigger trigger)
@@ -232,21 +232,22 @@ namespace DurableTask.Netherite.Faster
             }
             else if (
                 (this.numberEventsSinceLastCheckpoint > 0 || inputQueuePositionLag > 0)
-                && DateTime.UtcNow.Ticks > this.timeOfNextCheckpoint)
+                && DateTime.UtcNow.Ticks > this.timeOfNextIdleCheckpoint
+                && this.loadInfo.IsBusy() == null)
             {
-                trigger = CheckpointTrigger.TimeElapsed;
+                trigger = CheckpointTrigger.Idle;
             }
              
             return trigger != CheckpointTrigger.None;
         }
 
-        void ScheduleNextCheckpointTime()
+        void ScheduleNextIdleCheckpointTime()
         {
             // to avoid all partitions taking snapshots at the same time, align to a partition-based spot
-            var period = this.partition.Settings.MaxTimeMsBetweenCheckpoints * TimeSpan.TicksPerMillisecond;
+            var period = this.partition.Settings.IdleCheckpointFrequencyMs * TimeSpan.TicksPerMillisecond;
             var offset = (this.partition.PartitionId * period / this.partition.NumberPartitions());
             var maxTime = DateTime.UtcNow.Ticks + period;
-            this.timeOfNextCheckpoint = (((maxTime - offset) / period) * period) + offset;
+            this.timeOfNextIdleCheckpoint = (((maxTime - offset) / period) * period) + offset;
         }
 
         protected override async Task Process(IList<PartitionEvent> batch)
@@ -315,7 +316,7 @@ namespace DurableTask.Netherite.Faster
                             = await this.pendingStoreCheckpoint.ConfigureAwait(false); // observe exceptions here
                         this.pendingStoreCheckpoint = null;
                         this.pendingCheckpointTrigger = CheckpointTrigger.None;
-                        this.ScheduleNextCheckpointTime();
+                        this.ScheduleNextIdleCheckpointTime();
                     }
                 }
                 else if (this.pendingIndexCheckpoint != null)
@@ -347,13 +348,13 @@ namespace DurableTask.Netherite.Faster
                     await this.PublishPartitionLoad().ConfigureAwait(false);
                 }
 
-                if (this.lastCheckpointedCommitLogPosition == this.CommitLogPosition 
-                    && this.lastCheckpointedInputQueuePosition == this.InputQueuePosition
-                    && this.LogWorker.LastCommittedInputQueuePosition <= this.InputQueuePosition)
+                if (this.loadInfo.IsBusy() != null
+                     || (this.lastCheckpointedCommitLogPosition == this.CommitLogPosition 
+                         && this.lastCheckpointedInputQueuePosition == this.InputQueuePosition
+                         && this.LogWorker.LastCommittedInputQueuePosition <= this.InputQueuePosition))
                 {
-                    // since there were no changes since the last snapshot 
-                    // we can pretend that it was taken just now
-                    this.ScheduleNextCheckpointTime();
+                    // the partition is not idle, or nothing has changed, so we do delay the time for the nex idle checkpoint
+                    this.ScheduleNextIdleCheckpointTime();
                 }
 
                 // make sure to complete ready read requests, or notify this worker

--- a/src/DurableTask.Netherite/Tracing/EtwSource.cs
+++ b/src/DurableTask.Netherite/Tracing/EtwSource.cs
@@ -128,10 +128,10 @@ namespace DurableTask.Netherite
         }
 
         [Event(222, Level = EventLevel.Warning, Version = 1)]
-        public void TaskMessageDiscarded(string Account, string TaskHub, int PartitionId, string MessageId, string Reason, string EventType, int TaskEventId, string InstanceId, string ExecutionId, string AppName, string ExtensionVersion)
+        public void TaskMessageDiscarded(string Account, string TaskHub, int PartitionId, string MessageId, string Details, string EventType, int TaskEventId, string InstanceId, string ExecutionId, string AppName, string ExtensionVersion)
         {
             SetCurrentThreadActivityId(serviceInstanceId);
-            this.WriteEvent(222, Account, TaskHub, PartitionId, MessageId, Reason, EventType, TaskEventId, InstanceId, ExecutionId, AppName, ExtensionVersion);
+            this.WriteEvent(222, Account, TaskHub, PartitionId, MessageId, Details, EventType, TaskEventId, InstanceId, ExecutionId, AppName, ExtensionVersion);
         }
 
         [Event(223, Level = EventLevel.Verbose, Version = 1)]
@@ -156,10 +156,10 @@ namespace DurableTask.Netherite
         }
 
         [Event(226, Level = EventLevel.Warning, Version = 1)]
-        public void WorkItemDiscarded(string Account, string TaskHub, int PartitionId, string WorkItemType, string WorkItemId, string InstanceId, string Reason, string ReplacedBy, string AppName, string ExtensionVersion)
+        public void WorkItemDiscarded(string Account, string TaskHub, int PartitionId, string WorkItemType, string WorkItemId, string InstanceId, string Details, string ReplacedBy, string AppName, string ExtensionVersion)
         {
             SetCurrentThreadActivityId(serviceInstanceId);
-            this.WriteEvent(226, Account, TaskHub, PartitionId, WorkItemType, WorkItemId, InstanceId, Reason, ReplacedBy, AppName, ExtensionVersion);
+            this.WriteEvent(226, Account, TaskHub, PartitionId, WorkItemType, WorkItemId, InstanceId, Details, ReplacedBy, AppName, ExtensionVersion);
         }
 
         [Event(227, Level = EventLevel.Verbose, Version = 1)]

--- a/src/DurableTask.Netherite/Tracing/WorkItemTraceHelper.cs
+++ b/src/DurableTask.Netherite/Tracing/WorkItemTraceHelper.cs
@@ -111,7 +111,7 @@ namespace DurableTask.Netherite
             }
         }
 
-        public void TraceWorkItemDiscarded(uint partitionId, WorkItemType workItemType, string workItemId, string instanceId, string replacedBy, string reason)
+        public void TraceWorkItemDiscarded(uint partitionId, WorkItemType workItemType, string workItemId, string instanceId, string replacedBy, string details)
         {
             if (this.logLevelLimit <= LogLevel.Warning)
             {
@@ -120,11 +120,11 @@ namespace DurableTask.Netherite
                     (long commitLogPosition, string eventId) = EventTraceContext.Current;
 
                     string prefix = commitLogPosition > 0 ? $".{commitLogPosition:D10}   " : "";
-                    this.logger.LogWarning("Part{partition:D2}{prefix} discarded {workItemType}WorkItem {workItemId} because {reason}; instanceId={instanceId} replacedBy={replacedBy}",
-                        partitionId, prefix, workItemType, workItemId, reason, instanceId, replacedBy);
+                    this.logger.LogWarning("Part{partition:D2}{prefix} discarded {workItemType}WorkItem {workItemId} because {details}; instanceId={instanceId} replacedBy={replacedBy}",
+                        partitionId, prefix, workItemType, workItemId, details, instanceId, replacedBy);
                 }
 
-                this.etw?.WorkItemDiscarded(this.account, this.taskHub, (int)partitionId, workItemType.ToString(), workItemId, instanceId, reason, replacedBy ?? "", TraceUtils.AppName, TraceUtils.ExtensionVersion);
+                this.etw?.WorkItemDiscarded(this.account, this.taskHub, (int)partitionId, workItemType.ToString(), workItemId, instanceId, details, replacedBy ?? "", TraceUtils.AppName, TraceUtils.ExtensionVersion);
             }
         }
 
@@ -184,7 +184,7 @@ namespace DurableTask.Netherite
             }
         }
 
-        public void TraceTaskMessageDiscarded(uint partitionId, TaskMessage message, string workItemId, string reason)
+        public void TraceTaskMessageDiscarded(uint partitionId, TaskMessage message, string workItemId, string details)
         {
             if (this.logLevelLimit <= LogLevel.Warning)
             {
@@ -195,11 +195,11 @@ namespace DurableTask.Netherite
                     (long commitLogPosition, string eventId) = EventTraceContext.Current;
 
                     string prefix = commitLogPosition > 0 ? $".{commitLogPosition:D10}   " : "";
-                    this.logger.LogWarning("Part{partition:D2}{prefix} discarded TaskMessage {messageId} reason={reason} eventType={eventType} taskEventId={taskEventId} instanceId={instanceId} executionId={executionId}",
-                        partitionId, prefix, messageId, reason, message.Event.EventType.ToString(), TraceUtils.GetTaskEventId(message.Event), message.OrchestrationInstance.InstanceId, message.OrchestrationInstance.ExecutionId);
+                    this.logger.LogWarning("Part{partition:D2}{prefix} discarded TaskMessage {messageId} because {details} eventType={eventType} taskEventId={taskEventId} instanceId={instanceId} executionId={executionId}",
+                        partitionId, prefix, messageId, details, message.Event.EventType.ToString(), TraceUtils.GetTaskEventId(message.Event), message.OrchestrationInstance.InstanceId, message.OrchestrationInstance.ExecutionId);
                 }
 
-                this.etw?.TaskMessageDiscarded(this.account, this.taskHub, (int)partitionId, messageId, reason, message.Event.EventType.ToString(), TraceUtils.GetTaskEventId(message.Event), message.OrchestrationInstance.InstanceId, message.OrchestrationInstance.ExecutionId ?? "", TraceUtils.AppName, TraceUtils.ExtensionVersion);
+                this.etw?.TaskMessageDiscarded(this.account, this.taskHub, (int)partitionId, messageId, details, message.Event.EventType.ToString(), TraceUtils.GetTaskEventId(message.Event), message.OrchestrationInstance.InstanceId, message.OrchestrationInstance.ExecutionId ?? "", TraceUtils.AppName, TraceUtils.ExtensionVersion);
             }
         }
     }

--- a/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsProcessor.cs
+++ b/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsProcessor.cs
@@ -36,13 +36,14 @@ namespace DurableTask.Netherite.EventHubs
 
         // we occasionally checkpoint received packets with eventhubs. It is not required for correctness
         // as we filter duplicates anyway, but it will help startup time.
-        readonly Stopwatch timeSinceLastCheckpoint = new Stopwatch();
-        volatile Checkpoint pendingCheckpoint;
+        long persistedSequenceNumber;
+        long persistedOffset;
+        long? lastCheckpointedOffset;
 
         // since EventProcessorHost does not redeliver packets, we need to keep them around until we are sure
         // they are processed durably, so we can redeliver them when recycling/recovering a partition
         // we make this a concurrent queue so we can remove confirmed events concurrently with receiving new ones
-        readonly ConcurrentQueue<(PartitionEvent evt, string offset, long seqno)> pendingDelivery;
+        readonly ConcurrentQueue<(PartitionEvent evt, long offset, long seqno)> pendingDelivery;
         AsyncLock deliveryLock;
 
         // this points to the latest incarnation of this partition; it gets
@@ -76,7 +77,7 @@ namespace DurableTask.Netherite.EventHubs
             this.host = host;
             this.sender = sender;
             this.parameters = parameters;
-            this.pendingDelivery = new ConcurrentQueue<(PartitionEvent evt, string offset, long seqno)>();
+            this.pendingDelivery = new ConcurrentQueue<(PartitionEvent evt, long offset, long seqno)>();
             this.partitionContext = partitionContext;
             this.settings = settings;
             this.eventHubName = this.partitionContext.EventHubPath;
@@ -86,7 +87,7 @@ namespace DurableTask.Netherite.EventHubs
             this.traceHelper = new EventHubsTraceHelper(traceHelper, this.partitionId);
 
             var _ = shutdownToken.Register(
-              () => { var _ = Task.Run(() => this.IdempotentShutdown("shutdownToken")); },
+              () => { var _ = Task.Run(() => this.IdempotentShutdown("shutdownToken", false)); },
               useSynchronizationContext: false);
         }
 
@@ -98,7 +99,7 @@ namespace DurableTask.Netherite.EventHubs
 
             // make sure we shut down as soon as the partition is closing
             var _ = context.CancellationToken.Register(
-              () => { var _ = Task.Run(() => this.IdempotentShutdown("context.CancellationToken")); },
+              () => { var _ = Task.Run(() => this.IdempotentShutdown("context.CancellationToken", true)); },
               useSynchronizationContext: false);
 
             // we kick off the start-and-retry mechanism for the partition, but don't wait for it to be fully started.
@@ -118,11 +119,8 @@ namespace DurableTask.Netherite.EventHubs
             {
                 if (this.pendingDelivery.TryDequeue(out var candidate))
                 {
-                    if (this.timeSinceLastCheckpoint.ElapsedMilliseconds > 30000)
-                    {
-                        this.pendingCheckpoint = new Checkpoint(this.partitionId.ToString(), candidate.offset, candidate.seqno);
-                        this.timeSinceLastCheckpoint.Restart();
-                    }
+                    this.persistedOffset = Math.Max(this.persistedOffset, candidate.offset);
+                    this.persistedSequenceNumber = Math.Max(this.persistedSequenceNumber, candidate.seqno);
                 }
             }
         }
@@ -195,8 +193,6 @@ namespace DurableTask.Netherite.EventHubs
                         this.traceHelper.LogDebug("EventHubsProcessor {eventHubName}/{eventHubPartition} received {batchsize} packets, starting with #{seqno}, next expected packet is #{nextSeqno}", this.eventHubName, this.eventHubPartition, batch.Count, batch[0].NextInputQueuePosition - 1, c.NextPacketToReceive);
                     }
                 }
-
-                this.timeSinceLastCheckpoint.Start();
             }
             catch (OperationCanceledException) when (c.ErrorHandler.IsTerminated)
             {
@@ -212,11 +208,11 @@ namespace DurableTask.Netherite.EventHubs
             return c;
         }
 
-        async Task IdempotentShutdown(string reason)
+        async Task IdempotentShutdown(string reason, bool quickly)
         {
             async Task ShutdownAsync()
             {
-                this.traceHelper.LogInformation("EventHubsProcessor {eventHubName}/{eventHubPartition} is shutting down (reason: {reason})", this.eventHubName, this.eventHubPartition, reason);
+                this.traceHelper.LogInformation("EventHubsProcessor {eventHubName}/{eventHubPartition} is shutting down (reason: {reason}, quickly: {quickly})", this.eventHubName, this.eventHubPartition, reason, quickly);
 
                 this.eventProcessorShutdown.Cancel(); // stops reincarnations
 
@@ -233,8 +229,8 @@ namespace DurableTask.Netherite.EventHubs
                 }
                 else
                 {
-                    this.traceHelper.LogDebug("EventHubsProcessor {eventHubName}/{eventHubPartition} stopping partition (incarnation {incarnation})", this.eventHubName, this.eventHubPartition, current.Incarnation);
-                    await current.Partition.StopAsync(false).ConfigureAwait(false);
+                    this.traceHelper.LogDebug("EventHubsProcessor {eventHubName}/{eventHubPartition} stopping partition (incarnation: {incarnation}, quickly: {quickly})", this.eventHubName, this.eventHubPartition, current.Incarnation, quickly);
+                    await current.Partition.StopAsync(quickly).ConfigureAwait(false);
                     this.traceHelper.LogDebug("EventHubsProcessor {eventHubName}/{eventHubPartition} stopped partition (incarnation {incarnation})", this.eventHubName, this.eventHubPartition, current.Incarnation);
                 }
 
@@ -245,7 +241,7 @@ namespace DurableTask.Netherite.EventHubs
             {
                 if (this.shutdownTask == null)
                 {
-                    this.shutdownTask = ShutdownAsync();
+                    this.shutdownTask = Task.Run(() => ShutdownAsync());
                 }
             }
 
@@ -254,27 +250,31 @@ namespace DurableTask.Netherite.EventHubs
 
         async Task IEventProcessor.CloseAsync(PartitionContext context, CloseReason reason)
         {
-            this.traceHelper.LogInformation("EventHubsProcessor {eventHubName}/{eventHubPartition} is closing", this.eventHubName, this.eventHubPartition);
+            this.traceHelper.LogInformation("EventHubsProcessor {eventHubName}/{eventHubPartition} is closing (reason: {reason})", this.eventHubName, this.eventHubPartition, reason);
 
-            await this.IdempotentShutdown("CloseAsync");
+            if (reason != CloseReason.LeaseLost)
+            {
+                await this.SaveEventHubsReceiverCheckpoint(context, 0).ConfigureAwait(false);
+            }
 
-            await this.SaveEventHubsReceiverCheckpoint(context).ConfigureAwait(false);
+            await this.IdempotentShutdown("CloseAsync", reason == CloseReason.LeaseLost);
 
             this.deliveryLock.Dispose();
 
             this.traceHelper.LogInformation("EventHubsProcessor {eventHubName}/{eventHubPartition} closed", this.eventHubName, this.eventHubPartition);
-        }
+        }   
 
-        async ValueTask SaveEventHubsReceiverCheckpoint(PartitionContext context)
+        async ValueTask SaveEventHubsReceiverCheckpoint(PartitionContext context, long byteThreshold)
         {
-            var checkpoint = this.pendingCheckpoint;
-            if (checkpoint != null)
+            if (this.lastCheckpointedOffset.HasValue && this.persistedOffset - this.lastCheckpointedOffset.Value > byteThreshold)
             {
-                this.pendingCheckpoint = null;
+                var checkpoint = new Checkpoint(this.partitionId.ToString(), this.persistedOffset.ToString(), this.persistedSequenceNumber);
+
                 this.traceHelper.LogInformation("EventHubsProcessor {eventHubName}/{eventHubPartition} is checkpointing receive position through #{seqno}", this.eventHubName, this.eventHubPartition, checkpoint.SequenceNumber);
                 try
                 {
                     await context.CheckpointAsync(checkpoint).ConfigureAwait(false);
+                    this.lastCheckpointedOffset = long.Parse(checkpoint.Offset);
                 }
                 catch (Exception e) when (!Utils.IsFatal(e))
                 {
@@ -300,7 +300,7 @@ namespace DurableTask.Netherite.EventHubs
                     // since this processor is no longer going to receive events, let's shut it down
                     // one would expect that this is redundant with EventProcessHost calling close
                     // but empirically we have observed that the latter does not always happen in this situation
-                    Task.Run(() => this.IdempotentShutdown("Receiver was disconnected"));
+                    Task.Run(() => this.IdempotentShutdown("Receiver was disconnected", true));
 
                     break;
 
@@ -318,6 +318,13 @@ namespace DurableTask.Netherite.EventHubs
         async Task IEventProcessor.ProcessEventsAsync(PartitionContext context, IEnumerable<EventData> packets)
         {
             this.traceHelper.LogTrace("EventHubsProcessor {eventHubName}/{eventHubPartition} receiving #{seqno}", this.eventHubName, this.eventHubPartition, packets.First().SystemProperties.SequenceNumber);
+
+            if (!this.lastCheckpointedOffset.HasValue)
+            {
+                // the first packet we receive indicates what our last checkpoint was
+                var first = packets.FirstOrDefault();
+                this.lastCheckpointedOffset = first == null ? null : long.Parse(first.SystemProperties.Offset);
+            }
 
             PartitionIncarnation current = await this.currentIncarnation.ConfigureAwait(false);
 
@@ -370,7 +377,7 @@ namespace DurableTask.Netherite.EventHubs
 
                             partitionEvent.NextInputQueuePosition = current.NextPacketToReceive;
                             batch.Add(partitionEvent);
-                            this.pendingDelivery.Enqueue((partitionEvent, eventData.SystemProperties.Offset, eventData.SystemProperties.SequenceNumber));
+                            this.pendingDelivery.Enqueue((partitionEvent, long.Parse(eventData.SystemProperties.Offset), eventData.SystemProperties.SequenceNumber));
                             DurabilityListeners.Register(partitionEvent, this);
                             partitionEvent.ReceivedTimestamp = current.Partition.CurrentTimeMs;
                             //partitionEvent.ReceivedTimestampUnixMs = DateTimeOffset.Now.ToUnixTimeMilliseconds();
@@ -401,7 +408,7 @@ namespace DurableTask.Netherite.EventHubs
                     current.Partition.SubmitExternalEvents(batch);
                 }
 
-                await this.SaveEventHubsReceiverCheckpoint(context).ConfigureAwait(false);
+                await this.SaveEventHubsReceiverCheckpoint(context, 600000).ConfigureAwait(false);
 
                 // can use this for testing: terminates partition after every one packet received, but
                 // that packet is then processed once the partition recovers, so in the end there is progress

--- a/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsTransport.cs
+++ b/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsTransport.cs
@@ -251,7 +251,7 @@ namespace DurableTask.Netherite.EventHubs
             }
         }
 
-        async Task ITaskHub.StopAsync(bool isForced)
+        async Task ITaskHub.StopAsync()
         {
             this.traceHelper.LogInformation("Shutting down EventHubsBackend");
             this.shutdownSource.Cancel(); // initiates shutdown of client and of all partitions

--- a/src/DurableTask.Netherite/TransportProviders/EventHubs/ScriptedEventProcessorHost.cs
+++ b/src/DurableTask.Netherite/TransportProviders/EventHubs/ScriptedEventProcessorHost.cs
@@ -254,7 +254,7 @@ namespace DurableTask.Netherite.EventHubs
 
                     this.partitionEventLoop = Task.Run(() => this.PartitionEventLoop(nextPacketToReceive));
                 }
-                catch(Exception e) when (!Utils.IsFatal(e))
+                catch (Exception e) when (!Utils.IsFatal(e))
                 {
                     this.host.logger.LogError("PartitionInstance {eventHubName}/{eventHubPartition}({incarnation}) failed to start partition: {exception}", this.host.eventHubPath, this.partitionId, this.Incarnation, e);
                     throw;

--- a/src/DurableTask.Netherite/TransportProviders/Memory/MemoryTransport.cs
+++ b/src/DurableTask.Netherite/TransportProviders/Memory/MemoryTransport.cs
@@ -115,7 +115,7 @@ namespace DurableTask.Netherite.Emulated
             clientQueue.Resume();
         }
 
-        async Task ITaskHub.StopAsync(bool isForced)
+        async Task ITaskHub.StopAsync()
         {
             if (this.shutdownTokenSource != null)
             {
@@ -127,7 +127,7 @@ namespace DurableTask.Netherite.Emulated
                 var tasks = new List<Task>();
                 foreach(var p in this.partitions)
                 {
-                    tasks.Add(p.StopAsync(isForced));
+                    tasks.Add(p.StopAsync(false));
                 }
                 await Task.WhenAll(tasks).ConfigureAwait(false);
             }

--- a/test/DurableTask.Netherite.Tests/TestConstants.cs
+++ b/test/DurableTask.Netherite.Tests/TestConstants.cs
@@ -40,7 +40,7 @@ namespace DurableTask.Netherite.Tests
                 PartitionCount = 12,
                 TakeStateCheckpointWhenStoppingPartition = true,  // set to false for testing recovery from log
                 UseAlternateObjectStore = false,                  // set to true to bypass FasterKV; default is false
-                MaxTimeMsBetweenCheckpoints = 1000000000,         // set this low for testing frequent checkpointing
+                IdleCheckpointFrequencyMs = 1000000000,         // set this low for testing frequent checkpointing
                 //MaxNumberBytesBetweenCheckpoints = 10000000, // set this low for testing frequent checkpointing
                 //MaxNumberEventsBetweenCheckpoints = 10, // set this low for testing frequent checkpointing
             };

--- a/test/DurableTask.Netherite.Tests/TestOrchestrationHost.cs
+++ b/test/DurableTask.Netherite.Tests/TestOrchestrationHost.cs
@@ -55,9 +55,9 @@ namespace DurableTask.Netherite.Tests
             await this.worker.StartAsync();
         }
 
-        public Task StopAsync(bool isForced)
+        public Task StopAsync(bool quickly)
         {
-            return this.worker.StopAsync(isForced);
+            return this.worker.StopAsync(quickly);
         }
 
         public void AddAutoStartOrchestrator(Type type)

--- a/test/PerformanceTests/host.json
+++ b/test/PerformanceTests/host.json
@@ -56,7 +56,7 @@
         "TakeStateCheckpointWhenStoppingPartition": "true",
         "MaxNumberBytesBetweenCheckpoints": "20000000",
         "MaxNumberEventsBetweenCheckpoints": "10000",
-        "MaxTimeMsBetweenCheckpoints": "60000",
+        "IdleCheckpointFrequencyMs": "60000",
         "PackPartitionTaskMessages": 100,
 
         "PartitionCount": 12,

--- a/test/PerformanceTests/series/host.neth-12-ls.json
+++ b/test/PerformanceTests/series/host.neth-12-ls.json
@@ -50,7 +50,7 @@
         "TakeStateCheckpointWhenStoppingPartition": "true",
         "MaxNumberBytesBetweenCheckpoints": "20000000",
         "MaxNumberEventsBetweenCheckpoints": "10000",
-        "MaxTimeMsBetweenCheckpoints": "60000",
+        "IdleCheckpointFrequencyMs": "60000",
         "PackPartitionTaskMessages": 100,
 
         "PartitionCount": 12,


### PR DESCRIPTION
Revised the following heuristics for taking state checkpoints in faster:

1. Do not take time-based checkpoints unless a partition is idle.
2. Do not take state checkpoints when closing individual partitions, only when shutting down the entire hub.

With regard to 1. the setting `MaxTimeMsBetweenCheckpoints` was renamed to `IdleCheckpointFrequencyMs`. The default setting is still 1 minute.