### PR TITLE
Fix hanging storage

### DIFF
--- a/src/DurableTask.Netherite.AzureFunctions/NetheriteProviderFactory.cs
+++ b/src/DurableTask.Netherite.AzureFunctions/NetheriteProviderFactory.cs
@@ -111,6 +111,32 @@ namespace DurableTask.Netherite.AzureFunctions
 
             eventSourcedSettings.Validate((name) => this.nameResolver.Resolve(name));
 
+            int randomProbability = 0;
+            bool attachFaultInjector =
+                (this.options.StorageProvider.TryGetValue("FaultInjectionProbability", out object value)
+                && value is string str
+                && int.TryParse(str, out randomProbability));        
+
+            bool attachReplayChecker = 
+                (this.options.StorageProvider.TryGetValue("AttachReplayChecker", out object setting)
+                && setting is string s
+                && bool.TryParse(s, out bool x)
+                && x);
+                    
+            if (attachFaultInjector || attachReplayChecker)
+            {
+                eventSourcedSettings.TestHooks = new TestHooks();
+
+                if (attachFaultInjector)
+                {
+                    eventSourcedSettings.TestHooks.FaultInjector = new Faster.FaultInjector() { RandomProbability = randomProbability };
+                }
+                if (attachReplayChecker)
+                {
+                    eventSourcedSettings.TestHooks.ReplayChecker = new Faster.ReplayChecker(eventSourcedSettings.TestHooks);
+                }
+            }
+
             if (this.TraceToConsole || this.TraceToBlob)
             {
                 // capture trace events generated in the backend and redirect them to additional sinks

--- a/src/DurableTask.Netherite/OrchestrationService/Client.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/Client.cs
@@ -403,15 +403,15 @@ namespace DurableTask.Netherite
                 TimeoutUtc = this.GetTimeoutBucket(timeout),
             };
 
-            try
-            {
+            //try
+            //{
                 var response = await this.PerformRequestWithTimeoutAndCancellation(cancellationToken, request, false).ConfigureAwait(false);
                 return ((WaitResponseReceived)response)?.OrchestrationState;
-            }
-            catch(TimeoutException)
-            {
-                return null; // to match semantics of other backends, wait returns null when timing out
-            }
+            //}
+            //catch(TimeoutException)
+            //{
+            //    return null; // to match semantics of other backends, wait returns null when timing out
+            //}
         }
 
         public async Task<OrchestrationState> GetOrchestrationStateAsync(uint partitionId, string instanceId, bool fetchInput = true, bool fetchOutput = true)

--- a/src/DurableTask.Netherite/OrchestrationService/PartitionErrorHandler.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/PartitionErrorHandler.cs
@@ -49,15 +49,18 @@ namespace DurableTask.Netherite
             var logLevel = isWarning ? LogLevel.Warning : LogLevel.Error;
             if (this.logLevelLimit <= logLevel)
             {
-                this.logger?.Log(logLevel, "Part{partition:D2} !!! {message} in {context}: {exception} terminatePartition={terminatePartition}", this.partitionId, message, context, exception, terminatePartition);
+                // for warnings, do not print the entire exception message
+                string details = exception == null ? string.Empty : (isWarning ? $"{exception.GetType().FullName}: {exception.Message}" : exception.ToString());
+                
+                this.logger?.Log(logLevel, "Part{partition:D2} !!! {message} in {context}: {details} terminatePartition={terminatePartition}", this.partitionId, message, context, details, terminatePartition);
 
                 if (isWarning)
                 {
-                    EtwSource.Log.PartitionWarning(this.account, this.taskHub, this.partitionId, context, terminatePartition, message, exception?.ToString() ?? string.Empty, TraceUtils.AppName, TraceUtils.ExtensionVersion);
+                    EtwSource.Log.PartitionWarning(this.account, this.taskHub, this.partitionId, context, terminatePartition, message, details, TraceUtils.AppName, TraceUtils.ExtensionVersion);
                 }
                 else
                 {
-                    EtwSource.Log.PartitionError(this.account, this.taskHub, this.partitionId, context, terminatePartition, message, exception?.ToString() ?? string.Empty, TraceUtils.AppName, TraceUtils.ExtensionVersion);
+                    EtwSource.Log.PartitionError(this.account, this.taskHub, this.partitionId, context, terminatePartition, message, details, TraceUtils.AppName, TraceUtils.ExtensionVersion);
                 }
             }
         }

