### PR TITLE
Implement replay checker

### DIFF
--- a/src/DurableTask.Netherite/Abstractions/PartitionState/EffectTracker.cs
+++ b/src/DurableTask.Netherite/Abstractions/PartitionState/EffectTracker.cs
@@ -14,29 +14,16 @@ namespace DurableTask.Netherite
     /// information about the context, and to enumerate the objects on which the effect
     /// is being processed.
     /// </summary>
-    class EffectTracker : List<TrackedObjectKey>
+    abstract class EffectTracker : List<TrackedObjectKey>
     {
-        readonly Func<TrackedObjectKey, EffectTracker, ValueTask> applyToStore;
-        readonly Func<IEnumerable<TrackedObjectKey>, ValueTask> removeFromStore;
-        readonly Func<(long, long)> getPositions;
-        readonly System.Diagnostics.Stopwatch stopWatch;
         readonly HashSet<TrackedObjectKey> deletedKeys;
 
-        public EffectTracker(Partition partition, Func<TrackedObjectKey, EffectTracker, ValueTask> applyToStore, Func<IEnumerable<TrackedObjectKey>, ValueTask> removeFromStore, Func<(long, long)> getPositions)
-        {
-            this.Partition = partition;
-            this.applyToStore = applyToStore;
-            this.removeFromStore = removeFromStore;
-            this.getPositions = getPositions;
-            this.stopWatch = new System.Diagnostics.Stopwatch();
-            this.deletedKeys = new HashSet<TrackedObjectKey>();
-            this.stopWatch.Start();
-        }
+        PartitionUpdateEvent currentUpdate;
 
-        /// <summary>
-        /// The current partition.
-        /// </summary>
-        public Partition Partition { get; }
+        public EffectTracker()
+        {
+            this.deletedKeys = new HashSet<TrackedObjectKey>();
+        }
 
         /// <summary>
         /// The event id of the current effect.
@@ -55,7 +42,30 @@ namespace DurableTask.Netherite
             this.currentUpdate = updateEvent;
         }
 
-        PartitionUpdateEvent currentUpdate;
+
+        #region abstract methods
+
+        public abstract ValueTask ApplyToStore(TrackedObjectKey key, EffectTracker tracker);
+
+        public abstract ValueTask RemoveFromStore(IEnumerable<TrackedObjectKey> keys);
+        
+        public abstract (long, long) GetPositions();
+
+        public abstract Partition Partition { get; }
+
+        public abstract EventTraceHelper EventTraceHelper { get; }    
+
+        public abstract EventTraceHelper EventDetailTracer { get; }
+
+        protected abstract void HandleError(string where, string message, Exception e, bool terminatePartition, bool reportAsWarning);
+
+        public abstract void Assert(bool condition);
+
+        public abstract uint PartitionId { get; }
+
+        public abstract double CurrentTimeMs { get; }
+
+        #endregion
 
         /// <summary>
         /// Applies the event to the given tracked object, using visitor pattern to
@@ -73,7 +83,7 @@ namespace DurableTask.Netherite
             {
                 // for robustness, we swallow exceptions inside event processing.
                 // It does not mean they are not serious. We still report them as errors.
-                this.Partition.ErrorHandler.HandleError(nameof(ProcessUpdate), $"Encountered exception on {trackedObject} when applying update event {this.currentUpdate}, eventId={this.currentUpdate?.EventId}", exception, false, false);
+                this.HandleError(nameof(ProcessUpdate), $"Encountered exception on {trackedObject} when applying update event {this.currentUpdate}, eventId={this.currentUpdate?.EventId}", exception, false, false);
             }
         }
 
@@ -84,16 +94,16 @@ namespace DurableTask.Netherite
 
         public async Task ProcessUpdate(PartitionUpdateEvent updateEvent)
         {
-            (long commitLogPosition, long inputQueuePosition) = this.getPositions();
-            double startedTimestamp = this.Partition.CurrentTimeMs;
+            (long commitLogPosition, long inputQueuePosition) = this.GetPositions();
+            double startedTimestamp = this.CurrentTimeMs;
 
             using (EventTraceContext.MakeContext(commitLogPosition, updateEvent.EventIdString))
             {
                 try
                 {
-                    this.Partition.EventDetailTracer?.TraceEventProcessingStarted(commitLogPosition, updateEvent, EventTraceHelper.EventCategory.UpdateEvent, this.IsReplaying);
+                    this.EventDetailTracer?.TraceEventProcessingStarted(commitLogPosition, updateEvent, EventTraceHelper.EventCategory.UpdateEvent, this.IsReplaying);
 
-                    this.Partition.Assert(updateEvent != null);
+                    this.Assert(updateEvent != null);
 
                     this.SetCurrentUpdateEvent(updateEvent);
 
@@ -111,10 +121,10 @@ namespace DurableTask.Netherite
                         var startPos = this.Count - 1;
                         var key = this[startPos];
 
-                        this.Partition.EventDetailTracer?.TraceEventProcessingDetail($"Process on [{key}]");
+                        this.EventDetailTracer?.TraceEventProcessingDetail($"Process on [{key}]");
 
                         // start with processing the event on this object 
-                        await this.applyToStore(key, this).ConfigureAwait(false);
+                        await this.ApplyToStore(key, this).ConfigureAwait(false);
 
                         // recursively process all additional objects to process
                         while (this.Count - 1 > startPos)
@@ -128,7 +138,7 @@ namespace DurableTask.Netherite
 
                     if (this.deletedKeys.Count > 0)
                     {
-                        await this.removeFromStore(this.deletedKeys);
+                        await this.RemoveFromStore(this.deletedKeys);
                         this.deletedKeys.Clear();
                     }
 
@@ -142,21 +152,21 @@ namespace DurableTask.Netherite
                 {
                     // for robustness, we swallow exceptions inside event processing.
                     // It does not mean they are not serious. We still report them as errors.
-                    this.Partition.ErrorHandler.HandleError(nameof(ProcessUpdate), $"Encountered exception while processing update event {updateEvent}", exception, false, false);
+                    this.HandleError(nameof(ProcessUpdate), $"Encountered exception while processing update event {updateEvent}", exception, false, false);
                 }
                 finally
                 {
-                    double finishedTimestamp = this.Partition.CurrentTimeMs;
-                    this.Partition.EventTraceHelper.TraceEventProcessed(commitLogPosition, updateEvent, EventTraceHelper.EventCategory.UpdateEvent, startedTimestamp, finishedTimestamp, this.IsReplaying);
+                    double finishedTimestamp = this.CurrentTimeMs;
+                    this.EventTraceHelper?.TraceEventProcessed(commitLogPosition, updateEvent, EventTraceHelper.EventCategory.UpdateEvent, startedTimestamp, finishedTimestamp, this.IsReplaying);
                 }
             }
         }
 
         public void ProcessReadResult(PartitionReadEvent readEvent, TrackedObjectKey key, TrackedObject target)
         {
-            (long commitLogPosition, long inputQueuePosition) = this.getPositions();
-            this.Partition.Assert(!this.IsReplaying); // read events are never part of the replay
-            double startedTimestamp = this.Partition.CurrentTimeMs;
+            (long commitLogPosition, long inputQueuePosition) = this.GetPositions();
+            this.Assert(!this.IsReplaying); // read events are never part of the replay
+            double startedTimestamp = this.CurrentTimeMs;
 
             using (EventTraceContext.MakeContext(commitLogPosition, readEvent.EventIdString))
             {
@@ -171,7 +181,7 @@ namespace DurableTask.Netherite
                             InstanceState instanceState = (InstanceState)target;
                             string instanceExecutionId = instanceState?.OrchestrationState?.OrchestrationInstance.ExecutionId;
                             string status = instanceState?.OrchestrationState?.OrchestrationStatus.ToString() ?? "null";
-                            this.Partition.EventTraceHelper.TraceFetchedInstanceStatus(readEvent, key.InstanceId, instanceExecutionId, status, startedTimestamp - readEvent.IssuedTimestamp);
+                            this.EventTraceHelper?.TraceFetchedInstanceStatus(readEvent, key.InstanceId, instanceExecutionId, status, startedTimestamp - readEvent.IssuedTimestamp);
                             break;
 
                         case TrackedObjectKey.TrackedObjectType.History:
@@ -179,7 +189,7 @@ namespace DurableTask.Netherite
                             string historyExecutionId = historyState?.ExecutionId;
                             int eventCount = historyState?.History?.Count ?? 0;
                             int episode = historyState?.Episode ?? 0;
-                            this.Partition.EventTraceHelper.TraceFetchedInstanceHistory(readEvent, key.InstanceId, historyExecutionId, eventCount, episode, startedTimestamp - readEvent.IssuedTimestamp);
+                            this.EventTraceHelper?.TraceFetchedInstanceHistory(readEvent, key.InstanceId, historyExecutionId, eventCount, episode, startedTimestamp - readEvent.IssuedTimestamp);
                             break;
 
                         default:
@@ -188,7 +198,7 @@ namespace DurableTask.Netherite
 
                     if (isReady)
                     {
-                        this.Partition.EventDetailTracer?.TraceEventProcessingStarted(commitLogPosition, readEvent, EventTraceHelper.EventCategory.ReadEvent, false);
+                        this.EventDetailTracer?.TraceEventProcessingStarted(commitLogPosition, readEvent, EventTraceHelper.EventCategory.ReadEvent, false);
                         readEvent.Fire(this.Partition);
                     }
                 }
@@ -200,27 +210,27 @@ namespace DurableTask.Netherite
                 {
                     // for robustness, we swallow exceptions inside event processing.
                     // It does not mean they are not serious. We still report them as errors.
-                    this.Partition.ErrorHandler.HandleError(nameof(ProcessReadResult), $"Encountered exception while processing read event {readEvent}", exception, false, false);
+                    this.HandleError(nameof(ProcessReadResult), $"Encountered exception while processing read event {readEvent}", exception, false, false);
                 }
                 finally
                 {
-                    double finishedTimestamp = this.Partition.CurrentTimeMs;
-                    this.Partition.EventTraceHelper.TraceEventProcessed(commitLogPosition, readEvent, EventTraceHelper.EventCategory.ReadEvent, startedTimestamp, finishedTimestamp, false);
+                    double finishedTimestamp = this.CurrentTimeMs;
+                    this.EventTraceHelper?.TraceEventProcessed(commitLogPosition, readEvent, EventTraceHelper.EventCategory.ReadEvent, startedTimestamp, finishedTimestamp, false);
                 }
             }
         }
         
         public async Task ProcessQueryResultAsync(PartitionQueryEvent queryEvent, IAsyncEnumerable<OrchestrationState> instances)
         {
-            (long commitLogPosition, long inputQueuePosition) = this.getPositions();
-            this.Partition.Assert(!this.IsReplaying); // query events are never part of the replay
-            double startedTimestamp = this.Partition.CurrentTimeMs;
+            (long commitLogPosition, long inputQueuePosition) = this.GetPositions();
+            this.Assert(!this.IsReplaying); // query events are never part of the replay
+            double startedTimestamp = this.CurrentTimeMs;
 
             using (EventTraceContext.MakeContext(commitLogPosition, queryEvent.EventIdString))
             {
                 try
                 {
-                    this.Partition.EventDetailTracer?.TraceEventProcessingStarted(commitLogPosition, queryEvent, EventTraceHelper.EventCategory.QueryEvent, false);
+                    this.EventDetailTracer?.TraceEventProcessingStarted(commitLogPosition, queryEvent, EventTraceHelper.EventCategory.QueryEvent, false);
                     await queryEvent.OnQueryCompleteAsync(instances, this.Partition);
                 }
                 catch (OperationCanceledException)
@@ -231,12 +241,12 @@ namespace DurableTask.Netherite
                 {
                     // for robustness, we swallow exceptions inside event processing.
                     // It does not mean they are not serious. We still report them as errors.
-                    this.Partition.ErrorHandler.HandleError(nameof(ProcessQueryResultAsync), $"Encountered exception while processing query event {queryEvent}", exception, false, false);
+                    this.HandleError(nameof(ProcessQueryResultAsync), $"Encountered exception while processing query event {queryEvent}", exception, false, false);
                 }
                 finally
                 {
-                    double finishedTimestamp = this.Partition.CurrentTimeMs;
-                    this.Partition.EventTraceHelper.TraceEventProcessed(commitLogPosition, queryEvent, EventTraceHelper.EventCategory.QueryEvent, startedTimestamp, finishedTimestamp, false);
+                    double finishedTimestamp = this.CurrentTimeMs;
+                    this.EventTraceHelper?.TraceEventProcessed(commitLogPosition, queryEvent, EventTraceHelper.EventCategory.QueryEvent, startedTimestamp, finishedTimestamp, false);
                 }
             }
         }

