### PR TITLE
Improve performance of query results

### DIFF
--- a/src/DurableTask.Netherite/Abstractions/PartitionState/IPartitionState.cs
+++ b/src/DurableTask.Netherite/Abstractions/PartitionState/IPartitionState.cs
@@ -37,18 +37,25 @@ namespace DurableTask.Netherite
         Task CleanShutdown(bool takeFinalCheckpoint);
 
         /// <summary>
-        /// Queues an internal event (originating on this same partition)
-        /// for processing on this partition.
+        /// Queues a read or update event 
+        /// for in-order processing on this partition.
         /// </summary>
         /// <param name="evt">The event to process.</param>
-        void SubmitInternalEvent(PartitionEvent evt);
+        void SubmitEvent(PartitionEvent evt);
 
         /// <summary>
-        /// Queues external events (originating on clients or other partitions)
-        /// for processing on this partition.
+        /// Queues a list of read or update events
+        /// for in-order processing on this partition.
         /// </summary>
         /// <param name="evt">The collection of events to process.</param>
-        void SubmitExternalEvents(IList<PartitionEvent> evt);
+        void SubmitEvents(IList<PartitionEvent> evt);
+
+        /// <summary>
+        /// Launches a read or query event 
+        /// for immediate processing on this partition, bypassing the queue
+        /// </summary>
+        /// <param name="evt">The event to process.</param>
+        void SubmitParallelEvent(PartitionEvent evt);
 
         /// <summary>
         /// Prefetches the supplied keys.

--- a/src/DurableTask.Netherite/Abstractions/TransportAbstraction.cs
+++ b/src/DurableTask.Netherite/Abstractions/TransportAbstraction.cs
@@ -96,13 +96,13 @@ namespace DurableTask.Netherite
             /// Queues a single event for processing on this partition.
             /// </summary>
             /// <param name="partitionEvent">The event to process.</param>
-            void SubmitInternalEvent(PartitionUpdateEvent partitionEvent);
+            void SubmitEvent(PartitionUpdateEvent partitionEvent);
 
             /// <summary>
             /// Queues a batch of incoming external events for processing on this partition.
             /// </summary>
             /// <param name="partitionEvents">The events to process.</param>
-            void SubmitExternalEvents(IList<PartitionEvent> partitionEvents);
+            void SubmitEvents(IList<PartitionEvent> partitionEvents);
 
             /// <summary>
             /// The error handler for this partition.

--- a/src/DurableTask.Netherite/Events/ClientEvents/QueryResponseReceived.cs
+++ b/src/DurableTask.Netherite/Events/ClientEvents/QueryResponseReceived.cs
@@ -11,8 +11,11 @@ namespace DurableTask.Netherite
     class QueryResponseReceived : ClientEvent
     {
         [DataMember]
-        public IList<OrchestrationState> OrchestrationStates { get; set; }
+        public List<OrchestrationState> OrchestrationStates { get; set; }
 
-        public override string ToString() => $"Count: {this.OrchestrationStates.Count}";
+        [DataMember]
+        public int? Final { get; set; }
+
+        public override string ToString() => $"Count={this.OrchestrationStates.Count} Final={this.Final}";
     }
 }

--- a/src/DurableTask.Netherite/Events/ClientEvents/QueryResponseReceived.cs
+++ b/src/DurableTask.Netherite/Events/ClientEvents/QueryResponseReceived.cs
@@ -5,17 +5,91 @@ namespace DurableTask.Netherite
 {
     using System.Collections.Generic;
     using System.Runtime.Serialization;
+    using System.IO;
     using DurableTask.Core;
+    using System;
 
     [DataContract]
     class QueryResponseReceived : ClientEvent
     {
-        [DataMember]
+        // for efficiency, we use a binary representation with custom serialization and deserialization (see below)
+        [IgnoreDataMember]
         public List<OrchestrationState> OrchestrationStates { get; set; }
 
         [DataMember]
         public int? Final { get; set; }
 
-        public override string ToString() => $"Count={this.OrchestrationStates.Count} Final={this.Final}";
+        [DataMember]
+        byte[] BinaryState { get; set; }
+
+        public void SerializeOrchestrationStates(MemoryStream memoryStream, bool includeInput)
+        {
+            var writer = new BinaryWriter(memoryStream);
+
+            void writeNullableString(string s)
+            {
+                bool present = s != null;
+                writer.Write((bool)present);
+                if (present)
+                {
+                    writer.Write((string)s);
+                }
+            }
+            void writeNullableDateTime(DateTime? d)
+            {
+                writer.Write((bool)d.HasValue);
+                if (d.HasValue)
+                {
+                    writer.Write((long)d.Value.Ticks);
+                }
+            }
+
+            writer.Write((int)this.OrchestrationStates.Count);
+            foreach (var state in this.OrchestrationStates)
+            {
+                writeNullableString((string)state.Version);
+                writeNullableString((string)state.Status);
+                writeNullableString((string)state.Output);
+                writeNullableString((string)state.Name);
+                writeNullableString((string)(includeInput ? state.Input : null));
+                writer.Write((string)state.OrchestrationInstance.InstanceId);
+                writer.Write((string)state.OrchestrationInstance.ExecutionId);
+                writer.Write((long)state.CompletedTime.Ticks);
+                writer.Write((byte)state.OrchestrationStatus);
+                writer.Write((long)state.LastUpdatedTime.Ticks);
+                writer.Write((long)state.CreatedTime.Ticks);
+                writeNullableDateTime(state.ScheduledStartTime);
+            }
+            writer.Flush();
+            this.BinaryState = memoryStream.ToArray();
+            memoryStream.Seek(0, SeekOrigin.Begin);
+        }
+
+
+        public void DeserializeOrchestrationStates()
+        {
+            this.OrchestrationStates = new List<OrchestrationState>();
+            var memoryStream = new MemoryStream(this.BinaryState);
+            using var reader = new BinaryReader(memoryStream);
+            var numStates = reader.ReadInt32();
+            for (int i = 0; i < numStates; i++)
+            {
+                var state = new OrchestrationState();
+                state.OrchestrationInstance = new OrchestrationInstance();
+                state.Version = reader.ReadBoolean() ? reader.ReadString() : null;
+                state.Status = reader.ReadBoolean() ? reader.ReadString() : null;
+                state.Output = reader.ReadBoolean() ? reader.ReadString() : null;
+                state.Name = reader.ReadBoolean() ? reader.ReadString() : null;
+                state.Input = reader.ReadBoolean() ? reader.ReadString() : null;
+                state.OrchestrationInstance.InstanceId = reader.ReadString();
+                state.OrchestrationInstance.ExecutionId = reader.ReadString();
+                state.CompletedTime = new DateTime(reader.ReadInt64(), DateTimeKind.Utc);
+                state.OrchestrationStatus = (OrchestrationStatus)reader.ReadByte();
+                state.LastUpdatedTime = new DateTime(reader.ReadInt64(), DateTimeKind.Utc);
+                state.CreatedTime = new DateTime(reader.ReadInt64(), DateTimeKind.Utc);
+                state.ScheduledStartTime = reader.ReadBoolean() ? new DateTime(reader.ReadInt64(), DateTimeKind.Utc) : null;
+                this.OrchestrationStates.Add(state);
+            }
+        }
     }
 }

