### PR TITLE
Maintain a count of instances in each partition

### DIFF
--- a/src/DurableTask.Netherite/Abstractions/PartitionState/TrackedObjectKey.cs
+++ b/src/DurableTask.Netherite/Abstractions/PartitionState/TrackedObjectKey.cs
@@ -30,6 +30,7 @@ namespace DurableTask.Netherite
             Timers,
             Prefetch,
             Queries,
+            Stats,
 
             // non-singletons
             History,
@@ -46,6 +47,7 @@ namespace DurableTask.Netherite
             { TrackedObjectType.Timers, typeof(TimersState) },
             { TrackedObjectType.Prefetch, typeof(PrefetchState) },
             { TrackedObjectType.Queries, typeof(QueriesState) },
+            { TrackedObjectType.Stats, typeof(StatsState) },
             
             // non-singletons
             { TrackedObjectType.History, typeof(HistoryState) },
@@ -89,6 +91,7 @@ namespace DurableTask.Netherite
         public static TrackedObjectKey Timers = new TrackedObjectKey() { ObjectType = TrackedObjectType.Timers };
         public static TrackedObjectKey Prefetch = new TrackedObjectKey() { ObjectType = TrackedObjectType.Prefetch };
         public static TrackedObjectKey Queries = new TrackedObjectKey() { ObjectType = TrackedObjectType.Queries };
+        public static TrackedObjectKey Stats = new TrackedObjectKey() { ObjectType = TrackedObjectType.Stats };
 
         // convenient constructors for non-singletons
 
@@ -113,6 +116,7 @@ namespace DurableTask.Netherite
                 TrackedObjectType.Timers => new TimersState(),
                 TrackedObjectType.Prefetch => new PrefetchState(),
                 TrackedObjectType.Queries => new QueriesState(),
+                TrackedObjectType.Stats => new StatsState(),
                 TrackedObjectType.History => new HistoryState() { InstanceId = key.InstanceId },
                 TrackedObjectType.Instance => new InstanceState() { InstanceId = key.InstanceId },
                 _ => throw new ArgumentException("invalid key", nameof(key)),

--- a/src/DurableTask.Netherite/Events/PartitionEvents/Internal/PurgeBatchIssued.cs
+++ b/src/DurableTask.Netherite/Events/PartitionEvents/Internal/PurgeBatchIssued.cs
@@ -59,9 +59,10 @@ namespace DurableTask.Netherite
 
         public override void DetermineEffects(EffectTracker effects)
         {
-            // the last-added effects are processed first
-            // so they can set the Purged list to contain only the instance ids that are actually purged
+            // the following singletons are added first, so they are processed last, and can thus
+            // access the Purged list that contains only the instance ids that were actually purged
 
+            effects.Add(TrackedObjectKey.Stats);
             effects.Add(TrackedObjectKey.Queries);
             effects.Add(TrackedObjectKey.Sessions);
 

--- a/src/DurableTask.Netherite/PartitionState/StatsState.cs
+++ b/src/DurableTask.Netherite/PartitionState/StatsState.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace DurableTask.Netherite
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Runtime.Serialization;
+    using DurableTask.Core;
+    using DurableTask.Core.Common;
+    using DurableTask.Core.History;
+    using DurableTask.Netherite.Scaling;
+
+    [DataContract]
+    class StatsState : TrackedObject
+    {
+        [DataMember]
+        public long InstanceCount { get; set; }
+
+        [IgnoreDataMember]
+        public override TrackedObjectKey Key => new TrackedObjectKey(TrackedObjectKey.TrackedObjectType.Stats);
+
+        public override string ToString()
+        {
+            return $"Stats (InstanceCount={this.InstanceCount})";
+        }
+
+        public override void UpdateLoadInfo(PartitionLoadInfo info)
+        {
+            info.Instances = this.InstanceCount;
+        }
+
+        public override void Process(CreationRequestReceived evt, EffectTracker effects)
+        {
+            this.InstanceCount++;
+        }
+
+        public override void Process(BatchProcessed evt, EffectTracker effects)
+        {
+            this.InstanceCount++;
+        }
+
+        public override void Process(PurgeBatchIssued evt, EffectTracker effects)
+        {
+            this.InstanceCount -= evt.Purged.Count;
+        }
+
+        public override void Process(DeletionRequestReceived evt, EffectTracker effects)
+        {
+            this.InstanceCount--;
+        }
+
+    }
+}