--- a/src/DurableTask.Netherite/Abstractions/PartitionState/PartitionEffectTracker.cs
+++ b/src/DurableTask.Netherite/Abstractions/PartitionState/PartitionEffectTracker.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace DurableTask.Netherite
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using DurableTask.Core;
+    using DurableTask.Core.Common;
+
+    /// <summary>
+    /// Is used while applying an effect to a partition state, to carry
+    /// information about the context, and to enumerate the objects on which the effect
+    /// is being processed.
+    /// </summary>
+    abstract class PartitionEffectTracker : EffectTracker
+    {
+        readonly Partition partition;
+
+        public PartitionEffectTracker(Partition partition) 
+        {
+            this.partition = partition;
+            if (partition == null)
+            {
+                throw new ArgumentNullException(nameof(partition));
+            }
+        }
+
+        public override Partition Partition => this.partition;
+
+        public override EventTraceHelper EventTraceHelper
+            => this.Partition.EventTraceHelper;
+
+        public override EventTraceHelper EventDetailTracer
+            => this.Partition.EventDetailTracer;
+
+        protected override void HandleError(string where, string message, Exception e, bool terminatePartition, bool reportAsWarning)
+            => this.Partition.ErrorHandler.HandleError(where, message, e, terminatePartition, reportAsWarning);
+
+        public override void Assert(bool condition)
+            => this.Partition.Assert(condition);
+
+        public override uint PartitionId
+            => this.Partition.PartitionId;
+
+        public override double CurrentTimeMs
+            => this.Partition.CurrentTimeMs;
+    }
+}

--- a/src/DurableTask.Netherite/Abstractions/PartitionState/TrackedObject.cs
+++ b/src/DurableTask.Netherite/Abstractions/PartitionState/TrackedObject.cs
@@ -68,7 +68,7 @@ namespace DurableTask.Netherite
         /// Is automatically called on all singleton objects after recovery. Typically used to
         /// restart pending activities, timers, tasks and the like.
         /// </summary>
-        public virtual void OnRecoveryCompleted()
+        public virtual void OnRecoveryCompleted(EffectTracker effects)
         {
         }
 

--- a/src/DurableTask.Netherite/Events/PartitionEvents/External/FromClients/CreationRequestReceived.cs
+++ b/src/DurableTask.Netherite/Events/PartitionEvents/External/FromClients/CreationRequestReceived.cs
@@ -16,9 +16,6 @@ namespace DurableTask.Netherite
         public OrchestrationStatus[] DedupeStatuses { get; set; }
 
         [DataMember]
-        public DateTime CreationTimestamp { get; set; }
-
-        [DataMember]
         public TaskMessage TaskMessage { get; set; }
         
         [DataMember]
@@ -42,9 +39,12 @@ namespace DurableTask.Netherite
         [IgnoreDataMember]
         public CreationResponseReceived ResponseToSend { get; set; } // used to communicate response to ClientState
 
+        [IgnoreDataMember]
+        public DateTime CreationTimestamp { get; set; }
+
         public override bool OnReadComplete(TrackedObject target, Partition partition)
         {
-            // Use this moment of time as the creation timestamp, replacing the original timestamp taken on the client.
+            // Use this moment of time as the creation timestamp, which is going to replace the original timestamp taken on the client.
             // This is preferrable because it avoids clock synchronization issues (which can result in negative orchestration durations)
             // and means the timestamp is consistently ordered with respect to timestamps of other events on this partition.
             this.CreationTimestamp = DateTime.UtcNow;

--- a/src/DurableTask.Netherite/Events/PartitionEvents/External/FromClients/WaitRequestReceived.cs
+++ b/src/DurableTask.Netherite/Events/PartitionEvents/External/FromClients/WaitRequestReceived.cs
@@ -40,11 +40,11 @@ namespace DurableTask.Netherite
             s.Append(this.InstanceId);
         }
 
