### PR TITLE
Fix autoscaler

### DIFF
--- a/src/DurableTask.Netherite.AzureFunctions/NetheriteProvider.cs
+++ b/src/DurableTask.Netherite.AzureFunctions/NetheriteProvider.cs
@@ -202,7 +202,7 @@ namespace DurableTask.Netherite.AzureFunctions
                 ScaleRecommendation recommendation;               
                 try
                 { 
-                    if (metrics.Length == 0)
+                    if (metrics == null || metrics.Length == 0)
                     {
                         recommendation = new ScaleRecommendation(ScaleAction.None, keepWorkersAlive: true, reason: "missing metrics");
                     }

--- a/src/DurableTask.Netherite.AzureFunctions/NetheriteProvider.cs
+++ b/src/DurableTask.Netherite.AzureFunctions/NetheriteProvider.cs
@@ -117,6 +117,7 @@ namespace DurableTask.Netherite.AzureFunctions
             if (this.Service.TryGetScalingMonitor(out var monitor))
             {
                 scaleMonitor = new ScaleMonitor(monitor);
+                monitor.InformationTracer($"ScaleMonitor Constructed Microsoft.Azure.WebJobs.Host.Scale.IScaleMonitor {scaleMonitor.Descriptor}");
                 return true;
             }
             else
@@ -158,6 +159,7 @@ namespace DurableTask.Netherite.AzureFunctions
                 var cached = cachedMetrics;
                 if (cached != null && DateTime.UtcNow - cached.Item1 < TimeSpan.FromSeconds(1.5))
                 {
+                    this.scalingMonitor.InformationTracer?.Invoke($"ScaleMonitor returned metrics cached previously, at {cached.Item2.Timestamp:o}");
                     return cached.Item2;
                 }
                 
@@ -174,13 +176,12 @@ namespace DurableTask.Netherite.AzureFunctions
                     this.serializer.WriteObject(stream, collectedMetrics);
                     metrics.Metrics = stream.ToArray();
 
-                    this.scalingMonitor.Logger.LogInformation(
-                        "Collected scale info for {partitionCount} partitions at {time:o} in {latencyMs:F2}ms.",
-                        collectedMetrics.LoadInformation.Count, collectedMetrics.Timestamp, sw.Elapsed.TotalMilliseconds);
+                    this.scalingMonitor.InformationTracer?.Invoke(
+                        $"ScaleMonitor collected metrics for {collectedMetrics.LoadInformation.Count} partitions at {collectedMetrics.Timestamp:o} in {sw.Elapsed.TotalMilliseconds:F2}ms.");
                 }
-                catch (Exception e) when (!Utils.IsFatal(e))
+                catch (Exception e)
                 {
-                    this.scalingMonitor.Logger.LogError("IScaleMonitor.GetMetricsAsync() failed: {exception}", e);
+                    this.scalingMonitor.ErrorTracer?.Invoke("ScaleMonitor failed to collect metrics", e);
                 }
 
                 cachedMetrics = new Tuple<DateTime, NetheriteScaleMetrics>(DateTime.UtcNow, metrics);
@@ -212,12 +213,14 @@ namespace DurableTask.Netherite.AzureFunctions
                         var collectedMetrics = (ScalingMonitor.Metrics) this.serializer.ReadObject(stream);                 
                         recommendation = this.scalingMonitor.GetScaleRecommendation(workerCount, collectedMetrics);
                     }
-                 }
+                }
                 catch (Exception e) when (!Utils.IsFatal(e))
                 {
-                    this.scalingMonitor.Logger.LogError("IScaleMonitor.GetScaleStatus() failed: {exception}", e);
+                    this.scalingMonitor.ErrorTracer?.Invoke("ScaleMonitor failed to compute scale recommendation", e);
                     recommendation = new ScaleRecommendation(ScaleAction.None, keepWorkersAlive: true, reason: "unexpected error");
                 }
+               
+                this.scalingMonitor.RecommendationTracer?.Invoke(recommendation.Action.ToString(), workerCount, recommendation.Reason);
 
                 ScaleStatus scaleStatus = new ScaleStatus();
                 switch (recommendation?.Action)

--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
@@ -170,20 +170,26 @@ namespace DurableTask.Netherite
             if (this.configuredStorage == TransportConnectionString.StorageChoices.Faster
                 && this.configuredTransport == TransportConnectionString.TransportChoices.EventHubs)
             {
-                monitor = new ScalingMonitor(
-                    this.Settings.ResolvedStorageConnectionString, 
-                    this.Settings.ResolvedTransportConnectionString, 
-                    this.Settings.LoadInformationAzureTableName, 
-                    this.Settings.HubName,
-                    this.TraceHelper.TraceScaleRecommendation,
-                    this.TraceHelper.Logger);
-                return true;
+                try
+                {
+                    monitor = new ScalingMonitor(
+                        this.Settings.ResolvedStorageConnectionString,
+                        this.Settings.ResolvedTransportConnectionString,
+                        this.Settings.LoadInformationAzureTableName,
+                        this.Settings.HubName,
+                        this.TraceHelper.TraceScaleRecommendation,
+                        this.TraceHelper.TraceProgress,
+                        this.TraceHelper.TraceError);
+                    return true;
+                }
+                catch (Exception e)
+                {
+                    this.TraceHelper.TraceError("ScaleMonitor failure during construction", e);
+                }
             }