--- a/src/DurableTask.Netherite/Events/PartitionEvents/External/FromClients/ClientRequestEventWithPrefetch.cs
+++ b/src/DurableTask.Netherite/Events/PartitionEvents/External/FromClients/ClientRequestEventWithPrefetch.cs
@@ -37,6 +37,13 @@ namespace DurableTask.Netherite
                 }
             }
         }
+        public override void OnSubmit(Partition partition)
+        {
+            if (this.Phase == ProcessingPhase.Read)
+            {
+                partition.SubmitEvent(new PrefetchState.InstancePrefetch(this));
+            }
+        }
 
         public sealed override void DetermineEffects(EffectTracker effects)
         {

--- a/src/DurableTask.Netherite/Events/PartitionEvents/External/FromClients/ClientRequestEventWithQuery.cs
+++ b/src/DurableTask.Netherite/Events/PartitionEvents/External/FromClients/ClientRequestEventWithQuery.cs
@@ -22,6 +22,14 @@ namespace DurableTask.Netherite
         [IgnoreDataMember]
         public override EventId EventId => EventId.MakeClientRequestEventId(this.ClientId, this.RequestId);
 
+        public override void OnSubmit(Partition partition)
+        {
+            if (this.Phase == ProcessingPhase.Query)
+            {
+                partition.SubmitParallelEvent(new QueriesState.InstanceQueryEvent(this));
+            }
+        }
+
         public abstract Task OnQueryCompleteAsync(IAsyncEnumerable<OrchestrationState> result, Partition partition);
 
         public sealed override void DetermineEffects(EffectTracker effects)
@@ -33,7 +41,6 @@ namespace DurableTask.Netherite
         { 
              Query,
              Confirm,
-             ConfirmAndProcess,
         }
     }
 }

--- a/src/DurableTask.Netherite/Events/PartitionEvents/External/FromClients/PurgeRequestReceived.cs
+++ b/src/DurableTask.Netherite/Events/PartitionEvents/External/FromClients/PurgeRequestReceived.cs
@@ -39,7 +39,7 @@ namespace DurableTask.Netherite
             async Task ExecuteBatch()
             {
                 await partition.State.Prefetch(batch.KeysToPrefetch);
-                partition.SubmitInternalEvent(batch);
+                partition.SubmitEvent(batch);
                 await batch.WhenProcessed.Task;
             }
 

--- a/src/DurableTask.Netherite/Events/PartitionEvents/PartitionEvent.cs
+++ b/src/DurableTask.Netherite/Events/PartitionEvents/PartitionEvent.cs
@@ -30,6 +30,9 @@ namespace DurableTask.Netherite
         [IgnoreDataMember]
         public double IssuedTimestamp { get; set; }
 
