### PR TITLE
Support netstandard2.0

### DIFF
--- a/src/DurableTask.Netherite.AzureFunctions/DurableTask.Netherite.AzureFunctions.csproj
+++ b/src/DurableTask.Netherite.AzureFunctions/DurableTask.Netherite.AzureFunctions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/DurableTask.Netherite.AzureFunctions/NetheriteProvider.cs
+++ b/src/DurableTask.Netherite.AzureFunctions/NetheriteProvider.cs
@@ -208,7 +208,7 @@ namespace DurableTask.Netherite.AzureFunctions
                     }
                     else
                     {
-                        var stream = new MemoryStream(metrics[^1].Metrics);
+                        var stream = new MemoryStream(metrics[metrics.Length - 1].Metrics);
                         var collectedMetrics = (ScalingMonitor.Metrics) this.serializer.ReadObject(stream);                 
                         recommendation = this.scalingMonitor.GetScaleRecommendation(workerCount, collectedMetrics);
                     }

--- a/src/DurableTask.Netherite/DurableTask.Netherite.csproj
+++ b/src/DurableTask.Netherite/DurableTask.Netherite.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/DurableTask.Netherite/LoadMonitor/LoadMonitor.cs
+++ b/src/DurableTask.Netherite/LoadMonitor/LoadMonitor.cs
@@ -163,8 +163,8 @@ namespace DurableTask.Netherite
             }
 
             // trace backlog estimates
-            string estimated = string.Join(',', this.LoadInfo.Values.Select(i => i.ProjectedLoad.ToString()));
-            string mobile = string.Join(',', this.LoadInfo.Values.Select(i => i.EstimatedMobile.ToString()));
+            string estimated = string.Join(",", this.LoadInfo.Values.Select(i => i.ProjectedLoad.ToString()));
+            string mobile = string.Join(",", this.LoadInfo.Values.Select(i => i.EstimatedMobile.ToString()));
             this.traceHelper.TraceProgress($"BacklogEstimates pending={this.PendingOnSource.Count},{this.PendingOnDestination.Count} RTT={this.EstimatedTransferRTT:f2} estimated=[{estimated}] mobile=[{mobile}]");
         }
 

--- a/src/DurableTask.Netherite/Scaling/PartitionLoadInfo.cs
+++ b/src/DurableTask.Netherite/Scaling/PartitionLoadInfo.cs
@@ -190,7 +190,7 @@ namespace DurableTask.Netherite.Scaling
 
             if (copy.LatencyTrend.Length == PartitionLoadInfo.LatencyTrendLength)
             {
-                copy.LatencyTrend = $"{copy.LatencyTrend[1..PartitionLoadInfo.LatencyTrendLength]}{Idle}";
+                copy.LatencyTrend = $"{copy.LatencyTrend.Substring(1)}{Idle}";
             }
             else
             {
@@ -202,28 +202,28 @@ namespace DurableTask.Netherite.Scaling
 
         public void MarkActive()
         {
-            char last = this.LatencyTrend[^1];
+            char last = this.LatencyTrend[this.LatencyTrend.Length-1];
             if (last == Idle)
             {
-                this.LatencyTrend = $"{this.LatencyTrend[0..^1]}{LowLatency}"; 
+                this.LatencyTrend = $"{this.LatencyTrend.Substring(0, this.LatencyTrend.Length-1)}{LowLatency}"; 
             }
         }
 
         public void MarkMediumLatency()
         {
-            char last = this.LatencyTrend[^1];
+            char last = this.LatencyTrend[this.LatencyTrend.Length - 1];
             if (last == Idle || last == LowLatency)
             {
-                this.LatencyTrend = $"{this.LatencyTrend[0..^1]}{MediumLatency}"; 
+                this.LatencyTrend = $"{this.LatencyTrend.Substring(0, this.LatencyTrend.Length - 1)}{MediumLatency}"; 
             }
         }
 
         public void MarkHighLatency()
         {
-            char last = this.LatencyTrend[^1];
+            char last = this.LatencyTrend[this.LatencyTrend.Length - 1];
             if (last == Idle || last == LowLatency || last == MediumLatency)
             {
-                this.LatencyTrend = $"{this.LatencyTrend[0..^1]}{HighLatency}";
+                this.LatencyTrend = $"{this.LatencyTrend.Substring(0, this.LatencyTrend.Length - 1)}{HighLatency}";
             }
         }
     }


### PR DESCRIPTION
Update the Netherite dlls so we don't force everyone to use netstandard2.1:

```xml
<TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
```

This required some small changes to the code (had to remove features that were new in netstandard2.1). Other than that it seems to work.