--- a/src/DurableTask.Netherite/Scaling/AzureTableLoadMonitor.cs
+++ b/src/DurableTask.Netherite/Scaling/AzureTableLoadMonitor.cs
@@ -92,6 +92,7 @@ namespace DurableTask.Netherite.Scaling
                         Requests = e.Requests,
                         Wakeup = e.NextTimer,
                         Outbox = e.Outbox,
+                        Instances = e.Instances,
                         InputQueuePosition = e.InputQueuePosition,
                         CommitLogPosition = e.CommitLogPosition,
                         WorkerId = e.WorkerId,
@@ -111,6 +112,7 @@ namespace DurableTask.Netherite.Scaling
             public int Timers { get; set; }
             public int Requests { get; set; }
             public int Outbox { get; set; }
+            public long Instances { get; set; }
             public DateTime? NextTimer { get; set; }
             public long InputQueuePosition { get; set; }
             public long CommitLogPosition { get; set; }
@@ -139,6 +141,7 @@ namespace DurableTask.Netherite.Scaling
                 this.Requests = info.Requests;
                 this.NextTimer = info.Wakeup;
                 this.Outbox = info.Outbox;
+                this.Instances = info.Instances;
                 this.InputQueuePosition = info.InputQueuePosition;
                 this.CommitLogPosition = info.CommitLogPosition;
                 this.WorkerId = info.WorkerId;

--- a/src/DurableTask.Netherite/Scaling/PartitionLoadInfo.cs
+++ b/src/DurableTask.Netherite/Scaling/PartitionLoadInfo.cs
@@ -46,6 +46,12 @@ namespace DurableTask.Netherite.Scaling
         public int Outbox { get; set; }
 
         /// <summary>
+        /// The total number of orchestration and entity instances
+        /// </summary>
+        [DataMember]
+        public long Instances { get; set; }
+
+        /// <summary>
         /// The next time on which to wake up.
         /// </summary>
         [DataMember]

--- a/src/DurableTask.Netherite/StorageProviders/Faster/AzureBlobs/CheckpointInfo.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/AzureBlobs/CheckpointInfo.cs
@@ -21,5 +21,8 @@ namespace DurableTask.Netherite.Faster
 
         [JsonProperty]
         public long InputQueuePosition { get; set; }
+
+        [JsonProperty]
+        public long NumberInstances { get; set; }
     }
 }

--- a/src/DurableTask.Netherite/StorageProviders/Faster/ReplayChecker.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/ReplayChecker.cs
@@ -157,7 +157,8 @@ namespace DurableTask.Netherite.Faster
 
             System.Diagnostics.Trace.WriteLine($"REPLAYCHECK STARTED {partitionUpdateEvent}");
 
-            var eventForReplay = this.DeserializePartitionUpdateEvent(this.Serialize(partitionUpdateEvent));
+            string serializedEvent = this.Serialize(partitionUpdateEvent);
+            var eventForReplay = this.DeserializePartitionUpdateEvent(serializedEvent);
             eventForReplay.NextCommitLogPosition = partitionUpdateEvent.NextCommitLogPosition;
             await info.EffectTracker.ProcessUpdate(eventForReplay);
 
@@ -191,7 +192,8 @@ namespace DurableTask.Netherite.Faster
                             break;
                         }
                     }
-                    this.testHooks.Error(this.GetType().Name, $"key={key} line={i}\nexpectedline={expectedline}\nreplayedline={replayedline}\nexpected={expected}\nreplayed={replayed} ");
+                    this.testHooks.Error(this.GetType().Name, $"Part{partition.PartitionId:D2} pos={partitionUpdateEvent.NextCommitLogPosition} key={key}"
+                        + $"\nline={i}\nexpectedline={expectedline}\nreplayedline={replayedline}\nexpected={expected}\nreplayed={replayed}\nevent={serializedEvent}");
                     info.Store[key] = expected;
                 }
             });
@@ -225,9 +227,9 @@ namespace DurableTask.Netherite.Faster
 
             public override Partition Partition => this.info.Partition;
 
-            public override EventTraceHelper EventTraceHelper => null;
+            public override EventTraceHelper EventTraceHelper => this.info.Partition.EventTraceHelper;
 
-            public override EventTraceHelper EventDetailTracer => null;
+            public override EventTraceHelper EventDetailTracer => this.info.Partition.EventDetailTracer;
 
             public override uint PartitionId => this.info.Partition.PartitionId;
 