--- a/src/DurableTask.Netherite/OrchestrationService/TestHooks.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/TestHooks.cs
@@ -12,7 +12,7 @@ namespace DurableTask.Netherite
     {
         internal Faster.CacheDebugger CacheDebugger { get; set; }
 
-        internal Faster.ReplayChecker ReplayChecker { get; set; }
+        public Faster.ReplayChecker ReplayChecker { get; set; }
 
         public Faster.FaultInjector FaultInjector { get; set; }
 
@@ -25,7 +25,12 @@ namespace DurableTask.Netherite
             {
                 System.Diagnostics.Debugger.Break();
             }
-            this.OnError($"TestHook-{source} !!! {message}");
+            if (this.OnError != null)
+            {
+                this.OnError($"TestHook-{source} !!! {message}");
+            }
+            Console.Error.WriteLine($"TestHook-{source} !!! {message}");
+            System.Diagnostics.Trace.TraceError($"TestHook-{source} !!! {message}");
         }
     }
 }

--- a/src/DurableTask.Netherite/PartitionState/SessionsState.cs
+++ b/src/DurableTask.Netherite/PartitionState/SessionsState.cs
@@ -324,13 +324,15 @@ namespace DurableTask.Netherite
             // a different session id
             if (!this.Sessions.TryGetValue(evt.InstanceId, out var session) || session.SessionId != evt.SessionId)
             {
-                this.Partition.WorkItemTraceHelper.TraceWorkItemDiscarded(
-                    this.Partition.PartitionId, 
-                    WorkItemTraceHelper.WorkItemType.Orchestration, 
-                    evt.WorkItemId, evt.InstanceId, 
-                    session != null ? this.GetSessionPosition(session) : null,
-                    "session was replaced"); 
-                
+                if (!effects.IsReplaying)
+                {
+                    this.Partition.WorkItemTraceHelper.TraceWorkItemDiscarded(
+                        this.Partition.PartitionId,
+                        WorkItemTraceHelper.WorkItemType.Orchestration,
+                        evt.WorkItemId, evt.InstanceId,
+                        session != null ? this.GetSessionPosition(session) : null,
+                        "session was replaced");
+                }
                 return;
             };
 

--- a/src/DurableTask.Netherite/StorageProviders/Faster/AzureBlobs/BlobManager.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/AzureBlobs/BlobManager.cs
@@ -117,7 +117,7 @@ namespace DurableTask.Netherite.Faster
 
         static readonly int[] StorageFormatVersion = new int[] {
             1, //initial version
-            2, //separate singletons
+            2, //0.7.0-beta changed singleton storage, and adds dequeue count
         }; 
 
         public static string GetStorageFormat(NetheriteOrchestrationServiceSettings settings)
@@ -164,7 +164,7 @@ namespace DurableTask.Netherite.Faster
                 }
                 if (taskhubFormat.FormatVersion != StorageFormatVersion.Last())
                 {
-                    throw new InvalidOperationException($"The current storage format version (={StorageFormatVersion}) is incompatible with the existing taskhub (={taskhubFormat.FormatVersion}).");
+                    throw new InvalidOperationException($"The current storage format version (={StorageFormatVersion.Last()}) is incompatible with the existing taskhub (={taskhubFormat.FormatVersion}).");
                 }
             }
             catch(Exception e)

--- a/src/DurableTask.Netherite/StorageProviders/Faster/FasterStorage.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/FasterStorage.cs
@@ -28,6 +28,7 @@ namespace DurableTask.Netherite.Faster
         TrackedObjectStore store;
 
         CancellationToken terminationToken;
+        Task terminationTokenTask;
 
         internal FasterTraceHelper TraceHelper { get; private set; }
 
@@ -60,10 +61,27 @@ namespace DurableTask.Netherite.Faster
             return BlobManager.DeleteTaskhubStorageAsync(storageAccount, pageBlobAccount, localFileDirectory, taskHubName);
         }
 