-        public static bool SatisfiesWaitCondition(OrchestrationState value)
-             => (value != null &&
-                 value.OrchestrationStatus != OrchestrationStatus.Running &&
-                 value.OrchestrationStatus != OrchestrationStatus.Pending &&
-                 value.OrchestrationStatus != OrchestrationStatus.ContinuedAsNew);
+        public static bool SatisfiesWaitCondition(OrchestrationStatus? value)
+             => (value.HasValue &&
+                 value.Value != OrchestrationStatus.Running &&
+                 value.Value != OrchestrationStatus.Pending &&
+                 value.Value != OrchestrationStatus.ContinuedAsNew);
 
         public WaitResponseReceived CreateResponse(OrchestrationState value)
             => new WaitResponseReceived()

--- a/src/DurableTask.Netherite/Events/PartitionEvents/Internal/BatchProcessed.cs
+++ b/src/DurableTask.Netherite/Events/PartitionEvents/Internal/BatchProcessed.cs
@@ -43,9 +43,6 @@ namespace DurableTask.Netherite
         [DataMember]
         public OrchestrationStatus OrchestrationStatus { get; set; }
 
-        [IgnoreDataMember]
-        public OrchestrationState State { get; set; }
-
         [DataMember]
         public List<TaskMessage> ActivityMessages { get; set; }
 

--- a/src/DurableTask.Netherite/Events/PartitionEvents/PartitionEvent.cs
+++ b/src/DurableTask.Netherite/Events/PartitionEvents/PartitionEvent.cs
@@ -40,7 +40,7 @@ namespace DurableTask.Netherite
         public virtual void OnSubmit(Partition partition) { }
 
         // make a copy of an event so we run it through the pipeline a second time
-        public PartitionEvent Clone()
+        public virtual PartitionEvent Clone()
         {
             var evt = (PartitionEvent)this.MemberwiseClone();
 

--- a/src/DurableTask.Netherite/OrchestrationService/Client.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/Client.cs
@@ -324,7 +324,6 @@ namespace DurableTask.Netherite
                 RequestId = Interlocked.Increment(ref this.SequenceNumber),
                 TaskMessage = creationMessage,
                 DedupeStatuses = dedupeStatuses,
-                Timestamp = DateTime.UtcNow,
                 TimeoutUtc = this.GetTimeoutBucket(DefaultTimeout),
             };
 

--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
@@ -728,7 +728,6 @@ namespace DurableTask.Netherite
                 PersistFirst = partition.Settings.PersistStepsFirst ? BatchProcessed.PersistFirstStatus.Required : BatchProcessed.PersistFirstStatus.NotRequired,
                 OrchestrationStatus = state.OrchestrationStatus,
                 ExecutionId = state.OrchestrationInstance.ExecutionId,
-                State = state,
                 ActivityMessages = (List<TaskMessage>)activityMessages,
                 LocalMessages = localMessages,
                 RemoteMessages = remoteMessages,

--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
@@ -751,7 +751,7 @@ namespace DurableTask.Netherite
                 latencyMs,
                 sequenceNumber);
 
-             partition.SubmitEvent(batchProcessedEvent);
+            partition.SubmitEvent(batchProcessedEvent);
 
             if (this.workItemTraceHelper.TraceTaskMessages)
             {

--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
@@ -722,7 +722,7 @@ namespace DurableTask.Netherite
                 InstanceId = workItem.InstanceId,
                 BatchStartPosition = messageBatch.BatchStartPosition,
                 BatchLength = messageBatch.BatchLength,
-                NewEvents = (List<HistoryEvent>)newOrchestrationRuntimeState.NewEvents,
+                NewEvents = newOrchestrationRuntimeState.NewEvents.ToList(), // must make a copy of the list
                 WorkItemForReuse = cacheWorkItemForReuse ? orchestrationWorkItem : null,
                 PackPartitionTaskMessages = partition.Settings.PackPartitionTaskMessages,
                 PersistFirst = partition.Settings.PersistStepsFirst ? BatchProcessed.PersistFirstStatus.Required : BatchProcessed.PersistFirstStatus.NotRequired,

--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
@@ -722,7 +722,7 @@ namespace DurableTask.Netherite
                 InstanceId = workItem.InstanceId,
                 BatchStartPosition = messageBatch.BatchStartPosition,
                 BatchLength = messageBatch.BatchLength,
-                NewEvents = newOrchestrationRuntimeState.NewEvents.ToList(), // must make a copy of the list
+                NewEvents = (List<HistoryEvent>)newOrchestrationRuntimeState.NewEvents,
                 WorkItemForReuse = cacheWorkItemForReuse ? orchestrationWorkItem : null,
                 PackPartitionTaskMessages = partition.Settings.PackPartitionTaskMessages,
                 PersistFirst = partition.Settings.PersistStepsFirst ? BatchProcessed.PersistFirstStatus.Required : BatchProcessed.PersistFirstStatus.NotRequired,

--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationServiceSettings.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationServiceSettings.cs
@@ -181,10 +181,10 @@ namespace DurableTask.Netherite
         internal bool UseSeparatePageBlobStorage => !string.IsNullOrEmpty(this.ResolvedPageBlobStorageConnectionString);
 
         /// <summary>
-        /// Whether to attach a debugger for cache transitions. Used only for testing and debugging.
+        /// Allows attaching additional checkers and debuggers during testing.
         /// </summary>
         [JsonIgnore]
-        public Faster.CacheDebugger CacheDebugger { get; set; } = null;
+        public TestHooks TestHooks { get; set; } = null;
 
         /// <summary>
         /// A lower limit on the severity level of trace events emitted by the transport layer.

--- a/src/DurableTask.Netherite/OrchestrationService/Partition.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/Partition.cs
@@ -83,7 +83,7 @@ namespace DurableTask.Netherite
             this.WorkItemTraceHelper = workItemTraceHelper;
             this.stopwatch.Start();
             this.LastTransition = this.CurrentTimeMs;
-            this.CacheDebugger = this.Settings.CacheDebugger;
+            this.CacheDebugger = this.Settings.TestHooks?.CacheDebugger;
         }
 
         public async Task<long> CreateOrRestoreAsync(IPartitionErrorHandler errorHandler, long firstInputQueuePosition)

--- a/src/DurableTask.Netherite/OrchestrationService/TestHooks.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/TestHooks.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace DurableTask.Netherite
+{
+    using System;
+
+    /// <summary>
+    /// Hooks for attaching additional checkers and debuggers during testing.
+    /// </summary>
+    public class TestHooks
+    {
+        internal Faster.CacheDebugger CacheDebugger { get; set; } = null;
+
+        internal Faster.ReplayChecker ReplayChecker { get; set; } = null;
+
+        internal event Action<string> OnError;
+
+        internal void Error(string source, string message)
+        {
+            if (System.Diagnostics.Debugger.IsAttached)
+            {
+                System.Diagnostics.Debugger.Break();
+            }
+            this.OnError($"TestHook-{source} !!! {message}");
+        }
+    }
+}

--- a/src/DurableTask.Netherite/PartitionState/ActivitiesState.cs
+++ b/src/DurableTask.Netherite/PartitionState/ActivitiesState.cs
@@ -59,7 +59,7 @@ namespace DurableTask.Netherite
 
         const double SMOOTHING_FACTOR = 0.1;
 
