### PR TITLE
Fix NullReferenceException during recovery, add unit test for recovery

### DIFF
--- a/src/DurableTask.Netherite/StorageProviders/Faster/AzureBlobs/BlobManager.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/AzureBlobs/BlobManager.cs
@@ -842,7 +842,7 @@ namespace DurableTask.Netherite.Faster
         IEnumerable<Guid> ICheckpointManager.GetIndexCheckpointTokens()
         {
             var indexToken = this.CheckpointInfo.IndexToken;
-            this.StorageTracer?.FasterStorageProgress($"ICheckpointManager.GetLogCheckpointTokens returned logToken={indexToken}");
+            this.StorageTracer?.FasterStorageProgress($"ICheckpointManager.GetIndexCheckpointTokens returned indexToken={indexToken}");
             yield return indexToken;
         }
 

--- a/src/DurableTask.Netherite/StorageProviders/Faster/AzureBlobs/BlobManager.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/AzureBlobs/BlobManager.cs
@@ -694,6 +694,8 @@ namespace DurableTask.Netherite.Faster
 
         (string, string) GetObjectLogSnapshotBlobName(Guid token) => ($"cpr-checkpoints/{token}", "snapshot.obj.dat");
 
+        (string, string) GetDeltaLogSnapshotBlobName(Guid token) => ($"cpr-checkpoints/{token}", "snapshot.delta.dat");
+
         #endregion
 
         #region ILogCommitManager
@@ -1071,7 +1073,17 @@ namespace DurableTask.Netherite.Faster
             return device;
         }
 
-        internal IDevice GetDeltaLogDevice(Guid token, int indexOrdinal) => default;    // TODO
+        internal IDevice GetDeltaLogDevice(Guid token, int psfGroupOrdinal)
+        {
+            var (isPsf, tag) = this.IsPsfOrPrimary(psfGroupOrdinal);
+            this.StorageTracer?.FasterStorageProgress($"ICheckpointManager.GetDeltaLogDevice Called on {tag}, token={token}");
+            var (path, blobName) = this.GetDeltaLogSnapshotBlobName(token);
+            this.GetPartitionDirectories(isPsf, psfGroupOrdinal, path, out var blockBlobDir, out var pageBlobDir);
+            var device = new AzureStorageDevice(blobName, blockBlobDir, pageBlobDir, this, false); // we don't need a lease since the token provides isolation
+            device.StartAsync().Wait();
+            this.StorageTracer?.FasterStorageProgress($"ICheckpointManager.GetDeltaLogDevice Returned from {tag}, blobDirectory={blockBlobDir} blobName={blobName}");
+            return device;
+        }
 
         #endregion
 

--- a/test/DurableTask.Netherite.Tests/FasterPartitionTests.cs
+++ b/test/DurableTask.Netherite.Tests/FasterPartitionTests.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace DurableTask.Netherite.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Threading.Tasks;
+    using DurableTask.Core;
+    using DurableTask.Core.History;
+    using Microsoft.Extensions.Logging;
+    using Newtonsoft.Json;
+    using Xunit;
+    using Xunit.Abstractions;
+    using static DurableTask.Netherite.Tests.SingleHostFixture;
+
+    [Collection("NetheriteTests")]
+    public class FasterPartitionTests : IDisposable
+    {
+        readonly TestTraceListener traceListener;
+        readonly ILoggerFactory loggerFactory;
+        readonly XunitLoggerProvider provider;
+
+
+        public FasterPartitionTests(ITestOutputHelper output)
+        {
+            this.loggerFactory = new LoggerFactory();
+            this.provider = new XunitLoggerProvider();
+            this.loggerFactory.AddProvider(this.provider);
+            this.traceListener = new TestTraceListener();
+            Trace.Listeners.Add(this.traceListener);
+            this.provider.Output = output;
+            this.traceListener.Output = output;
+        }
+
+        public void Dispose()
+        {
+            this.provider.Output = null;
+            this.traceListener.Output = null;
+            Trace.Listeners.Remove(this.traceListener);
+        }
+
+        /// <summary>
+        /// Create a partition and then restore it.
+        /// </summary>
+        [Fact]
+        public async Task CreateThenRestore()
+        {
+            var settings = TestConstants.GetNetheriteOrchestrationServiceSettings();
+            settings.PartitionManagement = PartitionManagementOptions.Scripted;
+            settings.PartitionCount = 1;
+            settings.HubName = $"{TestConstants.TaskHubName}-{Guid.NewGuid()}";
+            var service = new NetheriteOrchestrationService(settings, this.loggerFactory);
+            await service.CreateAsync();
+            await service.StartAsync();
+            var host = (TransportAbstraction.IHost)service;
+            Assert.Equal(1u, service.NumberPartitions);
+            await service.StopAsync();
+        }
+    }
+
+}