+        // some events trigger some processing immediately upon receive (e.g. prefetches or queries)
+        public virtual void OnSubmit(Partition partition) { }
+
         // make a copy of an event so we run it through the pipeline a second time
         public PartitionEvent Clone()
         {

--- a/src/DurableTask.Netherite/Events/PartitionEvents/PartitionReadEvent.cs
+++ b/src/DurableTask.Netherite/Events/PartitionEvents/PartitionReadEvent.cs
@@ -24,17 +24,11 @@ namespace DurableTask.Netherite
         public virtual TrackedObjectKey? Prefetch => null;
 
         /// <summary>
-        /// Optionally, some extra action to perform before issuing the read
-        /// </summary>
-        public virtual void OnReadIssued(Partition partition) { }
-
-        /// <summary>
         /// The continuation for the read operation.
         /// </summary>
         /// <param name="target">The current value of the tracked object for this key, or null if not present</param>
         /// <param name="partition">The partition</param>
         public abstract void OnReadComplete(TrackedObject target, Partition partition);
-
 
         #region prefetch state machine
 

--- a/src/DurableTask.Netherite/OrchestrationService/Client.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/Client.cs
@@ -78,10 +78,11 @@ namespace DurableTask.Netherite
 
         public void Process(ClientEvent clientEvent)
         {
-            bool IsComplete(QueryResponseReceived r) => r.Final == r.OrchestrationStates.Count;
-
             if (clientEvent is QueryResponseReceived queryResponseReceived)
             {
+                queryResponseReceived.DeserializeOrchestrationStates();
+                bool GotAllResults() => queryResponseReceived.Final == queryResponseReceived.OrchestrationStates.Count;
+
                 if (this.QueryResponses.TryGetValue(queryResponseReceived.RequestId, out QueryResponseReceived prev))
                 {
                     // combine all received states
@@ -94,13 +95,13 @@ namespace DurableTask.Netherite
                         queryResponseReceived.Final = prev.Final;
                     }
 
-                    if (IsComplete(queryResponseReceived))
+                    if (GotAllResults())
                     {
                         this.QueryResponses.Remove(queryResponseReceived.RequestId);
                     }
                 }             
 
-                if (IsComplete(queryResponseReceived))
+                if (GotAllResults())
                 {
                     this.ProcessInternal(queryResponseReceived);
                 }

--- a/src/DurableTask.Netherite/OrchestrationService/Client.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/Client.cs
@@ -34,6 +34,7 @@ namespace DurableTask.Netherite
         readonly BatchTimer<PendingRequest> ResponseTimeouts;
         readonly ConcurrentDictionary<long, PendingRequest> ResponseWaiters;
         readonly Dictionary<string, MemoryStream> Fragments;
+        readonly Dictionary<long, QueryResponseReceived> QueryResponses;
 
         public static string GetShortId(Guid clientId) => clientId.ToString("N").Substring(0, 7);
 
@@ -56,6 +57,7 @@ namespace DurableTask.Netherite
             this.ResponseTimeouts = new BatchTimer<PendingRequest>(this.shutdownToken, this.Timeout, this.traceHelper.TraceTimerProgress);
             this.ResponseWaiters = new ConcurrentDictionary<long, PendingRequest>();
             this.Fragments = new Dictionary<string, MemoryStream>();
+            this.QueryResponses = new Dictionary<long, QueryResponseReceived>();
             this.ResponseTimeouts.Start("ClientTimer");
             this.workItemStopwatch = new Stopwatch();
             this.workItemStopwatch.Start();
@@ -76,11 +78,38 @@ namespace DurableTask.Netherite
 
         public void Process(ClientEvent clientEvent)
         {
-            if (!(clientEvent is ClientEventFragment fragment))
+            bool IsComplete(QueryResponseReceived r) => r.Final == r.OrchestrationStates.Count;
+
+            if (clientEvent is QueryResponseReceived queryResponseReceived)
             {
-                this.ProcessInternal(clientEvent);
+                if (this.QueryResponses.TryGetValue(queryResponseReceived.RequestId, out QueryResponseReceived prev))
+                {
+                    // combine all received states
+                    prev.OrchestrationStates.AddRange(queryResponseReceived.OrchestrationStates);
+                    queryResponseReceived.OrchestrationStates = prev.OrchestrationStates;
+
+                    // keep the final count, if known
+                    if (prev.Final.HasValue)
+                    {
+                        queryResponseReceived.Final = prev.Final;
+                    }
+
+                    if (IsComplete(queryResponseReceived))
+                    {
+                        this.QueryResponses.Remove(queryResponseReceived.RequestId);
+                    }
+                }             
+
+                if (IsComplete(queryResponseReceived))
+                {
+                    this.ProcessInternal(queryResponseReceived);
+                }
+                else
+                {
+                    this.QueryResponses[queryResponseReceived.RequestId] = queryResponseReceived;
+                }
             }
-            else
+            else if (clientEvent is ClientEventFragment fragment)
             {
                 var originalEventString = fragment.OriginalEventId.ToString();
 
@@ -99,6 +128,10 @@ namespace DurableTask.Netherite
 
                     this.ProcessInternal(reassembledEvent);
                 }
+            }
+            else
+            {
+                this.ProcessInternal(clientEvent);
             }
         }
 

--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
@@ -725,7 +725,7 @@ namespace DurableTask.Netherite
                 latencyMs,
                 sequenceNumber);
 
-             partition.SubmitInternalEvent(batchProcessedEvent);
+             partition.SubmitEvent(batchProcessedEvent);
 
             if (this.workItemTraceHelper.TraceTaskMessages)
             {
@@ -862,7 +862,7 @@ namespace DurableTask.Netherite
 
             try
             {
-                partition.SubmitInternalEvent(activityCompletedEvent);
+                partition.SubmitEvent(activityCompletedEvent);
                 this.workItemTraceHelper.TraceTaskMessageSent(partition.PartitionId, activityCompletedEvent.Response, activityWorkItem.WorkItemId, null, null);
             }
             catch (OperationCanceledException e)

--- a/src/DurableTask.Netherite/OrchestrationService/OrchestrationMessageBatch.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/OrchestrationMessageBatch.cs
@@ -46,7 +46,7 @@ namespace DurableTask.Netherite
             partition.EventDetailTracer?.TraceEventProcessingDetail($"OrchestrationMessageBatch is prefetching instance={this.InstanceId} batch={this.WorkItemId}");
 
             // continue when we have the history state loaded, which gives us the latest state and/or cursor
-            partition.SubmitInternalEvent(this);
+            partition.SubmitEvent(this);
         }
 
         public IEnumerable<(TaskMessage, string)> TracedMessages
@@ -118,7 +118,7 @@ namespace DurableTask.Netherite
                 }
 
                 // we issue a batch processed event which will remove the messages without updating the instance state