-        public override void OnRecoveryCompleted()
+        public override void OnRecoveryCompleted(EffectTracker effects)
         {
             // reschedule work items
             foreach (var pending in this.Pending)
@@ -251,7 +251,7 @@ namespace DurableTask.Netherite
             this.AverageActivityCompletionTime = !this.AverageActivityCompletionTime.HasValue ? evt.LatencyMs :
                 SMOOTHING_FACTOR * evt.LatencyMs + (1 - SMOOTHING_FACTOR) * this.AverageActivityCompletionTime.Value;
 
-            if (evt.OriginPartitionId == effects.Partition.PartitionId)
+            if (evt.OriginPartitionId == effects.PartitionId)
             {
                 // the response can be delivered to a session on this partition
                 effects.Add(TrackedObjectKey.Sessions);
@@ -305,7 +305,7 @@ namespace DurableTask.Netherite
                 this.TransferCommandsReceived[evt.PartitionId] = evt.Timestamp;
             }
 
-            this.Partition.EventTraceHelper.TraceEventProcessingDetail($"Processed OffloadCommand, " +
+            effects.EventTraceHelper?.TraceEventProcessingDetail($"Processed OffloadCommand, " +
                 $"OffloadDestination={evt.TransferDestination}, NumActivitiesSent={evt.TransferredActivities.Count}");
             effects.Add(TrackedObjectKey.Outbox);
         }
@@ -362,7 +362,7 @@ namespace DurableTask.Netherite
 
             if (!effects.IsReplaying)
             {
-                this.Partition.EventTraceHelper.TracePartitionOffloadDecision(this.EstimatedWorkItemQueueSize, this.Pending.Count, this.LocalBacklog.Count, -1, offloadDecisionEvent);
+                effects.EventTraceHelper?.TracePartitionOffloadDecision(this.EstimatedWorkItemQueueSize, this.Pending.Count, this.LocalBacklog.Count, -1, offloadDecisionEvent);
 
                 if (this.LocalBacklog.Count > 0)
                 {

--- a/src/DurableTask.Netherite/PartitionState/HistoryState.cs
+++ b/src/DurableTask.Netherite/PartitionState/HistoryState.cs
@@ -73,7 +73,7 @@ namespace DurableTask.Netherite
 
             if (!effects.IsReplaying)
             {
-                this.Partition.EventTraceHelper.TraceInstanceUpdate(
+                effects.EventTraceHelper?.TraceInstanceUpdate(
                     evt.EventIdString,
                     evt.InstanceId,
                     evt.ExecutionId,
@@ -88,7 +88,7 @@ namespace DurableTask.Netherite
                 if (this.CachedOrchestrationWorkItem != null 
                     && this.CachedOrchestrationWorkItem.OrchestrationRuntimeState?.OrchestrationInstance?.ExecutionId != evt.ExecutionId)
                 {
-                    effects.Partition.EventTraceHelper.TraceEventProcessingWarning($"Dropping bad workitem cache instance={this.InstanceId} expected_executionid={evt.ExecutionId} actual_executionid={this.CachedOrchestrationWorkItem.OrchestrationRuntimeState?.OrchestrationInstance?.ExecutionId}");
+                    effects.EventTraceHelper?.TraceEventProcessingWarning($"Dropping bad workitem cache instance={this.InstanceId} expected_executionid={evt.ExecutionId} actual_executionid={this.CachedOrchestrationWorkItem.OrchestrationRuntimeState?.OrchestrationInstance?.ExecutionId}");
                     this.CachedOrchestrationWorkItem = null;
                 }
             }

--- a/src/DurableTask.Netherite/PartitionState/InstanceState.cs
+++ b/src/DurableTask.Netherite/PartitionState/InstanceState.cs
@@ -102,47 +102,11 @@ namespace DurableTask.Netherite
             }
 
             this.OrchestrationState.LastUpdatedTime = evt.Timestamp;
-
-            if (evt.State != null)
-            {
-                this.Partition.Assert(
-                (
-                    evt.State.Version,
-                    evt.State.Status,
-                    evt.State.Output,
-                    evt.State.Name,
-                    evt.State.Input,
-                    evt.State.OrchestrationInstance.InstanceId,
-                    evt.State.OrchestrationInstance.ExecutionId,
-                    evt.State.CompletedTime,
-                    evt.State.OrchestrationStatus,
-                    evt.State.LastUpdatedTime,
-                    evt.State.CreatedTime,
-                    evt.State.ScheduledStartTime,
-                    evt.State.OrchestrationInstance.ExecutionId
-                )
-                ==
-                (
-                    this.OrchestrationState.Version,
-                    this.OrchestrationState.Status,
-                    this.OrchestrationState.Output,
-                    this.OrchestrationState.Name,
-                    this.OrchestrationState.Input,
-                    this.OrchestrationState.OrchestrationInstance.InstanceId,
-                    this.OrchestrationState.OrchestrationInstance.ExecutionId,
-                    this.OrchestrationState.CompletedTime,
-                    this.OrchestrationState.OrchestrationStatus,
-                    this.OrchestrationState.LastUpdatedTime,
-                    this.OrchestrationState.CreatedTime,
-                    this.OrchestrationState.ScheduledStartTime,
-                    evt.ExecutionId
-                ));
-            }
             
             // if the orchestration is complete, notify clients that are waiting for it
             if (this.Waiters != null)
             {
-                if (WaitRequestReceived.SatisfiesWaitCondition(this.OrchestrationState))
+                if (WaitRequestReceived.SatisfiesWaitCondition(this.OrchestrationState?.OrchestrationStatus))
                 {
                     // we do not need effects.Add(TrackedObjectKey.Outbox) because it has already been added by SessionsState
                     evt.ResponsesToSend = this.Waiters.Select(request => request.CreateResponse(this.OrchestrationState)).ToList();
@@ -190,7 +154,7 @@ namespace DurableTask.Netherite
 
         public override void Process(WaitRequestReceived evt, EffectTracker effects)
         {
-            if (WaitRequestReceived.SatisfiesWaitCondition(this.OrchestrationState))
+            if (WaitRequestReceived.SatisfiesWaitCondition(this.OrchestrationState?.OrchestrationStatus))
             {
                 effects.Add(TrackedObjectKey.Outbox);
                 evt.ResponseToSend =  evt.CreateResponse(this.OrchestrationState);              

--- a/src/DurableTask.Netherite/PartitionState/OutboxState.cs
+++ b/src/DurableTask.Netherite/PartitionState/OutboxState.cs
@@ -25,7 +25,7 @@ namespace DurableTask.Netherite
 
         public override TrackedObjectKey Key => new TrackedObjectKey(TrackedObjectKey.TrackedObjectType.Outbox);
 
-        public override void OnRecoveryCompleted()
+        public override void OnRecoveryCompleted(EffectTracker effects)
         {
             // resend all pending
             foreach (var kvp in this.Outbox)
@@ -35,7 +35,7 @@ namespace DurableTask.Netherite
                 kvp.Value.Partition = this.Partition;
 
                 // resend (anything we have recovered is of course persisted)
-                this.Partition.EventDetailTracer?.TraceEventProcessingDetail($"Resent {kvp.Key:D10} ({kvp.Value} messages)");
+                effects.EventDetailTracer?.TraceEventProcessingDetail($"Resent {kvp.Key:D10} ({kvp.Value} messages)");
                 this.Send(kvp.Value);
             }
         }
@@ -153,9 +153,9 @@ namespace DurableTask.Netherite
             }
         }
 
-        public override void Process(SendConfirmed evt, EffectTracker _)
+        public override void Process(SendConfirmed evt, EffectTracker effects)
         {
-            this.Partition.EventDetailTracer?.TraceEventProcessingDetail($"Store has sent all outbound messages by event {evt} id={evt.EventIdString}");
+            effects.EventDetailTracer?.TraceEventProcessingDetail($"Store has sent all outbound messages by event {evt} id={evt.EventIdString}");
 
             // we no longer need to keep these events around
             this.Outbox.Remove(evt.Position);

--- a/src/DurableTask.Netherite/PartitionState/OutboxState.cs
+++ b/src/DurableTask.Netherite/PartitionState/OutboxState.cs
@@ -59,6 +59,12 @@ namespace DurableTask.Netherite
             batch.Position = commitPosition;
             batch.Partition = this.Partition;
 
+            foreach (var partitionMessageEvent in batch.OutgoingMessages)
+            {
+                partitionMessageEvent.OriginPartition = this.Partition.PartitionId;
+                partitionMessageEvent.OriginPosition = commitPosition;
+            }
+
             if (!effects.IsReplaying)
             {
                 if (evt is BatchProcessed batchProcessedEvt 
@@ -90,8 +96,6 @@ namespace DurableTask.Netherite
             foreach (var outmessage in batch.OutgoingMessages)
             {
                 DurabilityListeners.Register(outmessage, batch);
-                outmessage.OriginPartition = this.Partition.PartitionId;
-                outmessage.OriginPosition = batch.Position;
                 this.Partition.Send(outmessage);
             }
             foreach (var outresponse in batch.OutgoingResponses)

--- a/src/DurableTask.Netherite/PartitionState/PrefetchState.cs
+++ b/src/DurableTask.Netherite/PartitionState/PrefetchState.cs
@@ -22,7 +22,7 @@ namespace DurableTask.Netherite
         [IgnoreDataMember]
         public override TrackedObjectKey Key => new TrackedObjectKey(TrackedObjectKey.TrackedObjectType.Prefetch);
 
-        public override void OnRecoveryCompleted()
+        public override void OnRecoveryCompleted(EffectTracker effects)
         {
             // reissue prefetch tasks for what did not complete prior to crash/recovery
             foreach (var kvp in this.PendingPrefetches)

--- a/src/DurableTask.Netherite/PartitionState/QueriesState.cs
+++ b/src/DurableTask.Netherite/PartitionState/QueriesState.cs
@@ -22,7 +22,7 @@ namespace DurableTask.Netherite
         [IgnoreDataMember]
         public override TrackedObjectKey Key => new TrackedObjectKey(TrackedObjectKey.TrackedObjectType.Queries);
 
-        public override void OnRecoveryCompleted()
+        public override void OnRecoveryCompleted(EffectTracker effects)
         {
             // reissue queries that did not complete prior to crash/recovery
             foreach (var kvp in this.PendingQueries)

--- a/src/DurableTask.Netherite/PartitionState/ReassemblyState.cs
+++ b/src/DurableTask.Netherite/PartitionState/ReassemblyState.cs
@@ -29,7 +29,7 @@ namespace DurableTask.Netherite
             {
                 evt.ReassembledEvent =  FragmentationAndReassembly.Reassemble<PartitionEvent>(this.Fragments[originalEventString], evt);
                 
-                this.Partition.EventDetailTracer?.TraceEventProcessingDetail($"Reassembled {evt.ReassembledEvent}");
+                effects.EventDetailTracer?.TraceEventProcessingDetail($"Reassembled {evt.ReassembledEvent}");
 
                 this.Fragments.Remove(originalEventString);
 

--- a/src/DurableTask.Netherite/PartitionState/SessionsState.cs
+++ b/src/DurableTask.Netherite/PartitionState/SessionsState.cs
@@ -327,7 +327,7 @@ namespace DurableTask.Netherite
                     effects.Add(TrackedObjectKey.Timers);
                 }
 
-                if (evt.RemoteMessages?.Count > 0 || WaitRequestReceived.SatisfiesWaitCondition(evt.State))
+                if (evt.RemoteMessages?.Count > 0 || WaitRequestReceived.SatisfiesWaitCondition(evt.OrchestrationStatus))
                 {
                     effects.Add(TrackedObjectKey.Outbox);
                 }

--- a/src/DurableTask.Netherite/PartitionState/SessionsState.cs
+++ b/src/DurableTask.Netherite/PartitionState/SessionsState.cs
@@ -49,7 +49,7 @@ namespace DurableTask.Netherite
         public static string GetWorkItemId(uint partition, long session, long position) => $"{partition:D2}S{session}P{position}";
 
 
-        public override void OnRecoveryCompleted()
+        public override void OnRecoveryCompleted(EffectTracker effects)
         {
             // start work items for all sessions
             foreach (var kvp in this.Sessions)
@@ -346,16 +346,16 @@ namespace DurableTask.Netherite
             }
 
             // remove processed messages from this batch
-            effects.Partition.Assert(session != null);
-            effects.Partition.Assert(session.SessionId == evt.SessionId);
-            effects.Partition.Assert(session.BatchStartPosition == evt.BatchStartPosition);
+            effects.Assert(session != null);
+            effects.Assert(session.SessionId == evt.SessionId);
+            effects.Assert(session.BatchStartPosition == evt.BatchStartPosition);
             session.Batch.RemoveRange(0, evt.BatchLength);
             session.BatchStartPosition += evt.BatchLength;
 
             this.StartNewBatchIfNeeded(session, effects, evt.InstanceId, effects.IsReplaying);
         }
 
-        void StartNewBatchIfNeeded(Session session, EffectTracker effects, string instanceId, bool inRecovery)
+        void StartNewBatchIfNeeded(Session session, EffectTracker effects, string instanceId, bool isReplaying)
         {
             if (session.Batch.Count == 0)
             {
@@ -364,7 +364,7 @@ namespace DurableTask.Netherite
             }
             else
             {
-                if (!inRecovery) // we don't start work items until end of recovery
+                if (!isReplaying) // we don't start work items until end of recovery
                 {
                     // there are more messages. Start another work item.
                     new OrchestrationMessageBatch(instanceId, session, this.Partition);

--- a/src/DurableTask.Netherite/PartitionState/TimersState.cs
+++ b/src/DurableTask.Netherite/PartitionState/TimersState.cs
@@ -30,12 +30,12 @@ namespace DurableTask.Netherite
             return $"Timers ({this.PendingTimers.Count} pending) next={this.SequenceNumber:D6}";
         }
 
-        public override void OnRecoveryCompleted()
+        public override void OnRecoveryCompleted(EffectTracker effects)
         {
             // restore the pending timers
             foreach (var kvp in this.PendingTimers)
             {
-                this.Schedule(kvp.Key, kvp.Value.due, kvp.Value.message, kvp.Value.workItemId);
+                this.Schedule(kvp.Key, kvp.Value.due, kvp.Value.message, kvp.Value.workItemId, effects);
             }
         }
 
@@ -53,7 +53,7 @@ namespace DurableTask.Netherite
             }
         }
 
-        void Schedule(long timerId, DateTime due, TaskMessage message, string originWorkItemId)
+        void Schedule(long timerId, DateTime due, TaskMessage message, string originWorkItemId, EffectTracker effects)
         {
             TimerFired expirationEvent = new TimerFired()
             {
@@ -64,20 +64,20 @@ namespace DurableTask.Netherite
                 Due = due,
             };
 
-            this.Partition.EventDetailTracer?.TraceEventProcessingDetail($"Scheduled {message} due at {expirationEvent.Due:o}, id={expirationEvent.EventIdString}");
+            effects.EventDetailTracer?.TraceEventProcessingDetail($"Scheduled {message} due at {expirationEvent.Due:o}, id={expirationEvent.EventIdString}");
             this.Partition.PendingTimers.Schedule(expirationEvent.Due, expirationEvent);
         }
 
-        void AddTimer(TaskMessage taskMessage, string originWorkItemId, bool isReplaying)
+        void AddTimer(TaskMessage taskMessage, string originWorkItemId, EffectTracker effects)
         {
             var timerId = this.SequenceNumber++;
             var due = GetDueTime(taskMessage);
             this.PendingTimers.Add(timerId, (due, taskMessage, originWorkItemId));
 
-            if (!isReplaying)
+            if (!effects.IsReplaying)
             {
                 this.Partition.WorkItemTraceHelper.TraceTaskMessageReceived(this.Partition.PartitionId, taskMessage, originWorkItemId, $"Timer@{due}");
-                this.Schedule(timerId, due, taskMessage, originWorkItemId);
+                this.Schedule(timerId, due, taskMessage, originWorkItemId, effects);
             }
         }
 
@@ -112,7 +112,7 @@ namespace DurableTask.Netherite
             // starts new timers as specified by the batch
             foreach (var taskMessage in evt.TimerMessages)
             {
-                this.AddTimer(taskMessage, evt.EventIdString, effects.IsReplaying);
+                this.AddTimer(taskMessage, evt.EventIdString, effects);
             }
         }
 
@@ -121,13 +121,13 @@ namespace DurableTask.Netherite
             // starts new timers as specified by the batch
             foreach (var taskMessage in evt.DelayedTaskMessages)
             {
-                this.AddTimer(taskMessage, evt.WorkItemId, effects.IsReplaying);
+                this.AddTimer(taskMessage, evt.WorkItemId, effects);
             }
         }
 
         public override void Process(CreationRequestReceived creationRequestReceived, EffectTracker effects)
         {
-            this.AddTimer(creationRequestReceived.TaskMessage, creationRequestReceived.EventIdString, effects.IsReplaying);
+            this.AddTimer(creationRequestReceived.TaskMessage, creationRequestReceived.EventIdString, effects);
         }
     }
 }

--- a/src/DurableTask.Netherite/StorageProviders/Faster/FasterAlt.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/FasterAlt.cs
@@ -373,6 +373,13 @@ namespace DurableTask.Netherite.Faster
             throw new NotImplementedException();
         }
 
+        public override void EmitCurrentState(Action<TrackedObjectKey, TrackedObject> emitItem)
+        {
+            // TODO
+            throw new NotImplementedException();
+        }
+
+
         #region storage access operation
 
         CloudBlockBlob GetBlob(TrackedObjectKey key)

--- a/src/DurableTask.Netherite/StorageProviders/Faster/ReplayChecker.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/ReplayChecker.cs
@@ -1,0 +1,209 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace DurableTask.Netherite.Faster
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using FASTER.core;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Validates the replay, by maintaining an ongoing checkpoint and confirming the commutative diagram
+    /// serialize(new-state) = serialize(deserialize(old-state) + event)
+    /// This class is only used for testing and debugging, as it creates lots of overhead.
+    /// </summary>
+    class ReplayChecker
+    {
+        readonly ConcurrentDictionary<Partition, Info> partitionInfo;
+        readonly TestHooks testHooks;
+
+        public ReplayChecker(TestHooks testHooks)
+        {
+            this.testHooks = testHooks;
+            this.partitionInfo = new ConcurrentDictionary<Partition, Info>();
+        }
+
+        class Info
+        {
+            public Partition Partition;
+            public Dictionary<TrackedObjectKey, string> Store;
+            public long CommitLogPosition;
+            public long InputQueuePosition;
+            public EffectTracker EffectTracker;
+        }
+
+        readonly JsonSerializerSettings settings = new JsonSerializerSettings()
+        {
+            TypeNameHandling = TypeNameHandling.Auto,
+        };
+
+        string Serialize(TrackedObject trackedObject)
+        { 
+            string serialized =  trackedObject == null ? "null" : JsonConvert.SerializeObject(trackedObject, typeof(TrackedObject), Formatting.Indented, this.settings);
+            if (trackedObject is SessionsState)
+            {
+                serialized = serialized.Replace("\"IsPlayed\": true", "\"IsPlayed\": false");
+            }
+            else if (trackedObject is HistoryState)
+            {
+                serialized = serialized.Replace("\"IsPlayed\": false", "\"IsPlayed\": true");
+            }
+            return serialized;
+        }
+
+        TrackedObject DeserializeTrackedObject(string content, TrackedObjectKey key)
+            => (content != null) ? (TrackedObject) JsonConvert.DeserializeObject(content, this.settings) : TrackedObjectKey.Factory(key);
+
+        string Serialize(PartitionUpdateEvent partitionUpdateEvent)
+            => JsonConvert.SerializeObject(partitionUpdateEvent, typeof(PartitionUpdateEvent), Formatting.Indented, this.settings);
+
+        PartitionUpdateEvent DeserializePartitionUpdateEvent(string content)
+            => (PartitionUpdateEvent) JsonConvert.DeserializeObject(content, this.settings);
+
+        public void PartitionStarting(Partition partition, TrackedObjectStore store, long CommitLogPosition, long InputQueuePosition)
+        {
+            var info = new Info()
+            {
+                Partition = partition,
+                Store = new Dictionary<TrackedObjectKey, string>(),
+                CommitLogPosition = CommitLogPosition,
+                InputQueuePosition = InputQueuePosition,
+            };
+
+            this.partitionInfo[partition] = info;
+
+            store.EmitCurrentState((TrackedObjectKey key, TrackedObject value) =>
+            {
+                info.Store.Add(key, this.Serialize(value));
+            });
+
+            info.EffectTracker = new ReplayCheckEffectTracker(this, info);
+        }
+
+        public async Task CheckUpdate(Partition partition, PartitionUpdateEvent partitionUpdateEvent, TrackedObjectStore store)
+        {
+            var info = this.partitionInfo[partition];
+
+            System.Diagnostics.Trace.WriteLine($"REPLAYCHECK STARTED {partitionUpdateEvent}");
+
+            var eventForReplay = this.DeserializePartitionUpdateEvent(this.Serialize(partitionUpdateEvent));
+            eventForReplay.NextCommitLogPosition = partitionUpdateEvent.NextCommitLogPosition;
+            await info.EffectTracker.ProcessUpdate(eventForReplay);
+
+            // check that the two match, generate error message and fix difference otherwise
+
+            HashSet<TrackedObjectKey> NotVisited = new HashSet<TrackedObjectKey>(info.Store.Keys);
+
+            store.EmitCurrentState((TrackedObjectKey key, TrackedObject value) =>
+            {
+                NotVisited.Remove(key);
+                string expected = this.Serialize(value);
+
+                if (!info.Store.TryGetValue(key, out var replayed))
+                {
+                    this.testHooks.Error(this.GetType().Name, $"key={key}\nexpected={expected}\nreplayed=absent");
+                    info.Store[key] = expected;
+                }
+                if (expected != replayed)   
+                {
+                    var expectedlines = TraceUtils.GetLines(expected).ToArray();
+                    var replayedlines = TraceUtils.GetLines(replayed).ToArray();
+                    string expectedline = "";
+                    string replayedline = "";
+                    int i = 0;
+                    for (; i < Math.Max(expectedlines.Length, replayedlines.Length); i++)
+                    {
+                        expectedline = i < expectedlines.Length ? expectedlines[i] : "absent";
+                        replayedline = i < replayedlines.Length ? replayedlines[i] : "absent";
+                        if (expectedline != replayedline)
+                        {
+                            break;
+                        }
+                    }
+                    this.testHooks.Error(this.GetType().Name, $"key={key} line={i}\nexpectedline={expectedline}\nreplayedline={replayedline}\nexpected={expected}\nreplayed={replayed} ");
+                    info.Store[key] = expected;
+                }
+            });
+
+            foreach(var key in NotVisited)
+            {
+                string val = info.Store[key];
+                this.testHooks.Error(this.GetType().Name, $"key={key}\nexpected=absent\nreplayed={val}");
+                info.Store.Remove(key);
+            }
+
+            System.Diagnostics.Trace.WriteLine("REPLAYCHECK DONE");
+        }
+
+        public void PartitionStopped(Partition partition)
+        {
+            this.partitionInfo.TryRemove(partition, out _);
+        }
+
+        class ReplayCheckEffectTracker : EffectTracker
+        {
+            readonly ReplayChecker replayChecker;
+            readonly ReplayChecker.Info info;
+
+            public ReplayCheckEffectTracker(ReplayChecker replayChecker, ReplayChecker.Info info)
+            {
+                this.replayChecker = replayChecker;
+                this.info = info;
+                this.IsReplaying = true;
+            }
+
+            public override Partition Partition => this.info.Partition;
+
+            public override EventTraceHelper EventTraceHelper => null;
+
+            public override EventTraceHelper EventDetailTracer => null;
+
+            public override uint PartitionId => this.info.Partition.PartitionId;
+
+            public override double CurrentTimeMs => 0;
+ 
+            public override ValueTask ApplyToStore(TrackedObjectKey key, EffectTracker tracker)
+            {
+                this.info.Store.TryGetValue(key, out string content);
+                var trackedObject = this.replayChecker.DeserializeTrackedObject(content, key);
+                trackedObject.Partition = this.Partition;
+                tracker.ProcessEffectOn(trackedObject);
+                content = this.replayChecker.Serialize(trackedObject);
+                this.info.Store[key] = content;
+                return default;
+            }
+
+            public override ValueTask RemoveFromStore(IEnumerable<TrackedObjectKey> keys)
+            {
+                foreach (var key in keys)
+                {
+                    this.info.Store.Remove(key);
+                }
+                return default;
+            }
+
+            public override (long, long) GetPositions()
+            {
+                return (this.info.CommitLogPosition, this.info.InputQueuePosition);
+            }
+
+            public override void Assert(bool condition)
+            {
+                if (!condition)
+                {
+                    this.replayChecker.testHooks.Error(this.replayChecker.GetType().Name, "assertion failed");
+                }
+            }
+
+            protected override void HandleError(string where, string message, Exception e, bool terminatePartition, bool reportAsWarning)
+            {
+                this.replayChecker.testHooks.Error(this.replayChecker.GetType().Name, $"{where}: {message} {e}");
+            }       
+        }
+    }
+}

--- a/src/DurableTask.Netherite/StorageProviders/Faster/StoreWorker.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/StoreWorker.cs
@@ -16,6 +16,7 @@ namespace DurableTask.Netherite.Faster
         readonly FasterTraceHelper traceHelper;
         readonly BlobManager blobManager;
         readonly Random random;
+        readonly ReplayChecker replayChecker;
 
         readonly EffectTracker effectTracker;
 
@@ -43,7 +44,7 @@ namespace DurableTask.Netherite.Faster
         public static TimeSpan PokePeriod = TimeSpan.FromSeconds(3); // allows storeworker to checkpoint and publish load even while idle
 
 
-        public StoreWorker(TrackedObjectStore store, Partition partition, FasterTraceHelper traceHelper, BlobManager blobManager, CancellationToken cancellationToken) 
+        public StoreWorker(TrackedObjectStore store, Partition partition, FasterTraceHelper traceHelper, BlobManager blobManager, CancellationToken cancellationToken)
             : base($"{nameof(StoreWorker)}{partition.PartitionId:D2}", true, 500, cancellationToken, partition.TraceHelper)
         {
             partition.ErrorHandler.Token.ThrowIfCancellationRequested();
@@ -53,18 +54,14 @@ namespace DurableTask.Netherite.Faster
             this.traceHelper = traceHelper;
             this.blobManager = blobManager;
             this.random = new Random();
+            this.replayChecker = this.partition.Settings.TestHooks?.ReplayChecker;
 
             this.loadInfo = PartitionLoadInfo.FirstFrame(this.partition.Settings.WorkerId);
             this.lastPublished = DateTime.MinValue;
             this.lastPublishedLatencyTrend = "";
 
             // construct an effect tracker that we use to apply effects to the store
-            this.effectTracker = new EffectTracker(
-                this.partition,
-                (key, tracker) => store.ProcessEffectOnTrackedObject(key, tracker),
-                (keys) => store.RemoveKeys(keys),
-                () => (this.CommitLogPosition, this.InputQueuePosition)
-            );
+            this.effectTracker = new TrackedObjectStoreEffectTracker(this.partition, this, store);
         }
 
         public async Task Initialize(long initialCommitLogPosition, long initialInputQueuePosition)
@@ -85,6 +82,8 @@ namespace DurableTask.Netherite.Faster
             this.lastCheckpointedCommitLogPosition = this.CommitLogPosition;
             this.lastCheckpointedInputQueuePosition = this.InputQueuePosition;
             this.numberEventsSinceLastCheckpoint = initialCommitLogPosition;
+
+            this.replayChecker?.PartitionStarting(this.partition, this.store, this.CommitLogPosition, this.InputQueuePosition);
         }
 
         public void StartProcessing()
@@ -148,6 +147,8 @@ namespace DurableTask.Netherite.Faster
             {
                 await this.pendingStoreCheckpoint.ConfigureAwait(false);
             }
+
+            this.replayChecker?.PartitionStopped(this.partition);
 
             this.traceHelper.FasterProgress("Stopped StoreWorker");
         }
@@ -443,12 +444,14 @@ namespace DurableTask.Netherite.Faster
         {
             this.traceHelper.FasterProgress("Restarting tasks");
 
+            this.replayChecker?.PartitionStarting(this.partition, this.store, this.CommitLogPosition, this.InputQueuePosition);
+
             using (EventTraceContext.MakeContext(this.CommitLogPosition, string.Empty))
             {
                 foreach (var key in TrackedObjectKey.GetSingletons())
                 {
                     var target = (TrackedObject)await this.store.ReadAsync(key, this.effectTracker).ConfigureAwait(false);
-                    target.OnRecoveryCompleted();
+                    target.OnRecoveryCompleted(this.effectTracker);
                 }
             }
         }
@@ -485,6 +488,11 @@ namespace DurableTask.Netherite.Faster
             }
 
             await this.effectTracker.ProcessUpdate(partitionUpdateEvent).ConfigureAwait(false);
