### PR TITLE
Fix deduplication of fragmented partition and client events

### DIFF
--- a/src/DurableTask.Netherite/OrchestrationService/Client.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/Client.cs
@@ -116,9 +116,15 @@ namespace DurableTask.Netherite
 
                 if (!fragment.IsLast)
                 {
-                    if (!this.Fragments.TryGetValue(originalEventString, out var stream))
+                    MemoryStream stream;
+
+                    if (fragment.Fragment == 0)
                     {
                         this.Fragments[originalEventString] = stream = new MemoryStream();
+                    }
+                    else
+                    {
+                        stream = this.Fragments[originalEventString];
                     }
                     stream.Write(fragment.Bytes, 0, fragment.Bytes.Length);
                 }

--- a/src/DurableTask.Netherite/PartitionState/ReassemblyState.cs
+++ b/src/DurableTask.Netherite/PartitionState/ReassemblyState.cs
@@ -57,10 +57,17 @@ namespace DurableTask.Netherite
             }
             else
             {
-                if (!this.Fragments.TryGetValue(originalEventString, out var list))
+                List<PartitionEventFragment> list;
+
+                if (evt.Fragment == 0)
                 {
                     this.Fragments[originalEventString] = list = new List<PartitionEventFragment>();
                 }
+                else
+                {
+                    list = this.Fragments[originalEventString];
+                }
+
                 list.Add(evt);
             }
         } 

--- a/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsSender.cs
+++ b/src/DurableTask.Netherite/TransportProviders/EventHubs/EventHubsSender.cs
@@ -100,7 +100,7 @@ namespace DurableTask.Netherite.EventHubs
                         if (tooBig)
                         {
                             // the message is too big. Break it into fragments, and send each individually.
-                            this.traceHelper.LogTrace("EventHubsSender {eventHubName}/{eventHubPartitionId} fragmenting large event ({size} bytes) id={eventId}", this.eventHubName, this.eventHubPartition, length, evt.EventIdString);
+                            this.traceHelper.LogDebug("EventHubsSender {eventHubName}/{eventHubPartitionId} fragmenting large event ({size} bytes) id={eventId}", this.eventHubName, this.eventHubPartition, length, evt.EventIdString);
                             var fragments = FragmentationAndReassembly.Fragment(arraySegment, evt, maxFragmentSize);
                             maybeSent = i;
                             for (int k = 0; k < fragments.Count; k++)


### PR DESCRIPTION
fixes problem observed in #105.

The issue was that under failures the EventHubsSender may start over a sequence of fragments before sending the final fragment, and in that case, the receiver has to throw away the partial sequence received earlier, and start over also.