--- a/src/DurableTask.Netherite/Tracing/EtwSource.cs
+++ b/src/DurableTask.Netherite/Tracing/EtwSource.cs
@@ -250,11 +250,11 @@ namespace DurableTask.Netherite
             this.WriteEvent(245, Account, TaskHub, PartitionId, PartitionEventId, ReportedLocalLoad, Pending, Backlog, Remotes, Distribution, AppName, ExtensionVersion);
         }
 
-        [Event(246, Level = EventLevel.Informational, Version = 1)]
-        public void PartitionLoadPublished(string Account, string TaskHub, int PartitionId, int WorkItems, int Activities, int Timers, int Requests, int Outbox, string NextTimer, string WorkerId, string LatencyTrend, double MissRate, long InputQueuePosition, long CommitLogPosition, string AppName, string ExtensionVersion)
+        [Event(246, Level = EventLevel.Informational, Version = 2)]
+        public void PartitionLoadPublished(string Account, string TaskHub, int PartitionId, int WorkItems, int Activities, int Timers, int Requests, int Outbox, long Instances, string NextTimer, string WorkerId, string LatencyTrend, double MissRate, long InputQueuePosition, long CommitLogPosition, string AppName, string ExtensionVersion)
         {
             SetCurrentThreadActivityId(serviceInstanceId);
-            this.WriteEvent(246, Account, TaskHub, PartitionId, WorkItems, Activities, Timers, Requests, Outbox, NextTimer, WorkerId, LatencyTrend, MissRate, InputQueuePosition, CommitLogPosition, AppName, ExtensionVersion);
+            this.WriteEvent(246, Account, TaskHub, PartitionId, WorkItems, Activities, Timers, Requests, Outbox, Instances, NextTimer, WorkerId, LatencyTrend, MissRate, InputQueuePosition, CommitLogPosition, AppName, ExtensionVersion);
         }
 
         [Event(247, Level = EventLevel.Verbose, Version = 2)]

--- a/src/DurableTask.Netherite/Tracing/PartitionTraceHelper.cs
+++ b/src/DurableTask.Netherite/Tracing/PartitionTraceHelper.cs
@@ -44,10 +44,10 @@ namespace DurableTask.Netherite
         {
             if (this.logLevelLimit <= LogLevel.Information)
             {
-                this.logger.LogInformation("Part{partition:D2} Publishing LoadInfo WorkItems={workItems} Activities={activities} Timers={timers} Requests={requests} Outbox={outbox} Wakeup={wakeup} WorkerId={workerId} LatencyTrend={latencyTrend} MissRate={missRate} InputQueuePosition={inputQueuePosition} CommitLogPosition={commitLogPosition}",
-                    this.partitionId, info.WorkItems, info.Activities, info.Timers, info.Requests, info.Outbox, info.Wakeup, info.WorkerId, info.LatencyTrend, info.MissRate, info.InputQueuePosition, info.CommitLogPosition);
+                this.logger.LogInformation("Part{partition:D2} Publishing LoadInfo WorkItems={workItems} Activities={activities} Timers={timers} Requests={requests} Outbox={outbox} Instances={instances} Wakeup={wakeup} WorkerId={workerId} LatencyTrend={latencyTrend} MissRate={missRate} InputQueuePosition={inputQueuePosition} CommitLogPosition={commitLogPosition}",
+                    this.partitionId, info.WorkItems, info.Activities, info.Timers, info.Requests, info.Outbox, info.Instances, info.Wakeup, info.WorkerId, info.LatencyTrend, info.MissRate, info.InputQueuePosition, info.CommitLogPosition);
 
-                EtwSource.Log.PartitionLoadPublished(this.account, this.taskHub, this.partitionId, info.WorkItems, info.Activities, info.Timers, info.Requests, info.Outbox, info.Wakeup?.ToString("o") ?? "", info.WorkerId, info.LatencyTrend, info.MissRate, info.InputQueuePosition, info.CommitLogPosition, TraceUtils.AppName, TraceUtils.ExtensionVersion);
+                EtwSource.Log.PartitionLoadPublished(this.account, this.taskHub, this.partitionId, info.WorkItems, info.Activities, info.Timers, info.Requests, info.Outbox, info.Instances, info.Wakeup?.ToString("o") ?? "", info.WorkerId, info.LatencyTrend, info.MissRate, info.InputQueuePosition, info.CommitLogPosition, TraceUtils.AppName, TraceUtils.ExtensionVersion);
             }
         }
 


### PR DESCRIPTION
Add a stats object that tracks the number of instances present in a partition.
This will be used for determining compaction need.
This is also published in the load table.