+
+            if (this.replayChecker != null)
+            {
+                await this.replayChecker.CheckUpdate(this.partition, partitionUpdateEvent, this.store);
+            }
 
             // update the commit log position
             if (partitionUpdateEvent.NextCommitLogPosition > 0)

--- a/src/DurableTask.Netherite/StorageProviders/Faster/TrackedObjectStore.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/TrackedObjectStore.cs
@@ -50,6 +50,8 @@ namespace DurableTask.Netherite.Faster
 
         public abstract ValueTask RemoveKeys(IEnumerable<TrackedObjectKey> keys);
 
+        public abstract void EmitCurrentState(Action<TrackedObjectKey, TrackedObject> emitItem);     
+
         public StoreStatistics StoreStats { get; } = new StoreStatistics();
 
         public class StoreStatistics

--- a/src/DurableTask.Netherite/StorageProviders/Faster/TrackedObjectStoreEffectTracker.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/TrackedObjectStoreEffectTracker.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace DurableTask.Netherite.Faster
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+
+    class TrackedObjectStoreEffectTracker : PartitionEffectTracker
+    {
+        readonly TrackedObjectStore store;
+        readonly StoreWorker storeWorker;
+
+        public TrackedObjectStoreEffectTracker(Partition partition, StoreWorker storeWorker, TrackedObjectStore store)
+            : base(partition)
+        {
+            this.store = store;
+            this.storeWorker = storeWorker;
+        }
+
+        public override ValueTask ApplyToStore(TrackedObjectKey key, EffectTracker tracker)
+        {
+            this.store.ProcessEffectOnTrackedObject(key, tracker);
+            return default;
+        }
+
+        public override (long, long) GetPositions()
+        {
+            return (this.storeWorker.CommitLogPosition, this.storeWorker.InputQueuePosition);
+        }
+
+        public override ValueTask RemoveFromStore(IEnumerable<TrackedObjectKey> keys)
+        {
+            this.store.RemoveKeys(keys);
+            return default;
+        }
+    }
+}