+        async Task<T> TerminationWrapper<T>(Task<T> what)
+        {
+            // wrap a task so the await is canceled if this partition terminates
+            await Task.WhenAny(what, this.terminationTokenTask);
+            this.terminationToken.ThrowIfCancellationRequested();
+            return await what;
+        }
+
+        async Task TerminationWrapper(Task what)
+        {
+            // wrap a task so the await is canceled if this partition terminates
+            await Task.WhenAny(what, this.terminationTokenTask);
+            this.terminationToken.ThrowIfCancellationRequested();
+            await what;
+        }
+
         public async Task<long> CreateOrRestoreAsync(Partition partition, IPartitionErrorHandler errorHandler, long firstInputQueuePosition)
         {
             this.partition = partition;
             this.terminationToken = errorHandler.Token;
+            this.terminationTokenTask = Task.Delay(-1, errorHandler.Token);
 
             int psfCount = 0;
 
@@ -83,7 +101,8 @@ namespace DurableTask.Netherite.Faster
             this.blobManager.FaultInjector?.Starting(this.blobManager);
 
             this.TraceHelper.FasterProgress("Starting BlobManager");
-            await this.blobManager.StartAsync().ConfigureAwait(false);
+            await this.TerminationWrapper(this.blobManager.StartAsync());
+
 
             var stopwatch = new System.Diagnostics.Stopwatch();
             stopwatch.Start();
@@ -116,9 +135,9 @@ namespace DurableTask.Netherite.Faster
                     this.TraceHelper.FasterProgress("Creating store");
 
                     // this is a fresh partition
-                    await this.storeWorker.Initialize(this.log.BeginAddress, firstInputQueuePosition).ConfigureAwait(false);
+                    await this.TerminationWrapper(this.storeWorker.Initialize(this.log.BeginAddress, firstInputQueuePosition));
 
-                    await this.storeWorker.TakeFullCheckpointAsync("initial checkpoint").ConfigureAwait(false);
+                    await this.TerminationWrapper(this.storeWorker.TakeFullCheckpointAsync("initial checkpoint").AsTask());
                     this.TraceHelper.FasterStoreCreated(this.storeWorker.InputQueuePosition, stopwatch.ElapsedMilliseconds);
 
                     this.partition.Assert(!FASTER.core.LightEpoch.AnyInstanceProtected(), "unexpected FASTER.AnyInstanceProtected in CreateOrRestoreAsync");
@@ -136,7 +155,7 @@ namespace DurableTask.Netherite.Faster
                 try
                 {
                     // we are recovering the last checkpoint of the store
-                    (long commitLogPosition, long inputQueuePosition) = await this.store.RecoverAsync();
+                    (long commitLogPosition, long inputQueuePosition) = await this.TerminationWrapper(this.store.RecoverAsync());
                     this.storeWorker.SetCheckpointPositionsAfterRecovery(commitLogPosition, inputQueuePosition);
 
                     // truncate the log in case the truncation did not commit after the checkpoint was taken
@@ -163,7 +182,7 @@ namespace DurableTask.Netherite.Faster
                     if (this.log.TailAddress > (long)this.storeWorker.CommitLogPosition)
                     {
                         // replay log as the store checkpoint lags behind the log
-                        await this.storeWorker.ReplayCommitLog(this.logWorker).ConfigureAwait(false);
+                        await this.TerminationWrapper(this.storeWorker.ReplayCommitLog(this.logWorker));
                     }
                 }
                 catch (OperationCanceledException) when (this.partition.ErrorHandler.IsTerminated)
@@ -177,7 +196,7 @@ namespace DurableTask.Netherite.Faster
                 }
 
                 // restart pending actitivities, timers, work items etc.
-                await this.storeWorker.RestartThingsAtEndOfRecovery().ConfigureAwait(false);
+                await this.TerminationWrapper(this.storeWorker.RestartThingsAtEndOfRecovery());
 
                 this.TraceHelper.FasterProgress("Recovery complete");
             }
@@ -200,18 +219,18 @@ namespace DurableTask.Netherite.Faster
             Task t2 = this.storeWorker.CancelAndShutdown();
 
             // observe exceptions if the clean shutdown is not working correctly
-            await t1.ConfigureAwait(false);
-            await t2.ConfigureAwait(false);
+            await this.TerminationWrapper(t1);
+            await this.TerminationWrapper(t2);
 
             // if the the settings indicate we want to take a final checkpoint, do so now.
             if (takeFinalCheckpoint)
             {
                 this.TraceHelper.FasterProgress("Writing final checkpoint");
-                await this.storeWorker.TakeFullCheckpointAsync("final checkpoint").ConfigureAwait(false);
+                await this.TerminationWrapper(this.storeWorker.TakeFullCheckpointAsync("final checkpoint").AsTask());
             }
 
             this.TraceHelper.FasterProgress("Stopping BlobManager");
-            await this.blobManager.StopAsync().ConfigureAwait(false);
+            await this.blobManager.StopAsync();
         }
 
         public void SubmitEvents(IList<PartitionEvent> evts)

--- a/src/DurableTask.Netherite/StorageProviders/Faster/FasterStorage.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/FasterStorage.cs
@@ -139,8 +139,6 @@ namespace DurableTask.Netherite.Faster
 
                     await this.TerminationWrapper(this.storeWorker.TakeFullCheckpointAsync("initial checkpoint").AsTask());
                     this.TraceHelper.FasterStoreCreated(this.storeWorker.InputQueuePosition, stopwatch.ElapsedMilliseconds);
