### PR TITLE
add more target frameworks

### DIFF
--- a/src/DurableTask.Netherite.AzureFunctions/BlobLogger.cs
+++ b/src/DurableTask.Netherite.AzureFunctions/BlobLogger.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#if !NETCOREAPP2_2
 namespace DurableTask.Netherite.AzureFunctions
 {
     using System;
@@ -100,3 +101,4 @@ namespace DurableTask.Netherite.AzureFunctions
         }
     }
 }
+#endif

--- a/src/DurableTask.Netherite.AzureFunctions/DurableTask.Netherite.AzureFunctions.csproj
+++ b/src/DurableTask.Netherite.AzureFunctions/DurableTask.Netherite.AzureFunctions.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
+	<!--The target netcoreapp2.2 is not functional, but just generates runtime error when used.-->
+    <TargetFrameworks>netstandard2.1;netstandard2.0;netcoreapp2.2;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
@@ -43,8 +44,8 @@
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\DurableTask.Netherite\DurableTask.Netherite.csproj" />
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp2.2' ">
+	<ProjectReference Include="..\DurableTask.Netherite\DurableTask.Netherite.csproj" />
   </ItemGroup>
-  
+	
 </Project>

--- a/src/DurableTask.Netherite.AzureFunctions/LoggerFactoryWrapper.cs
+++ b/src/DurableTask.Netherite.AzureFunctions/LoggerFactoryWrapper.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#if !NETCOREAPP2_2
 namespace DurableTask.Netherite.AzureFunctions
 {
     using System;
@@ -88,7 +89,6 @@ namespace DurableTask.Netherite.AzureFunctions
                 }
             }
         }
-
     }
-
 }
+#endif

--- a/src/DurableTask.Netherite.AzureFunctions/NetheriteProvider.cs
+++ b/src/DurableTask.Netherite.AzureFunctions/NetheriteProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#if !NETCOREAPP2_2
 namespace DurableTask.Netherite.AzureFunctions
 {
     using System;
@@ -241,3 +242,4 @@ namespace DurableTask.Netherite.AzureFunctions
         }
     }
 }
+#endif

--- a/src/DurableTask.Netherite.AzureFunctions/NetheriteProviderFactory.cs
+++ b/src/DurableTask.Netherite.AzureFunctions/NetheriteProviderFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#if !NETCOREAPP2_2
 namespace DurableTask.Netherite.AzureFunctions
 {
     using System;
@@ -226,3 +227,4 @@ namespace DurableTask.Netherite.AzureFunctions
         }
     }
 }
+#endif

--- a/src/DurableTask.Netherite.AzureFunctions/NetheriteProviderPseudoFactory.cs
+++ b/src/DurableTask.Netherite.AzureFunctions/NetheriteProviderPseudoFactory.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace DurableTask.Netherite.AzureFunctions
+{
+    using System;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+    using Microsoft.Azure.WebJobs.Host.Executors;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Options;
+
+    public class NetheriteProviderPseudoFactory : IDurabilityProviderFactory
+    { 
+        public const string ProviderName = "Netherite";
+        public string Name => ProviderName;
+
+        // Called by the Azure Functions runtime dependency injection infrastructure
+        public NetheriteProviderPseudoFactory(
+            IOptions<DurableTaskOptions> extensionOptions,
+            ILoggerFactory loggerFactory,
+            IConnectionStringResolver connectionStringResolver,
+            IHostIdProvider hostIdProvider,
+            INameResolver nameResolver,
+#pragma warning disable CS0612 // Type or member is obsolete
+            IPlatformInformation platformInfo)
+#pragma warning restore CS0612 // Type or member is obsolete
+        {
+        }
+
+        /// <inheritdoc/>
+        public DurabilityProvider GetDurabilityProvider()
+        {
+            throw new Exception("The Netherite storage provider is not supported on netcoreapp2. Please use netcoreapp3.1 or later.");
+        }
+
+        // Called by the Durable client binding infrastructure
+        public DurabilityProvider GetDurabilityProvider(DurableClientAttribute attribute)
+        {
+            throw new Exception("The Netherite storage provider is not supported on netcoreapp2. Please use netcoreapp3.1 or later.");
+        }
+    }
+}

--- a/src/DurableTask.Netherite.AzureFunctions/NetheriteProviderStartup.cs
+++ b/src/DurableTask.Netherite.AzureFunctions/NetheriteProviderStartup.cs
@@ -16,7 +16,11 @@ namespace DurableTask.Netherite.AzureFunctions
     {
         public override void Configure(IFunctionsHostBuilder builder)
         {
+#if !NETCOREAPP2_2
             builder.Services.AddSingleton<IDurabilityProviderFactory, NetheriteProviderFactory>();
+#else
+            builder.Services.AddSingleton<IDurabilityProviderFactory, NetheriteProviderPseudoFactory>();
+#endif
         }
     }
 }

--- a/src/DurableTask.Netherite/DurableTask.Netherite.csproj
+++ b/src/DurableTask.Netherite/DurableTask.Netherite.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
@@ -117,8 +117,9 @@ namespace DurableTask.Netherite
 
                 if (this.configuredStorage == TransportConnectionString.StorageChoices.Faster)
                 {
-                    // force dll load here so exceptions are observed early
-                    var _ = System.Threading.Channels.Channel.CreateBounded<DateTime>(10);
+                    // force the loading of potentially problematic dll dependencies here so exceptions are observed early
+                    var _a = System.Threading.Channels.Channel.CreateBounded<DateTime>(10);
+                    bool _c = System.Runtime.CompilerServices.Unsafe.AreSame(ref _a, ref _a);
 
                     // throw descriptive exception if run on 32bit platform
                     if (!Environment.Is64BitProcess)


### PR DESCRIPTION
This PR adds more target frameworks to the build, including a special dummy netcoreapp2.2. target that generates a runtime error message when used.

This is intended as a workaround to the legacy bundles build which requires a netcoreapp2 target.