--- a/src/DurableTask.Netherite/StorageProviders/Memory/MemoryStorage.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Memory/MemoryStorage.cs
@@ -16,6 +16,7 @@ namespace DurableTask.Netherite
     {
         readonly ILogger logger;
         Partition partition;
+        EffectTracker effects;
         long nextSubmitPosition = 0;
         long commitPosition = 0;
         long inputQueuePosition = 0;
@@ -65,6 +66,7 @@ namespace DurableTask.Netherite
         public Task<long> CreateOrRestoreAsync(Partition partition, IPartitionErrorHandler termination, long initialInputQueuePosition)
         {
             this.partition = partition;
+            this.effects = new MemoryStorageEffectTracker(partition, this);
 
             foreach (var trackedObject in this.trackedObjects.Values)
             {
@@ -114,14 +116,7 @@ namespace DurableTask.Netherite
         protected override async Task Process(IList<PartitionEvent> batch)
         {
             try
-            {
-                var effects = new EffectTracker(
-                    this.partition,
-                    this.ApplyToStore,
-                    this.RemoveFromStore,
-                    () => (this.commitPosition, this.inputQueuePosition)
-                );
-
+            {             
                 if (batch.Count != 0)
                 {
                     foreach (var partitionEvent in batch)
@@ -135,7 +130,7 @@ namespace DurableTask.Netherite
                             {
                                 case PartitionUpdateEvent updateEvent:
                                     updateEvent.NextCommitLogPosition = this.commitPosition + 1;
-                                    await effects.ProcessUpdate(updateEvent).ConfigureAwait(false);
+                                    await this.effects.ProcessUpdate(updateEvent).ConfigureAwait(false);
                                     DurabilityListeners.ConfirmDurable(updateEvent);
                                     if (updateEvent.NextCommitLogPosition > 0)
                                     {
@@ -148,15 +143,15 @@ namespace DurableTask.Netherite
                                     if (readEvent.Prefetch.HasValue)
                                     {
                                         var prefetchTarget = this.GetOrAdd(readEvent.Prefetch.Value);
-                                        effects.ProcessReadResult(readEvent, readEvent.Prefetch.Value, prefetchTarget);
+                                        this.effects.ProcessReadResult(readEvent, readEvent.Prefetch.Value, prefetchTarget);
                                     }
                                     var readTarget = this.GetOrAdd(readEvent.ReadTarget);
-                                    effects.ProcessReadResult(readEvent, readEvent.ReadTarget, readTarget);
+                                    this.effects.ProcessReadResult(readEvent, readEvent.ReadTarget, readTarget);
                                     break;
 
                                 case PartitionQueryEvent queryEvent:
                                     var instances = this.QueryOrchestrationStates(queryEvent.InstanceQuery);
-                                    var backgroundTask = Task.Run(() => effects.ProcessQueryResultAsync(queryEvent, instances.ToAsyncEnumerable()));
+                                    var backgroundTask = Task.Run(() => this.effects.ProcessQueryResultAsync(queryEvent, instances.ToAsyncEnumerable()));
                                     break;
 
                                 default:
@@ -182,24 +177,40 @@ namespace DurableTask.Netherite
             }
         }
 
-        public ValueTask ApplyToStore(TrackedObjectKey key, EffectTracker tracker)
-        {
-            tracker.ProcessEffectOn(this.GetOrAdd(key));
-            return default;
-        }
-
-        public ValueTask RemoveFromStore(IEnumerable<TrackedObjectKey> keys)
-        {
-            foreach (var key in keys)
-            {
-                this.trackedObjects.TryRemove(key, out _);
-            }
-            return default;
-        }
-
         public Task Prefetch(IEnumerable<TrackedObjectKey> keys)
         {
             return Task.CompletedTask;
+        }
+
+        class MemoryStorageEffectTracker : PartitionEffectTracker
+        {
+            readonly MemoryStorage memoryStorage;
+
+            public MemoryStorageEffectTracker(Partition partition, MemoryStorage memoryStorage)
+                : base(partition)
+            { 
+                this.memoryStorage = memoryStorage;
+            }
+
+            public override ValueTask ApplyToStore(TrackedObjectKey key, EffectTracker tracker)
+            {
+                tracker.ProcessEffectOn(this.memoryStorage.GetOrAdd(key));
+                return default;
+            }
+
+            public override (long, long) GetPositions()
+            {
+                return (this.memoryStorage.commitPosition, this.memoryStorage.inputQueuePosition);
+            }
+
+            public override ValueTask RemoveFromStore(IEnumerable<TrackedObjectKey> keys)
+            {
+                foreach (var key in keys)
+                {
+                    this.memoryStorage.trackedObjects.TryRemove(key, out _);
+                }
+                return default;
+            }
         }
     }
 }

--- a/src/DurableTask.Netherite/Util/Utils.cs
+++ b/src/DurableTask.Netherite/Util/Utils.cs
@@ -6,6 +6,7 @@ namespace DurableTask.Netherite
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.IO;
     using System.Linq;
     using DurableTask.Core;
     using DurableTask.Core.History;
@@ -63,6 +64,22 @@ namespace DurableTask.Netherite
                 default:
                     taskScheduledId = -1;
                     return false;
+            }
+        }
+
+        public static IEnumerable<string> GetLines(this string str, bool removeEmptyLines = false)
+        {
+            using (var sr = new StringReader(str))
+            {
+                string line;
+                while ((line = sr.ReadLine()) != null)
+                {
+                    if (removeEmptyLines && String.IsNullOrWhiteSpace(line))
+                    {
+                        continue;
+                    }
+                    yield return line;
+                }
             }
         }
     }

--- a/test/DurableTask.Netherite.Tests/FasterPartitionTests.cs
+++ b/test/DurableTask.Netherite.Tests/FasterPartitionTests.cs
@@ -121,16 +121,16 @@ namespace DurableTask.Netherite.Tests
             };
 
             // create a cache monitor
-            var cacheDebugger = new Faster.CacheDebugger();
+            var cacheDebugger = new Faster.CacheDebugger(settings.TestHooks);
             var cts = new CancellationTokenSource();
             string reportedProblem = null;
-            cacheDebugger.OnError += (message) =>
+            settings.TestHooks.OnError += (message) =>
             {
-                this.output?.Invoke($"CACHEDEBUGGER: {message}");
+                this.output?.Invoke($"TESTHOOKS: {message}");
                 reportedProblem = reportedProblem ?? message;
                 cts.Cancel();
             };
-            settings.CacheDebugger = cacheDebugger;
+            settings.TestHooks.CacheDebugger = cacheDebugger;
 
             // we use the standard hello orchestration from the samples, which calls 5 activities in sequence
             var orchestrationType = typeof(ScenarioTests.Orchestrations.Hello5);

--- a/test/DurableTask.Netherite.Tests/QueryTests.cs
+++ b/test/DurableTask.Netherite.Tests/QueryTests.cs
@@ -50,6 +50,8 @@ namespace DurableTask.Netherite.Tests
                 throw new TimeoutException("timed out while purging instances after running test");
             }
 