-
-                    this.partition.Assert(!FASTER.core.LightEpoch.AnyInstanceProtected(), "unexpected FASTER.AnyInstanceProtected in CreateOrRestoreAsync");
                 }
                 catch (Exception e)
                 {
@@ -172,8 +170,6 @@ namespace DurableTask.Netherite.Faster
                     this.TraceHelper.FasterStorageError("loading checkpoint", e);
                     throw;
                 }
-
-                this.partition.Assert(!FASTER.core.LightEpoch.AnyInstanceProtected(), "unexpected FASTER.AnyInstanceProtected after loading checkpoint");
 
                 this.TraceHelper.FasterProgress($"Replaying log length={this.log.TailAddress - this.storeWorker.CommitLogPosition} range={this.storeWorker.CommitLogPosition}-{this.log.TailAddress}");
 

--- a/src/DurableTask.Netherite/StorageProviders/Faster/FaultInjector.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/FaultInjector.cs
@@ -29,6 +29,9 @@ namespace DurableTask.Netherite.Faster
         int countdown;
         int nextrun;
 
+        public int RandomProbability { get; set; }
+        readonly Random random = new Random();
+
         public void StartNewTest()
         {
             System.Diagnostics.Trace.TraceInformation($"FaultInjector: StartNewTest");
@@ -135,6 +138,17 @@ namespace DurableTask.Netherite.Faster
                             this.countdown = this.nextrun++;
                         }
                     }
+                }
+            }
+
+            if (this.RandomProbability > 0)
+            {
+                var dieRoll = this.random.Next(this.RandomProbability);
+                //Console.WriteLine(dieRoll);
+
+                if (dieRoll == 0)
+                {
+                    pass = false;
                 }
             }
 

--- a/src/DurableTask.Netherite/StorageProviders/Faster/ReplayChecker.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/ReplayChecker.cs
@@ -19,7 +19,7 @@ namespace DurableTask.Netherite.Faster
     /// serialize(new-state) = serialize(deserialize(old-state) + event)
     /// This class is only used for testing and debugging, as it creates lots of overhead.
     /// </summary>
