### PR TITLE
Fix concurrency bug in outbox

### DIFF
--- a/src/DurableTask.Netherite/PartitionState/OutboxState.cs
+++ b/src/DurableTask.Netherite/PartitionState/OutboxState.cs
@@ -146,7 +146,9 @@ namespace DurableTask.Netherite
                     }
                 }
 
-                if (++this.numAcks == this.OutgoingMessages.Count + this.OutgoingResponses.Count)
+                int currentAckCount = Interlocked.Increment(ref this.numAcks);
+
+                if (currentAckCount == this.OutgoingMessages.Count + this.OutgoingResponses.Count)
                 {
                     this.Partition.SubmitEvent(new SendConfirmed()
                     {


### PR DESCRIPTION
This caused messages to sometimes not be confirmed as persisted, and thus hang around in the outbox even after they were successfully sent.