+            Assert.Null(this.fixture.TestHooksError);
+
             this.outputHelper = null;
         }
 

--- a/test/DurableTask.Netherite.Tests/ScenarioTests.cs
+++ b/test/DurableTask.Netherite.Tests/ScenarioTests.cs
@@ -47,6 +47,7 @@ namespace DurableTask.Netherite.Tests
                 throw new TimeoutException("timed out while purging instances after running test");
             }
 
+            Assert.Null(this.fixture.TestHooksError);
             this.outputHelper = null;
         }
 

--- a/test/DurableTask.Netherite.Tests/SingleHostFixture.cs
+++ b/test/DurableTask.Netherite.Tests/SingleHostFixture.cs
@@ -20,6 +20,8 @@ namespace DurableTask.Netherite.Tests
         internal TestOrchestrationHost Host { get; private set; }
         internal ILoggerFactory LoggerFactory { get; private set; }
 
+        internal string TestHooksError { get; private set; }
+
         public SingleHostFixture()
         {
             this.LoggerFactory = new LoggerFactory();
@@ -32,6 +34,7 @@ namespace DurableTask.Netherite.Tests
             settings.TestHooks.OnError += (message) =>
             {
                 System.Diagnostics.Trace.WriteLine($"TESTHOOKS: {message}");
+                this.TestHooksError ??= message;
             };
             this.Host = new TestOrchestrationHost(settings, this.LoggerFactory);
             this.Host.StartAsync().Wait();
@@ -50,6 +53,7 @@ namespace DurableTask.Netherite.Tests
         {
             this.loggerProvider.Output = output;
             this.traceListener.Output = output;
+            this.TestHooksError = null;
         }
 
         internal class TestTraceListener : TraceListener

--- a/test/DurableTask.Netherite.Tests/SingleHostFixture.cs
+++ b/test/DurableTask.Netherite.Tests/SingleHostFixture.cs
@@ -28,6 +28,11 @@ namespace DurableTask.Netherite.Tests
             TestConstants.ValidateEnvironment();
             var settings = TestConstants.GetNetheriteOrchestrationServiceSettings();
             settings.PartitionManagement = PartitionManagementOptions.EventProcessorHost;
+            settings.TestHooks.ReplayChecker = new Faster.ReplayChecker(settings.TestHooks);
+            settings.TestHooks.OnError += (message) =>
+            {
+                System.Diagnostics.Trace.WriteLine($"TESTHOOKS: {message}");
+            };
             this.Host = new TestOrchestrationHost(settings, this.LoggerFactory);
             this.Host.StartAsync().Wait();
             this.traceListener = new TestTraceListener();

--- a/test/DurableTask.Netherite.Tests/TestConstants.cs
+++ b/test/DurableTask.Netherite.Tests/TestConstants.cs
@@ -51,6 +51,7 @@ namespace DurableTask.Netherite.Tests
             //settings.UseLocalDirectoryForPartitionStorage = $"{Environment.GetEnvironmentVariable("temp")}\\FasterTestStorage";
 
             settings.Validate((name) => Environment.GetEnvironmentVariable(name));
+            settings.TestHooks = new TestHooks();
 
             return settings;
         }


### PR DESCRIPTION
Implements a replay checker which runs in all tests.

The replay checker maintains a serialized checkpoint of the current state, and validates the commutative diagram after each step: *serialize(apply-effect(deserialize(old state))) = serialize(new state)*

To implement this, some refactoring was also required:
- Generalizes test hook structure to allow for various test checkers to be added easily and independently 
- Further develops the EffectTracker abstraction, using an abstract class instead of anonymous functions as done previously.


