### PR TITLE
fix incorrect uses of the resolved connection string

### DIFF
--- a/src/DurableTask.Netherite.AzureFunctions/NetheriteProvider.cs
+++ b/src/DurableTask.Netherite.AzureFunctions/NetheriteProvider.cs
@@ -29,7 +29,7 @@ namespace DurableTask.Netherite.AzureFunctions
         public NetheriteProvider(
             NetheriteOrchestrationService service,
             NetheriteOrchestrationServiceSettings settings)
-            : base("Netherite", service, service, settings.ResolvedStorageConnectionString)
+            : base("Netherite", service, service, settings.StorageConnectionName)
         {
             this.Service = service;
             this.Settings = settings;

--- a/src/DurableTask.Netherite.AzureFunctions/NetheriteProviderFactory.cs
+++ b/src/DurableTask.Netherite.AzureFunctions/NetheriteProviderFactory.cs
@@ -126,7 +126,7 @@ namespace DurableTask.Netherite.AzureFunctions
                 var key = new DurableClientAttribute()
                 {
                     TaskHub = settings.HubName,
-                    ConnectionName = settings.ResolvedStorageConnectionString,
+                    ConnectionName = settings.StorageConnectionName,
                 };
  
                 this.defaultProvider = this.cachedProviders.GetOrAdd(key, _ =>
@@ -145,7 +145,7 @@ namespace DurableTask.Netherite.AzureFunctions
             var settings = this.GetNetheriteOrchestrationServiceSettings(attribute.TaskHub);
 
             if (string.Equals(this.defaultProvider.Settings.HubName, settings.HubName, StringComparison.OrdinalIgnoreCase) &&
-                 string.Equals(this.defaultProvider.Settings.ResolvedStorageConnectionString, settings.ResolvedStorageConnectionString, StringComparison.OrdinalIgnoreCase))
+                 string.Equals(this.defaultProvider.Settings.StorageConnectionName, settings.StorageConnectionName, StringComparison.OrdinalIgnoreCase))
             {
                 return this.defaultProvider;
             }
@@ -153,7 +153,7 @@ namespace DurableTask.Netherite.AzureFunctions
             DurableClientAttribute key = new DurableClientAttribute()
             {
                 TaskHub = settings.HubName,
-                ConnectionName = settings.ResolvedStorageConnectionString,
+                ConnectionName = settings.StorageConnectionName,
             };
 
             return this.cachedProviders.GetOrAdd(key, _ =>

--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
@@ -93,8 +93,8 @@ namespace DurableTask.Netherite
             TransportConnectionString.Parse(this.Settings.ResolvedTransportConnectionString, out this.configuredStorage, out this.configuredTransport);
             this.Logger = loggerFactory.CreateLogger(LoggerCategoryName);
             this.LoggerFactory = loggerFactory;
-            this.StorageAccountName = this.configuredTransport == TransportConnectionString.TransportChoices.Memory
-                ? this.Settings.ResolvedStorageConnectionString
+            this.StorageAccountName = this.configuredStorage == TransportConnectionString.StorageChoices.Memory
+                ? "Memory"
                 : CloudStorageAccount.Parse(this.Settings.ResolvedStorageConnectionString).Credentials.AccountName;
 
             EtwSource.Log.OrchestrationServiceCreated(this.ServiceInstanceId, this.StorageAccountName, this.Settings.HubName, this.Settings.WorkerId, TraceUtils.AppName, TraceUtils.ExtensionVersion);


### PR DESCRIPTION
As discovered in #75, the provider uses the ResolvedConnectionString in several places where the ConnectionName should be used.

This PR fixes this by
- using StorageConnectionName when calling the baseclass constructor for `DurabilityProvider`
- using StorageConnectionName when constructing a `DurableClientAttribute`

I also fixed another case where the ResolvedConnectionString was incorrectly used as the account name, now using "Memory" instead.