### PR TITLE
fix recovery parameter for FASTER

### DIFF
--- a/src/DurableTask.Netherite/StorageProviders/Faster/FasterKV.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/FasterKV.cs
@@ -76,7 +76,7 @@ namespace DurableTask.Netherite.Faster
             {
                 await this.blobManager.FindCheckpointsAsync();
                 this.blobManager.TraceHelper.FasterProgress($"Recovering FasterKV");
-                await this.fht.RecoverAsync(numPagesToPreload: 0);
+                await this.fht.RecoverAsync();
                 this.mainSession = this.CreateASession();
                 return (this.blobManager.CheckpointInfo.CommitLogPosition, this.blobManager.CheckpointInfo.InputQueuePosition);
             }


### PR DESCRIPTION
FASTER was using the wrong setting which means it runs very slowly after recovery due to an excessive amount of cache misses.