-            else
-            {
-                monitor = null;
-                return false;
-            }
+
+            monitor = null;
+            return false;
         }
 
        

--- a/src/DurableTask.Netherite/Scaling/ScalingMonitor.cs
+++ b/src/DurableTask.Netherite/Scaling/ScalingMonitor.cs
@@ -12,19 +12,22 @@ namespace DurableTask.Netherite.Scaling
     using System.Threading;
     using System.Threading.Tasks;
     using DurableTask.Netherite.EventHubs;
-    using Microsoft.Extensions.Logging;
 
     /// <summary>
     /// Monitors the performance of the Netherite backend and makes scaling decisions.
     /// </summary>
-    public class ScalingMonitor 
+    public class ScalingMonitor
     {
         readonly string storageConnectionString;
         readonly string eventHubsConnectionString;
         readonly string partitionLoadTableName;
         readonly string taskHubName;
         readonly TransportConnectionString.TransportChoices configuredTransport;
-        readonly Action<string, int, string> recommendationTracer;
+
+        // public logging actions to enable collection of scale-monitor-related logging within the Netherite infrastructure
+        public Action<string, int, string> RecommendationTracer { get; }
+        public Action<string> InformationTracer { get; }
+        public Action<string, Exception> ErrorTracer { get; }
 
         readonly ILoadMonitorService loadMonitor;
 
@@ -34,11 +37,6 @@ namespace DurableTask.Netherite.Scaling
         public string TaskHubName => this.taskHubName;
 
         /// <summary>
-        /// A logger for scaling events.
-        /// </summary>
-        public ILogger Logger { get; }
-
-        /// <summary>
         /// Creates an instance of the scaling monitor, with the given parameters.
         /// </summary>
         /// <param name="storageConnectionString">The storage connection string.</param>
@@ -46,19 +44,22 @@ namespace DurableTask.Netherite.Scaling
         /// <param name="partitionLoadTableName">The name of the storage table with the partition load information.</param>
         /// <param name="taskHubName">The name of the taskhub.</param>
         public ScalingMonitor(
-            string storageConnectionString, 
-            string eventHubsConnectionString, 
-            string partitionLoadTableName, 
+            string storageConnectionString,
+            string eventHubsConnectionString,
+            string partitionLoadTableName,
             string taskHubName,
             Action<string, int, string> recommendationTracer,
-            ILogger logger)
+            Action<string> informationTracer,
+            Action<string, Exception> errorTracer)
         {
+            this.RecommendationTracer = recommendationTracer;
+            this.InformationTracer = informationTracer;
+            this.ErrorTracer = errorTracer;
+
             this.storageConnectionString = storageConnectionString;
             this.eventHubsConnectionString = eventHubsConnectionString;
             this.partitionLoadTableName = partitionLoadTableName;
             this.taskHubName = taskHubName;
-            this.recommendationTracer = recommendationTracer;
-            this.Logger = logger;
 
             TransportConnectionString.Parse(eventHubsConnectionString, out _, out this.configuredTransport);
 
@@ -128,8 +129,6 @@ namespace DurableTask.Netherite.Scaling
         public ScaleRecommendation GetScaleRecommendation(int workerCount, Metrics metrics)
         {
             var recommendation = DetermineRecommendation();
-
-            this.recommendationTracer?.Invoke(recommendation.Action.ToString(), workerCount, recommendation.Reason);
 
             return recommendation;
 

--- a/src/DurableTask.Netherite/Scaling/ScalingMonitor.cs
+++ b/src/DurableTask.Netherite/Scaling/ScalingMonitor.cs
@@ -148,12 +148,16 @@ namespace DurableTask.Netherite.Scaling
                         reason: "Task hub is idle");
                 }
 
-                int numberOfSlowPartitions = metrics.LoadInformation.Values.Count(info => info.LatencyTrend.Length > 1 && info.LatencyTrend.Last() == PartitionLoadInfo.MediumLatency);
+                bool isSlowPartition(PartitionLoadInfo info)
+                {
+                    char mostRecent = info.LatencyTrend.Last();
+                    return mostRecent == PartitionLoadInfo.HighLatency || mostRecent == PartitionLoadInfo.MediumLatency;
+                }
+                int numberOfSlowPartitions = metrics.LoadInformation.Values.Count(info => isSlowPartition(info));
 
                 if (workerCount < numberOfSlowPartitions)
                 {
                     // scale up to the number of busy partitions
-                    var partition = metrics.LoadInformation.First(kvp => kvp.Value.LatencyTrend.Last() == PartitionLoadInfo.MediumLatency);
                     return new ScaleRecommendation(
                         ScaleAction.AddWorker,
                         keepWorkersAlive: true,


### PR DESCRIPTION
This PR contains:

1. A fix in the autoscale logic which did lead to high latency not being recognized. This was a regression introduced while implementing the advanced activity scheduling #52.

2. Improved tracing and error handling for the autoscaler logic. In particular, Netherite logs more information to ETW which makes it easier to use Kusto when debugging auto-scaling related issues.

It may be necessary to propagate these changes to the consumption plan support work currently underway by @bachuv.