-    class ReplayChecker
+    public class ReplayChecker
     {
         readonly ConcurrentDictionary<Partition, Info> partitionInfo;
         readonly TestHooks testHooks;
@@ -131,7 +131,7 @@ namespace DurableTask.Netherite.Faster
         PartitionUpdateEvent DeserializePartitionUpdateEvent(string content)
             => (PartitionUpdateEvent) JsonConvert.DeserializeObject(content, this.settings);
 
-        public void PartitionStarting(Partition partition, TrackedObjectStore store, long CommitLogPosition, long InputQueuePosition)
+        internal void PartitionStarting(Partition partition, TrackedObjectStore store, long CommitLogPosition, long InputQueuePosition)
         {
             var info = new Info()
             {
@@ -151,7 +151,7 @@ namespace DurableTask.Netherite.Faster
             info.EffectTracker = new ReplayCheckEffectTracker(this, info);
         }
 
-        public async Task CheckUpdate(Partition partition, PartitionUpdateEvent partitionUpdateEvent, TrackedObjectStore store)
+        internal async Task CheckUpdate(Partition partition, PartitionUpdateEvent partitionUpdateEvent, TrackedObjectStore store)
         {
             var info = this.partitionInfo[partition];
 
@@ -206,7 +206,7 @@ namespace DurableTask.Netherite.Faster
             System.Diagnostics.Trace.WriteLine("REPLAYCHECK DONE");
         }
 
-        public void PartitionStopped(Partition partition)
+        internal void PartitionStopped(Partition partition)
         {
             this.partitionInfo.TryRemove(partition, out _);
         }

--- a/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsProcessor.cs
+++ b/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsProcessor.cs
@@ -281,7 +281,9 @@ namespace DurableTask.Netherite.EventHubs
 
         async ValueTask SaveEventHubsReceiverCheckpoint(PartitionContext context, long byteThreshold)
         {
-            if (this.lastCheckpointedOffset.HasValue && this.persistedOffset - this.lastCheckpointedOffset.Value > byteThreshold)
+            if (this.lastCheckpointedOffset.HasValue
+                && this.persistedOffset - this.lastCheckpointedOffset.Value > byteThreshold
+                && !context.CancellationToken.IsCancellationRequested)
             {
                 var checkpoint = new Checkpoint(this.partitionId.ToString(), this.persistedOffset.ToString(), this.persistedSequenceNumber);
 

--- a/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsTransport.cs
+++ b/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsTransport.cs
@@ -246,7 +246,8 @@ namespace DurableTask.Netherite.EventHubs
             {
                 if (this.settings.PartitionManagement != PartitionManagementOptions.Scripted)
                 {
-                    this.traceHelper.LogInformation("Registering Partition Host with EventHubs");
+                    string initialOffsets = string.Join(",", this.parameters.StartPositions.Select(x => $"#{x}"));
+                    this.traceHelper.LogInformation($"Registering Partition Host with EventHubs, initial offsets {initialOffsets}");
 
                     this.eventProcessorHost = new EventProcessorHost(
                         Guid.NewGuid().ToString(),

--- a/src/DurableTask.Netherite/TransportProviders/Memory/MemoryTransport.cs
+++ b/src/DurableTask.Netherite/TransportProviders/Memory/MemoryTransport.cs
@@ -98,7 +98,9 @@ namespace DurableTask.Netherite.Emulated
 
             // we finish the (possibly lengthy) partition loading asynchronously so it is possible to receive 
             // stop signals before partitions are fully recovered
-            this.startOrRecoverTask = this.StartOrRecoverAsync(0);
+            var tcs = new TaskCompletionSource<object>();
+            this.startOrRecoverTask = this.StartOrRecoverAsync(0, tcs.Task);
+            tcs.SetResult(null);
 
             return Task.CompletedTask;
         }
@@ -113,14 +115,15 @@ namespace DurableTask.Netherite.Emulated
 
             if (this.shutdownTokenSource?.IsCancellationRequested == false)
             {
-                this.startOrRecoverTask = this.StartOrRecoverAsync(epoch + 1);
+                var tcs = new TaskCompletionSource<object>();
+                this.startOrRecoverTask = this.StartOrRecoverAsync(epoch + 1, tcs.Task);
+                tcs.SetResult(null);
             }
         }
 
-        async Task StartOrRecoverAsync(int epoch)
+        async Task StartOrRecoverAsync(int epoch, Task continueStart)
         {
-            await Task.Yield();
-            System.Diagnostics.Debug.Assert(this.startOrRecoverTask != null);
+            await continueStart;
 
             if (epoch > 0)
             {

--- a/test/DurableTask.Netherite.Tests/TestOrchestrationClient.cs
+++ b/test/DurableTask.Netherite.Tests/TestOrchestrationClient.cs
@@ -39,7 +39,13 @@ namespace DurableTask.Netherite.Tests
 
             var latestGeneration = new OrchestrationInstance { InstanceId = this.instanceId };
             Stopwatch sw = Stopwatch.StartNew();
-            OrchestrationState state = await this.client.WaitForOrchestrationAsync(latestGeneration, timeout);
+
+            OrchestrationState state = null;
+            try
+            {
+                state = await this.client.WaitForOrchestrationAsync(latestGeneration, timeout);
+            }
+            catch (TimeoutException)  { }
             if (state != null)
             {
                 Trace.TraceInformation(
@@ -78,8 +84,13 @@ namespace DurableTask.Netherite.Tests
 
             do
             {
-                state = await this.client.WaitForOrchestrationAsync(latestGeneration, period);
-
+                try
+                {
+                    state = await this.client.WaitForOrchestrationAsync(latestGeneration, period);
+                }
+                catch (TimeoutException) 
+                {
+                }
             } while (state == null && sw.Elapsed < timeout);
 
             if (state != null)

--- a/test/PerformanceTests/host.json
+++ b/test/PerformanceTests/host.json
@@ -73,6 +73,11 @@
         // set this to "true" to disable all pipelining
         "PersistStepsFirst": false,
 
+        // set this to x to inject faults with probability 1/x
+        //"FaultInjectionProbability": 250,
+        // set this to true to attach replay checker
+        //"AttachReplayChecker": true,
+
         // set this to "Scripted" to control the scenario with a partition script
         // or to "ClientOnly" to run only the client
         "PartitionManagement": "EventProcessorHost",


### PR DESCRIPTION
Error injection revealed that FASTER hangs in some cases when storage experiences faults.
This causes problem with the automatic recycle in the EventProcessor. 

To avoid this issue, this PR wraps a termination wrapper around all storage calls, which terminates the call if the errorHandler moves to terminated state.

This PR also contains numerous small tracing changes and adds support for running error injection and replay testing inside DF deployments.