--- a/test/DurableTask.Netherite.Tests/FasterPartitionTests.cs
+++ b/test/DurableTask.Netherite.Tests/FasterPartitionTests.cs
@@ -49,7 +49,6 @@ namespace DurableTask.Netherite.Tests
         {
             var settings = TestConstants.GetNetheriteOrchestrationServiceSettings();
             settings.ResolvedTransportConnectionString = "MemoryF";
-            settings.PartitionManagement = PartitionManagementOptions.Scripted;
             settings.PartitionCount = 1;
             settings.HubName = $"{TestConstants.TaskHubName}-{Guid.NewGuid()}";
 

--- a/test/DurableTask.Netherite.Tests/PartitionTestFixture.cs
+++ b/test/DurableTask.Netherite.Tests/PartitionTestFixture.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace DurableTask.Netherite.Tests
+{
+    using Microsoft.Extensions.Logging;
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Text;
+    using Xunit.Abstractions;
+
+    public class PartitionTestFixture : IDisposable
+    {
+        readonly TestTraceListener traceListener;
+        readonly XunitLoggerProvider loggerProvider;
+        internal TestOrchestrationHost Host { get; private set; }
+        internal ILoggerFactory LoggerFactory { get; private set; }
+
+        public PartitionTestFixture()
+        {
+            this.LoggerFactory = new LoggerFactory();
+            this.loggerProvider = new XunitLoggerProvider();
+            this.LoggerFactory.AddProvider(this.loggerProvider);
+            TestConstants.ValidateEnvironment();
+            this.Host = TestConstants.GetTestOrchestrationHost(this.LoggerFactory);
+            this.Host.StartAsync().Wait();
+            this.traceListener = new TestTraceListener();
+            Trace.Listeners.Add(this.traceListener);
+        }
+
+        public void Dispose()
+        {
+            this.ClearOutput();
+            this.Host.StopAsync(false).Wait();
+            this.Host.Dispose();
+            Trace.Listeners.Remove(this.traceListener);
+        }
+
+        public void SetOutput(ITestOutputHelper output)
+        {
+            this.loggerProvider.Output = output;
+            this.traceListener.Output = output;
+        }
+
+        public void ClearOutput()
+        {
+            this.loggerProvider.Output = null;
+            this.traceListener.Output = null;
+        }
+
+        internal class TestTraceListener : TraceListener
+        {
+            public ITestOutputHelper Output { get; set; }
+            public override void Write(string message) {  }
+            public override void WriteLine(string message) { this.Output?.WriteLine($"{DateTime.Now:o} {message}"); }
+        }
+    }
+}

--- a/test/DurableTask.Netherite.Tests/QueryTests.cs
+++ b/test/DurableTask.Netherite.Tests/QueryTests.cs
@@ -12,7 +12,7 @@ namespace DurableTask.Netherite.Tests
     using System.Linq;
     using System.Collections.Generic;
 
-    using TestTraceListener = DurableTask.Netherite.Tests.TestFixture.TestTraceListener;
+    using TestTraceListener = DurableTask.Netherite.Tests.SingleHostFixture.TestTraceListener;
     using Orchestrations = DurableTask.Netherite.Tests.ScenarioTests.Orchestrations;
     using Microsoft.Extensions.Logging;
     using DurableTask.Netherite;
@@ -20,12 +20,12 @@ namespace DurableTask.Netherite.Tests
 
     // These tests are copied from AzureStorageScenarioTests
     [Collection("NetheriteTests")]
-    public partial class QueryTests : IClassFixture<TestFixture>, IDisposable
+    public partial class QueryTests : IClassFixture<SingleHostFixture>, IDisposable
     {
-        readonly TestFixture fixture;
+        readonly SingleHostFixture fixture;
         readonly TestOrchestrationHost host;
 
-        public QueryTests(TestFixture fixture, ITestOutputHelper outputHelper)
+        public QueryTests(SingleHostFixture fixture, ITestOutputHelper outputHelper)
         {
             this.fixture = fixture;
             this.host = fixture.Host;

--- a/test/DurableTask.Netherite.Tests/ScenarioTests.cs
+++ b/test/DurableTask.Netherite.Tests/ScenarioTests.cs
@@ -23,12 +23,12 @@ namespace DurableTask.Netherite.Tests
     // The majority of these tests were ported from AzureStorageScenarioTests in the azure/durabletask repository
 
     [Collection("NetheriteTests")]
-    public partial class ScenarioTests : IClassFixture<TestFixture>, IDisposable
+    public partial class ScenarioTests : IClassFixture<SingleHostFixture>, IDisposable
     {
-        readonly TestFixture fixture;
+        readonly SingleHostFixture fixture;
         readonly TestOrchestrationHost host;
 
-        public ScenarioTests(TestFixture fixture, ITestOutputHelper outputHelper)
+        public ScenarioTests(SingleHostFixture fixture, ITestOutputHelper outputHelper)
         {
             this.fixture = fixture;
             this.host = fixture.Host;

--- a/test/DurableTask.Netherite.Tests/SingleHostFixture.cs
+++ b/test/DurableTask.Netherite.Tests/SingleHostFixture.cs
@@ -10,20 +10,25 @@ namespace DurableTask.Netherite.Tests
     using System.Text;
     using Xunit.Abstractions;
 
-    public class TestFixture : IDisposable
+    /// <summary>
+    /// A test fixture that starts the host before the tests start, and shuts it down after all the tests complete.
+    /// </summary>
+    public class SingleHostFixture : IDisposable
     {
         readonly TestTraceListener traceListener;
         readonly XunitLoggerProvider loggerProvider;
         internal TestOrchestrationHost Host { get; private set; }
         internal ILoggerFactory LoggerFactory { get; private set; }
 
-        public TestFixture()
+        public SingleHostFixture()
         {
             this.LoggerFactory = new LoggerFactory();
             this.loggerProvider = new XunitLoggerProvider();
             this.LoggerFactory.AddProvider(this.loggerProvider);
             TestConstants.ValidateEnvironment();
-            this.Host = TestConstants.GetTestOrchestrationHost(this.LoggerFactory);
+            var settings = TestConstants.GetNetheriteOrchestrationServiceSettings();
+            settings.PartitionManagement = PartitionManagementOptions.EventProcessorHost;
+            this.Host = new TestOrchestrationHost(settings, this.LoggerFactory);
             this.Host.StartAsync().Wait();
             this.traceListener = new TestTraceListener();
             Trace.Listeners.Add(this.traceListener);


### PR DESCRIPTION
After updating to the latest FASTER, I broke recovery since the delta log was missing. This fixes the missing code in the commit manager.

Also, it adds a new unit test that tests recovery specifically.