-                partition.SubmitInternalEvent(new BatchProcessed()
+                partition.SubmitEvent(new BatchProcessed()
                 {
                     PartitionId = partition.PartitionId,
                     SessionId = this.SessionId,

--- a/src/DurableTask.Netherite/PartitionState/OutboxState.cs
+++ b/src/DurableTask.Netherite/PartitionState/OutboxState.cs
@@ -135,7 +135,7 @@ namespace DurableTask.Netherite
 
                 if (++this.numAcks == this.OutgoingMessages.Count)
                 {
-                    this.Partition.SubmitInternalEvent(new SendConfirmed()
+                    this.Partition.SubmitEvent(new SendConfirmed()
                     {
                         PartitionId = this.Partition.PartitionId,
                         Position = Position,

--- a/src/DurableTask.Netherite/PartitionState/ReassemblyState.cs
+++ b/src/DurableTask.Netherite/PartitionState/ReassemblyState.cs
@@ -36,15 +36,19 @@ namespace DurableTask.Netherite
                 switch (evt.ReassembledEvent)
                 {
                     case PartitionUpdateEvent updateEvent:
+                        if (!effects.IsReplaying)
+                        {
+                            updateEvent.OnSubmit(this.Partition);
+                        }
                         updateEvent.DetermineEffects(effects);
                         break;
 
                     case PartitionReadEvent readEvent:
-                        this.Partition.SubmitInternalEvent(readEvent);
+                        this.Partition.SubmitEvent(readEvent);
                         break;
 
                     case PartitionQueryEvent queryEvent:
-                        this.Partition.SubmitInternalEvent(queryEvent);
+                        this.Partition.SubmitParallelEvent(queryEvent);
                         break;
 
                     default:

--- a/src/DurableTask.Netherite/PartitionState/SessionsState.cs
+++ b/src/DurableTask.Netherite/PartitionState/SessionsState.cs
@@ -275,7 +275,7 @@ namespace DurableTask.Netherite
         {
             var evtCopy = (BatchProcessed) ((BatchProcessed) evt).Clone();
             evtCopy.PersistFirst = BatchProcessed.PersistFirstStatus.Done;
-            this.Partition.SubmitInternalEvent(evtCopy);
+            this.Partition.SubmitEvent(evtCopy);
         }
 
         public void Process(BatchProcessed evt, EffectTracker effects)

--- a/src/DurableTask.Netherite/StorageProviders/Faster/FasterKV.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/FasterKV.cs
@@ -521,9 +521,7 @@ namespace DurableTask.Netherite.Faster
 
                                 this.partition.EventDetailTracer?.TraceEventProcessingDetail($"match instance {key.InstanceId}");
 
-                                var value = orchestrationState.ClearFieldsImmutably(!instanceQuery.FetchInput, false);
-
-                                var task = channel.Writer.WriteAsync(value);
+                                var task = channel.Writer.WriteAsync(orchestrationState);
 
                                 if (!task.IsCompleted)
                                 {

--- a/src/DurableTask.Netherite/StorageProviders/Faster/FasterStorage.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/FasterStorage.cs
@@ -211,14 +211,19 @@ namespace DurableTask.Netherite.Faster
             await this.blobManager.StopAsync().ConfigureAwait(false);
         }
 
-        public void SubmitExternalEvents(IList<PartitionEvent> evts)
+        public void SubmitEvents(IList<PartitionEvent> evts)
         {
-            this.logWorker.SubmitExternalEvents(evts);
+            this.logWorker.SubmitEvents(evts);
         }
 
-        public void SubmitInternalEvent(PartitionEvent evt)
+        public void SubmitEvent(PartitionEvent evt)
         {
-            this.logWorker.SubmitInternalEvent(evt);
+            this.logWorker.SubmitEvent(evt);
+        }
+
+        public void SubmitParallelEvent(PartitionEvent evt)
+        {
+            this.storeWorker.ProcessInParallel(evt);
         }
 
         public Task Prefetch(IEnumerable<TrackedObjectKey> keys)

--- a/src/DurableTask.Netherite/StorageProviders/Faster/LogWorker.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/LogWorker.cs
@@ -90,12 +90,12 @@ namespace DurableTask.Netherite.Faster
             }
         }
 
-        public void SubmitInternalEvent(PartitionEvent evt)
+        public void SubmitEvent(PartitionEvent evt)
         {
             this.intakeWorker.Submit(evt);
         }
 
-        public void SubmitExternalEvents(IList<PartitionEvent> events)
+        public void SubmitEvents(IList<PartitionEvent> events)
         {
             this.intakeWorker.SubmitBatch(events);
         }

--- a/src/DurableTask.Netherite/StorageProviders/Memory/MemoryStorage.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Memory/MemoryStorage.cs
@@ -34,7 +34,7 @@ namespace DurableTask.Netherite
         }
         public CancellationToken Termination => CancellationToken.None;
 
-        public void SubmitInternalEvent(PartitionEvent entry)
+        public void SubmitEvent(PartitionEvent entry)
         {
             if (entry is PartitionUpdateEvent updateEvent)
             {
@@ -44,7 +44,12 @@ namespace DurableTask.Netherite
             base.Submit(entry);
         }
 
-        public void SubmitExternalEvents(IList<PartitionEvent> entries)
+        public void SubmitParallelEvent(PartitionEvent entry)
+        {
+            base.Submit(entry);
+        }
+
+        public void SubmitEvents(IList<PartitionEvent> entries)
         {
             foreach (var entry in entries)
             {
@@ -140,7 +145,6 @@ namespace DurableTask.Netherite
                                     break;
 
                                 case PartitionReadEvent readEvent:
-                                    readEvent.OnReadIssued(this.partition);
                                     if (readEvent.Prefetch.HasValue)
                                     {
                                         var prefetchTarget = this.GetOrAdd(readEvent.Prefetch.Value);

--- a/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsClientSender.cs
+++ b/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsClientSender.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace DurableTask.Netherite.EventHubs
+{
+    using DurableTask.Core.Common;
+    using Microsoft.Azure.EventHubs;
+    using Microsoft.Extensions.Logging;
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    class EventHubsClientSender
+    {
+        readonly EventHubsSender<ClientEvent>[] channels;
+        int roundRobin;
+
+        public EventHubsClientSender(TransportAbstraction.IHost host, byte[] taskHubGuid, Guid clientId, PartitionSender[] senders, EventHubsTraceHelper traceHelper)
+        {
+            this.channels = new EventHubs.EventHubsSender<ClientEvent>[senders.Length];
+            for (int i = 0; i < senders.Length; i++)
+            {
+                this.channels[i] = new EventHubsSender<ClientEvent>(host, taskHubGuid, senders[i], traceHelper);
+            }
+        }
+
+        EventHubsSender<ClientEvent> NextChannel()
+        {
+            this.roundRobin = (this.roundRobin + 1) % this.channels.Length;
+            return this.channels[this.roundRobin];
+        }
+
+        bool Idle(EventHubsSender<ClientEvent> sender) => sender.IsIdle;
+
+        public void Submit(ClientEvent toSend)
+        {
+            var channel = this.channels.FirstOrDefault(this.Idle) ?? this.NextChannel();
+            channel.Submit(toSend);
+        }
+    }
+}

--- a/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsProcessor.cs
+++ b/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsProcessor.cs
@@ -192,7 +192,7 @@ namespace DurableTask.Netherite.EventHubs
                     if (batch.Count > 0)
                     {
                         c.NextPacketToReceive = batch[batch.Count - 1].NextInputQueuePosition;
-                        c.Partition.SubmitExternalEvents(batch);
+                        c.Partition.SubmitEvents(batch);
                         this.traceHelper.LogDebug("EventHubsProcessor {eventHubName}/{eventHubPartition} received {batchsize} packets, starting with #{seqno}, next expected packet is #{nextSeqno}", this.eventHubName, this.eventHubPartition, batch.Count, batch[0].NextInputQueuePosition - 1, c.NextPacketToReceive);
                     }
                 }
@@ -408,7 +408,7 @@ namespace DurableTask.Netherite.EventHubs
                 if (batch.Count > 0)
                 {
                     this.traceHelper.LogDebug("EventHubsProcessor {eventHubName}/{eventHubPartition} received batch of {batchsize} packets, starting with #{seqno}, next expected packet is #{nextSeqno}", this.eventHubName, this.eventHubPartition, batch.Count, batch[0].NextInputQueuePosition - 1, current.NextPacketToReceive);
-                    current.Partition.SubmitExternalEvents(batch);
+                    current.Partition.SubmitEvents(batch);
                 }
 
                 await this.SaveEventHubsReceiverCheckpoint(context, 600000).ConfigureAwait(false);

--- a/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsSender.cs
+++ b/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsSender.cs
@@ -8,6 +8,7 @@ namespace DurableTask.Netherite.EventHubs
     using Microsoft.Extensions.Logging;
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.IO;
     using System.Threading;
     using System.Threading.Tasks;
@@ -23,6 +24,12 @@ namespace DurableTask.Netherite.EventHubs
         readonly TimeSpan backoff = TimeSpan.FromSeconds(5);
         const int maxFragmentSize = 500 * 1024; // account for very non-optimal serialization of event
         readonly MemoryStream stream = new MemoryStream(); // reused for all packets
+        readonly Stopwatch stopwatch = new Stopwatch();
+
+
+        // we manually set the max message size to leave extra room as
+        // we have observed exceptions in practice otherwise.
+        readonly BatchOptions batchOptions = new BatchOptions() { MaxMessageSize = 900 * 1024 };
 
         public EventHubsSender(TransportAbstraction.IHost host, byte[] taskHubGuid, PartitionSender sender, EventHubsTraceHelper traceHelper)
             : base($"EventHubsSender {sender.EventHubClient.EventHubName}/{sender.PartitionId}", false, 2000, CancellationToken.None, traceHelper)
@@ -49,9 +56,18 @@ namespace DurableTask.Netherite.EventHubs
             
             try
             {
-                // we manually set the max message size to leave extra room as
-                // we have observed exceptions in practice otherwise.
-                var batch = this.sender.CreateBatch(new BatchOptions() { MaxMessageSize = 900 * 1024 });
+                var batch = this.sender.CreateBatch(this.batchOptions);
+
+                async Task SendBatch(int lastPosition)
+                {
+                    maybeSent = lastPosition;
+                    this.stopwatch.Restart();
+                    await this.sender.SendAsync(batch).ConfigureAwait(false);
+                    this.stopwatch.Stop();
+                    sentSuccessfully = lastPosition;
+                    this.traceHelper.LogDebug("EventHubsSender {eventHubName}/{eventHubPartitionId} sent batch of {numPackets} packets ({size} bytes) in {latencyMs:F2}ms, throughput={throughput:F2}MB/s", this.eventHubName, this.eventHubPartition, batch.Count, batch.Size, this.stopwatch.Elapsed.TotalMilliseconds, batch.Size/(1024*1024*this.stopwatch.Elapsed.TotalSeconds));
+                    batch.Dispose();
+                }
 
                 for (int i = 0; i < toSend.Count; i++)
                 {
@@ -75,29 +91,28 @@ namespace DurableTask.Netherite.EventHubs
                         if (batch.Count > 0)
                         {
                             // send the batch we have so far
-                            maybeSent = i - 1;
-                            await this.sender.SendAsync(batch).ConfigureAwait(false);
-                            sentSuccessfully = i - 1;
-
-                            this.traceHelper.LogDebug("EventHubsSender {eventHubName}/{eventHubPartitionId} sent batch of {numPackets} packets", this.eventHubName, this.eventHubPartition, batch.Count);
+                            await SendBatch(i - 1);
 
                             // create a fresh batch
-                            batch = this.sender.CreateBatch();
+                            batch = this.sender.CreateBatch(this.batchOptions);
                         }
 
                         if (tooBig)
                         {
                             // the message is too big. Break it into fragments, and send each individually.
+                            this.traceHelper.LogTrace("EventHubsSender {eventHubName}/{eventHubPartitionId} fragmenting large event ({size} bytes) id={eventId}", this.eventHubName, this.eventHubPartition, length, evt.EventIdString);
                             var fragments = FragmentationAndReassembly.Fragment(arraySegment, evt, maxFragmentSize);
                             maybeSent = i;
-                            foreach (var fragment in fragments)
+                            for (int k = 0; k < fragments.Count; k++)
                             {
                                 //TODO send bytes directly instead of as events (which causes significant space overhead)
                                 this.stream.Seek(0, SeekOrigin.Begin);
+                                var fragment = fragments[k];
                                 Packet.Serialize((Event)fragment, this.stream, this.taskHubGuid);
+                                this.traceHelper.LogTrace("EventHubsSender {eventHubName}/{eventHubPartitionId} sending fragment {index}/{total} ({size} bytes) id={eventId}", this.eventHubName, this.eventHubPartition, k, fragments.Count, length, ((Event)fragment).EventIdString);
                                 length = (int)this.stream.Position;
                                 await this.sender.SendAsync(new EventData(new ArraySegment<byte>(this.stream.GetBuffer(), 0, length))).ConfigureAwait(false);
-                                this.traceHelper.LogDebug("EventHubsSender {eventHubName}/{eventHubPartitionId} sent packet ({size} bytes) {evt} id={eventId}", this.eventHubName, this.eventHubPartition, length, fragment, ((Event)fragment).EventIdString);
+                                this.traceHelper.LogDebug("EventHubsSender {eventHubName}/{eventHubPartitionId} sent fragment {index}/{total} ({size} bytes) id={eventId}", this.eventHubName, this.eventHubPartition, k, fragments.Count, length, ((Event)fragment).EventIdString);
                             }
                             sentSuccessfully = i;
                         }
@@ -114,12 +129,8 @@ namespace DurableTask.Netherite.EventHubs
 
                 if (batch.Count > 0)
                 {
-                    maybeSent = toSend.Count - 1;
-                    await this.sender.SendAsync(batch).ConfigureAwait(false);
-                    sentSuccessfully = toSend.Count - 1;
-
-                    this.traceHelper.LogDebug("EventHubsSender {eventHubName}/{eventHubPartitionId} sent batch of {numPackets} packets", this.eventHubName, this.eventHubPartition, batch.Count);
-
+                    await SendBatch(toSend.Count - 1);
+                    
                     // the buffer can be reused now
                     this.stream.Seek(0, SeekOrigin.Begin);
                 }

--- a/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsSender.cs
+++ b/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsSender.cs
@@ -57,6 +57,8 @@ namespace DurableTask.Netherite.EventHubs
                 {
                     long startPos = this.stream.Position;
                     var evt = toSend[i];
+
+                    this.traceHelper.LogTrace("EventHubsSender {eventHubName}/{eventHubPartitionId} is sending event {evt} id={eventId}", this.eventHubName, this.eventHubPartition, evt, evt.EventIdString);
                     Packet.Serialize(evt, this.stream, this.taskHubGuid);
                     int length = (int)(this.stream.Position - startPos);
                     var arraySegment = new ArraySegment<byte>(this.stream.GetBuffer(), (int)startPos, length);

--- a/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsTransport.cs
+++ b/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsTransport.cs
@@ -14,6 +14,8 @@ namespace DurableTask.Netherite.EventHubs
     using Microsoft.Azure.Storage.Blob;
     using Newtonsoft.Json;
     using DurableTask.Netherite.Faster;
+    using System.Linq;
+    using System.Threading.Channels;
 
     /// <summary>
     /// The EventHubs transport implementation.
@@ -37,7 +39,9 @@ namespace DurableTask.Netherite.EventHubs
         byte[] taskhubGuid;
         EventHubsConnections connections;
 
-        Task clientEventLoopTask = Task.CompletedTask;
+        Task[] clientReceiveTasks;
+        Task clientProcessTask;
+
         CancellationTokenSource shutdownSource;
         readonly CloudBlobContainer cloudBlobContainer;
         readonly CloudBlockBlob taskhubParameters;
@@ -190,7 +194,19 @@ namespace DurableTask.Netherite.EventHubs
 
             this.client = this.host.AddClient(this.ClientId, this.parameters.TaskhubGuid, this);
 
-            this.clientEventLoopTask = Task.Run(this.ClientEventLoop);
+            var channel = Channel.CreateBounded<ClientEvent>(new BoundedChannelOptions(500) {
+                SingleReader = true, 
+                AllowSynchronousContinuations = true 
+            });
+
+            var clientReceivers = this.connections.CreateClientReceivers(this.ClientId, EventHubsTransport.ClientConsumerGroup);
+
+            this.clientReceiveTasks = Enumerable
+                .Range(0, EventHubsConnections.NumClientChannels)
+                .Select(i => this.ClientReceiveLoopAsync(i, clientReceivers[i], channel.Writer))
+                .ToArray();
+
+            this.clientProcessTask = this.ClientProcessLoopAsync(channel.Reader);
 
             if (PartitionHubs.Length > 1)
             {
@@ -396,16 +412,13 @@ namespace DurableTask.Netherite.EventHubs
             }
         }
 
-        async Task ClientEventLoop()
+        async Task ClientReceiveLoopAsync(int index, PartitionReceiver receiver, ChannelWriter<ClientEvent> channelWriter)
         {
-            var clientReceiver = this.connections.CreateClientReceiver(this.ClientId, EventHubsTransport.ClientConsumerGroup);
-            var receivedEvents = new List<ClientEvent>();
-
             byte[] taskHubGuid = this.parameters.TaskhubGuid.ToByteArray();
 
             while (!this.shutdownSource.IsCancellationRequested)
             {
-                IEnumerable<EventData> eventData = await clientReceiver.ReceiveAsync(1000, TimeSpan.FromMinutes(1)).ConfigureAwait(false);
+                IEnumerable<EventData> eventData = await receiver.ReceiveAsync(1000, TimeSpan.FromMinutes(1));
 
                 if (eventData != null)
                 {
@@ -415,31 +428,29 @@ namespace DurableTask.Netherite.EventHubs
 
                         try
                         {
+                            this.traceHelper.LogDebug("Client{clientId}/{index} received packet #{seqno} ({size} bytes)", Client.GetShortId(this.ClientId), index, ed.SystemProperties.SequenceNumber, ed.Body.Count);
                             Packet.Deserialize(ed.Body, out clientEvent, taskHubGuid);
-
                             if (clientEvent != null && clientEvent.ClientId == this.ClientId)
                             {
-                                receivedEvents.Add(clientEvent);
+                                await channelWriter.WriteAsync(clientEvent);
                             }
                         }
                         catch (Exception)
                         {
-                            this.traceHelper.LogError("EventProcessor for Client{clientId} could not deserialize packet #{seqno} ({size} bytes)", Client.GetShortId(this.ClientId), ed.SystemProperties.SequenceNumber, ed.Body.Count);
+                            this.traceHelper.LogError("Client{clientId}/{index} could not deserialize packet #{seqno} ({size} bytes)", Client.GetShortId(this.ClientId), index, ed.SystemProperties.SequenceNumber, ed.Body.Count);
                             throw;
                         }
-                        this.traceHelper.LogDebug("EventProcessor for Client{clientId} received packet #{seqno} ({size} bytes)", Client.GetShortId(this.ClientId), ed.SystemProperties.SequenceNumber, ed.Body.Count);
-
-                    }
-
-                    if (receivedEvents.Count > 0)
-                    {
-                        foreach (var evt in receivedEvents)
-                        {
-                            this.client.Process(evt);
-                        }
-                        receivedEvents.Clear();
                     }
                 }
+            }
+        }
+
+        async Task ClientProcessLoopAsync(ChannelReader<ClientEvent> channelReader)
+        {           
+            while (!this.shutdownSource.IsCancellationRequested)
+            {
+                var clientEvent = await channelReader.ReadAsync(this.shutdownSource.Token);
+                this.client.Process(clientEvent);
             }
         }
     }

--- a/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsTransport.cs
+++ b/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsTransport.cs
@@ -432,7 +432,8 @@ namespace DurableTask.Netherite.EventHubs
                             Packet.Deserialize(ed.Body, out clientEvent, taskHubGuid);
                             if (clientEvent != null && clientEvent.ClientId == this.ClientId)
                             {
-                                await channelWriter.WriteAsync(clientEvent);
+                               this.traceHelper.LogTrace("Client{clientId}/{index} receiving event {evt} id={eventId}]", Client.GetShortId(this.ClientId), index, clientEvent, clientEvent.EventIdString);
+                               await channelWriter.WriteAsync(clientEvent);
                             }
                         }
                         catch (Exception)

--- a/src/DurableTask.Netherite/TransportProviders/EventHubs/ScriptedEventProcessorHost.cs
+++ b/src/DurableTask.Netherite/TransportProviders/EventHubs/ScriptedEventProcessorHost.cs
@@ -385,7 +385,7 @@ namespace DurableTask.Netherite.EventHubs
                             if (batch.Count > 0 && !this.shutdownSource.IsCancellationRequested)
                             {
                                 this.host.logger.LogDebug("PartitionInstance {eventHubName}/{eventHubPartition}({incarnation}) received batch of {batchsize} packets, starting with #{seqno}, next expected packet is #{nextSeqno}", this.host.eventHubPath, this.partitionId, this.Incarnation, batch.Count, batch[0].NextInputQueuePosition - 1, nextPacketToReceive);
-                                this.partition.SubmitExternalEvents(batch);
+                                this.partition.SubmitEvents(batch);
                             }
                         }
                     }

--- a/src/DurableTask.Netherite/TransportProviders/Memory/MemoryPartitionQueue.cs
+++ b/src/DurableTask.Netherite/TransportProviders/Memory/MemoryPartitionQueue.cs
@@ -44,7 +44,7 @@ namespace DurableTask.Netherite.Emulated
             {
                 evt.ReceivedTimestamp = this.partition.CurrentTimeMs;
 
-                this.partition.SubmitExternalEvents(new PartitionEvent[] { evt });
+                this.partition.SubmitEvents(new PartitionEvent[] { evt });
             }
             catch (System.Threading.Tasks.TaskCanceledException)
             {

--- a/src/DurableTask.Netherite/Util/BatchWorker.cs
+++ b/src/DurableTask.Netherite/Util/BatchWorker.cs
@@ -49,6 +49,8 @@ namespace DurableTask.Netherite
             this.traceHelper = traceHelper;
         }
 
+        public bool IsIdle => (this.state == IDLE);
+
         protected Action<string> Tracer { get; set; } = null;
 
         /// <summary>Implement this member in derived classes to process a batch</summary>

--- a/test/PerformanceTests/Common/Queries.cs
+++ b/test/PerformanceTests/Common/Queries.cs
@@ -79,7 +79,7 @@ namespace PerformanceTests
                     {
                         if (parameters.TryGetValue("showInput", out string val))
                         {
-                            parameters.Remove("showinput");
+                            parameters.Remove("showInput");
                             queryCondition.ShowInput = bool.Parse(val);
                         }
                     }

--- a/test/PerformanceTests/Common/Queries.cs
+++ b/test/PerformanceTests/Common/Queries.cs
@@ -1,0 +1,159 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace PerformanceTests
+{
+    using System;
+    using System.IO;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.Http;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.Extensions.Logging;
+    using Newtonsoft.Json;
+    using System.Collections.Generic;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+    using System.Linq;
+    using System.Diagnostics;
+    using System.Threading;
+    using System.Net.Http;
+    using System.Net;
+
+    public static class Queries
+    {
+        [FunctionName(nameof(PagedQuery))]
+        public static async Task<JsonResult> PagedQuery(
+          [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "pagedquery")] HttpRequest req,
+          [DurableClient] IDurableClient client,
+          ILogger log)
+        {
+            try
+            {
+                var queryCondition = new OrchestrationStatusQueryCondition()
+                {                   
+                    PageSize = 100,
+                };
+
+                try
+                {
+                    var parameters = req.GetQueryParameterDictionary();
+                    {
+                        if (parameters.TryGetValue("runtimeStatus", out string val))
+                        {
+                            parameters.Remove("runtimeStatus");
+                            queryCondition.RuntimeStatus = val
+                                .Split(",")
+                                .Select(s => (OrchestrationRuntimeStatus)Enum.Parse(typeof(OrchestrationRuntimeStatus), s))
+                                .ToList();
+                        }
+                    }
+                    {
+                        if (parameters.TryGetValue("createdTimeFrom", out string val))
+                        {
+                            parameters.Remove("createdTimeFrom");
+                            queryCondition.CreatedTimeFrom = DateTime.Parse(val);
+                        }
+                    }
+                    {
+                        if (parameters.TryGetValue("createdTimeTo", out string val))
+                        {
+                            parameters.Remove("createdTimeTo");
+                            queryCondition.CreatedTimeTo = DateTime.Parse(val);
+                        }
+                    }
+                    {
+                        if (parameters.TryGetValue("pageSize", out string val))
+                        {
+                            parameters.Remove("pageSize");
+                            queryCondition.PageSize = int.Parse(val);
+                        }
+                    }
+                    {
+                        if (parameters.TryGetValue("instanceIdPrefix", out string val))
+                        {
+                            parameters.Remove("instanceIdPrefix");
+                            queryCondition.InstanceIdPrefix = val;
+                        }
+                    }
+                    {
+                        if (parameters.TryGetValue("showInput", out string val))
+                        {
+                            parameters.Remove("showinput");
+                            queryCondition.ShowInput = bool.Parse(val);
+                        }
+                    }
+                    if (parameters.Count > 0)
+                    {
+                        throw new ArgumentException($"invalid parameter: {parameters.First().Key}");
+                    }
+                } 
+                catch(Exception e)
+                {
+                    return new JsonResult(new
+                    {
+                        message = e.Message,
+                    })
+                    {
+                        StatusCode = (int)HttpStatusCode.BadRequest,
+                    };
+                }
+
+                int records = 0;
+                int completed = 0;
+                int inputchars = 0;
+                int pages = 0;
+
+                log.LogWarning($"Querying orchestration instances...");
+
+                var stopwatch = Stopwatch.StartNew();
+
+                do
+                {
+                    pages++;
+                    OrchestrationStatusQueryResult result = await client.ListInstancesAsync(queryCondition, CancellationToken.None);
+                    queryCondition.ContinuationToken = result.ContinuationToken;
+
+                    foreach (var status in result.DurableOrchestrationState)
+                    {
+                        records++;
+
+                        if (status.RuntimeStatus == OrchestrationRuntimeStatus.Completed)
+                        {
+                            completed++;
+                        }
+ 
+                        if (status.Input != null)
+                        {
+                            inputchars += status.Input.ToString().Length;
+                        }
+                    }
+
+                } while (queryCondition.ContinuationToken != null);
+
+                stopwatch.Stop();
+                double querySec = stopwatch.ElapsedMilliseconds / 1000.0;
+
+                return new JsonResult(new
+                { 
+                    records,
+                    completed,
+                    inputchars,
+                    pages,
+                    querySec,
+                    throughput = records > 0 ? (records/querySec).ToString("F2") : "n/a",
+                });   
+            }
+            catch (Exception e)
+            {
+                return new JsonResult(new 
+                {
+                    error = e.ToString() 
+                })
+                {
+                    StatusCode = (int)HttpStatusCode.InternalServerError,
+                };
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add several optimizations to the query processing:
- start queries sooner when the request is received
- use 2 EH partitions per client to improve throughput of returned results
- use hand-written serialization/deserialization to improve throughput of returned results