### PR TITLE
Fix/Improve tracing of workitems, partition activity, and compaction

### DIFF
--- a/src/DurableTask.Netherite/Abstractions/PartitionState/EffectTracker.cs
+++ b/src/DurableTask.Netherite/Abstractions/PartitionState/EffectTracker.cs
@@ -84,7 +84,7 @@ namespace DurableTask.Netherite
             {
                 // for robustness, we swallow exceptions inside event processing.
                 // It does not mean they are not serious. We still report them as errors.
-                this.HandleError(nameof(ProcessUpdate), $"Encountered exception on {trackedObject} when applying update event {this.currentUpdate}, eventId={this.currentUpdate?.EventId}", exception, false, false);
+                this.HandleError(nameof(ProcessUpdate), $"Encountered exception on {trackedObject} when applying update event {this.currentUpdate} eventId={this.currentUpdate?.EventId}", exception, false, false);
             }
         }
 
@@ -153,7 +153,7 @@ namespace DurableTask.Netherite
                 {
                     // for robustness, we swallow exceptions inside event processing.
                     // It does not mean they are not serious. We still report them as errors.
-                    this.HandleError(nameof(ProcessUpdate), $"Encountered exception while processing update event {updateEvent}", exception, false, false);
+                    this.HandleError(nameof(ProcessUpdate), $"Encountered exception while processing update event {updateEvent} eventId={updateEvent?.EventId}", exception, false, false);
                 }
                 finally
                 {
@@ -190,7 +190,7 @@ namespace DurableTask.Netherite
                             string historyExecutionId = historyState?.ExecutionId;
                             int eventCount = historyState?.History?.Count ?? 0;
                             int episode = historyState?.Episode ?? 0;
-                            this.EventTraceHelper?.TraceFetchedInstanceHistory(readEvent, key.InstanceId, historyExecutionId, eventCount, episode, startedTimestamp - readEvent.IssuedTimestamp);
+                            this.EventTraceHelper?.TraceFetchedInstanceHistory(readEvent, key.InstanceId, historyExecutionId, eventCount, episode, historyState?.HistorySize ?? 0, startedTimestamp - readEvent.IssuedTimestamp);
                             break;
 
                         default:
@@ -212,7 +212,7 @@ namespace DurableTask.Netherite
                 {
                     // for robustness, we swallow exceptions inside event processing.
                     // It does not mean they are not serious. We still report them as errors.
-                    this.HandleError(nameof(ProcessReadResult), $"Encountered exception while processing read event {readEvent}", exception, false, false);
+                    this.HandleError(nameof(ProcessReadResult), $"Encountered exception while processing read event {readEvent} eventId={readEvent?.EventId}", exception, false, false);
                 }
                 finally
                 {
@@ -243,7 +243,7 @@ namespace DurableTask.Netherite
                 {
                     // for robustness, we swallow exceptions inside event processing.
                     // It does not mean they are not serious. We still report them as errors.
-                    this.HandleError(nameof(ProcessQueryResultAsync), $"Encountered exception while processing query event {queryEvent}", exception, false, false);
+                    this.HandleError(nameof(ProcessQueryResultAsync), $"Encountered exception while processing query event {queryEvent} eventId={queryEvent?.EventId}", exception, false, false);
                 }
                 finally
                 {

--- a/src/DurableTask.Netherite/Events/PartitionEvents/External/FromLoadMonitor/AcksReceived.cs
+++ b/src/DurableTask.Netherite/Events/PartitionEvents/External/FromLoadMonitor/AcksReceived.cs
@@ -27,6 +27,9 @@ namespace DurableTask.Netherite
             effects.Add(TrackedObjectKey.Outbox);
         }
 
+        [IgnoreDataMember]
+        public override bool CountsAsPartitionActivity => false;
+
         public override void ApplyTo(TrackedObject trackedObject, EffectTracker effects)
         {
             trackedObject.Process(this, effects);

--- a/src/DurableTask.Netherite/Events/PartitionEvents/External/FromLoadMonitor/SolicitationReceived.cs
+++ b/src/DurableTask.Netherite/Events/PartitionEvents/External/FromLoadMonitor/SolicitationReceived.cs
@@ -26,6 +26,9 @@ namespace DurableTask.Netherite
             effects.Add(TrackedObjectKey.Activities);
         }
 
+        [IgnoreDataMember]
+        public override bool CountsAsPartitionActivity => false;
+        
         public override void ApplyTo(TrackedObject trackedObject, EffectTracker effects)
         {
             trackedObject.Process(this, effects);

--- a/src/DurableTask.Netherite/Events/PartitionEvents/Internal/OffloadDecision.cs
+++ b/src/DurableTask.Netherite/Events/PartitionEvents/Internal/OffloadDecision.cs
@@ -28,6 +28,9 @@ namespace DurableTask.Netherite
             effects.Add(TrackedObjectKey.Activities);
         }
 
+        [IgnoreDataMember]
+        public override bool CountsAsPartitionActivity => false;
+
         public override void ApplyTo(TrackedObject trackedObject, EffectTracker effects)
         {
             trackedObject.Process(this, effects);

--- a/src/DurableTask.Netherite/Events/PartitionEvents/Internal/RecoveryCompleted.cs
+++ b/src/DurableTask.Netherite/Events/PartitionEvents/Internal/RecoveryCompleted.cs
@@ -45,6 +45,9 @@ namespace DurableTask.Netherite
             }
         }
 
+        [IgnoreDataMember]
+        public override bool CountsAsPartitionActivity => false;
+
         public override void OnSubmit(Partition partition)
         {
             partition.EventTraceHelper.TraceEventProcessingDetail($"Submitted {this}");

--- a/src/DurableTask.Netherite/Events/PartitionEvents/PartitionEvent.cs
+++ b/src/DurableTask.Netherite/Events/PartitionEvents/PartitionEvent.cs
@@ -32,7 +32,10 @@ namespace DurableTask.Netherite
 
         [IgnoreDataMember]
         public virtual bool ResetInputQueue => false;
-        
+
+        [IgnoreDataMember]
+        public virtual bool CountsAsPartitionActivity => true;
+
         /// <summary>
         /// For tracing purposes. Subclasses can override this to provide the instance id.
         /// </summary>

--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
@@ -883,7 +883,7 @@ namespace DurableTask.Netherite
             var originalHistory = orchestrationWorkItem.OrchestrationRuntimeState.Events.Take(originalHistorySize).ToList();
             var newWorkItem = new OrchestrationWorkItem(orchestrationWorkItem.Partition, orchestrationWorkItem.MessageBatch, originalHistory, originalCustomStatus);
             newWorkItem.Type = OrchestrationWorkItem.ExecutionType.ContinueFromHistory;
-            newWorkItem.HistorySize = originalHistory.Count;
+            newWorkItem.EventCount = originalHistory.Count;
 
             orchestrationWorkItem.Partition.EnqueueOrchestrationWorkItem(newWorkItem);
 

--- a/src/DurableTask.Netherite/OrchestrationService/OrchestrationMessageBatch.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/OrchestrationMessageBatch.cs
@@ -87,7 +87,7 @@ namespace DurableTask.Netherite
                 // we either have no previous instance, or want to replace the previous instance
                 this.workItem = new OrchestrationWorkItem(partition, this, previousHistory: null, customStatus: null);
                 this.workItem.Type = OrchestrationWorkItem.ExecutionType.Fresh;
-                this.workItem.HistorySize = 0;
+                this.workItem.EventCount = 0;
             }
             else if (historyState.CachedOrchestrationWorkItem != null)
             {
@@ -95,11 +95,11 @@ namespace DurableTask.Netherite
                 this.workItem = historyState.CachedOrchestrationWorkItem;
                 this.workItem.SetNextMessageBatch(this);
                 this.workItem.Type = OrchestrationWorkItem.ExecutionType.ContinueFromCursor;
-                this.workItem.HistorySize = this.workItem.OrchestrationRuntimeState?.Events?.Count ?? 0;
+                this.workItem.EventCount = this.workItem.OrchestrationRuntimeState?.Events?.Count ?? 0;
 
                 // sanity check: it appears cursor is sometimes corrupted, in that case, construct fresh
                 // TODO investigate reasons and fix root cause
-                if (this.workItem.HistorySize != historyState.History?.Count
+                if (this.workItem.EventCount != historyState.History?.Count
                     || this.workItem.OrchestrationRuntimeState?.OrchestrationInstance?.ExecutionId != historyState.ExecutionId)
                 {
                     partition.EventTraceHelper.TraceEventProcessingWarning($"Fixing bad workitem cache instance={this.InstanceId} batch={this.WorkItemId} expected_size={historyState.History?.Count} actual_size={this.workItem.OrchestrationRuntimeState?.Events?.Count} expected_executionid={historyState.ExecutionId} actual_executionid={this.workItem.OrchestrationRuntimeState?.OrchestrationInstance?.ExecutionId}");
@@ -107,7 +107,7 @@ namespace DurableTask.Netherite
                     // we create a new work item and rehydrate the instance from its history
                     this.workItem = new OrchestrationWorkItem(partition, this, previousHistory: historyState.History, historyState.CustomStatus);
                     this.workItem.Type = OrchestrationWorkItem.ExecutionType.ContinueFromHistory;
-                    this.workItem.HistorySize = historyState.History?.Count ?? 0;
+                    this.workItem.EventCount = historyState.History?.Count ?? 0;
                 }
             }
             else
@@ -115,7 +115,7 @@ namespace DurableTask.Netherite
                 // we have to rehydrate the instance from its history
                 this.workItem = new OrchestrationWorkItem(partition, this, previousHistory: historyState.History, historyState.CustomStatus);
                 this.workItem.Type = OrchestrationWorkItem.ExecutionType.ContinueFromHistory;
-                this.workItem.HistorySize = historyState.History?.Count ?? 0;
+                this.workItem.EventCount = historyState.History?.Count ?? 0;
             }
 
             if (!this.IsExecutableInstance(this.workItem, out var reason))

--- a/src/DurableTask.Netherite/OrchestrationService/OrchestrationWorkItem.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/OrchestrationWorkItem.cs
@@ -22,7 +22,7 @@ namespace DurableTask.Netherite
 
         public enum ExecutionType { Fresh, ContinueFromHistory, ContinueFromCursor };
 
-        public int HistorySize;
+        public int EventCount;
 
         public List<string> NewMessagesOrigin { get; set; }
 

--- a/src/DurableTask.Netherite/OrchestrationService/Partition.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/Partition.cs
@@ -317,7 +317,7 @@ namespace DurableTask.Netherite
                 item.MessageBatch.WorkItemId,
                 item.InstanceId,
                 item.Type.ToString(),
-                item.HistorySize,
+                item.EventCount,
                 WorkItemTraceHelper.FormatMessageIdList(item.MessageBatch.TracedMessages));
 
             this.OrchestrationWorkItemQueue.Add(item);

--- a/src/DurableTask.Netherite/StorageProviders/Faster/FasterKV.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/FasterKV.cs
@@ -125,11 +125,11 @@ namespace DurableTask.Netherite.Faster
             }
         }
 
-        long GetElapsedCompactionMilliseconds()
+        double GetElapsedCompactionMilliseconds()
         {
-            long elapsed = this.compactionStopwatch.ElapsedMilliseconds;
+            double elapsedMs = this.compactionStopwatch.Elapsed.TotalMilliseconds;
             this.compactionStopwatch.Restart();
-            return elapsed;
+            return elapsedMs;
         }
 
         ClientSession<Key, Value, EffectTracker, Output, object, IFunctions<Key, Value, EffectTracker, Output, object>> CreateASession(string id, bool isScan)
@@ -439,7 +439,9 @@ namespace DurableTask.Netherite.Faster
 
                             this.TraceHelper.FasterCompactionProgress(
                                 FasterTraceHelper.CompactionProgress.Completed,
-                                id, compactedUntil, this.Log.SafeReadOnlyAddress,
+                                id, 
+                                compactedUntil, 
+                                this.Log.SafeReadOnlyAddress,
                                 this.Log.TailAddress,
                                 this.MinimalLogSize,
                                 this.Log.BeginAddress - beginAddressBeforeCompaction,

--- a/src/DurableTask.Netherite/StorageProviders/Faster/FasterTraceHelper.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/FasterTraceHelper.cs
@@ -140,7 +140,7 @@ namespace DurableTask.Netherite.Faster
 
         public enum CompactionProgress { Skipped, Started, Completed };
 
-        public void FasterCompactionProgress(CompactionProgress progress, string operation, long begin, long safeReadOnly, long tail, long minimalSize, long compactionAreaSize, long elapsedMs)
+        public void FasterCompactionProgress(CompactionProgress progress, string operation, long begin, long safeReadOnly, long tail, long minimalSize, long compactionAreaSize, double elapsedMs)
         {
             if (this.logLevelLimit <= LogLevel.Information)
             {

--- a/src/DurableTask.Netherite/Tracing/EtwSource.cs
+++ b/src/DurableTask.Netherite/Tracing/EtwSource.cs
@@ -378,11 +378,11 @@ namespace DurableTask.Netherite
             this.WriteEvent(267, Account, TaskHub, PartitionId, Details, AppName, ExtensionVersion);
         }
 
-        [Event(268, Level = EventLevel.Informational, Version = 1)]
-        public void FasterCompactionProgress(string Account, string TaskHub, int PartitionId, string Details, string Operation, long Begin, long SafeReadOnly, long Tail, long MinimalSize, long CompactionAreaSize, long ElapsedMs, string AppName, string ExtensionVersion)
+        [Event(268, Level = EventLevel.Informational, Version = 3)]
+        public void FasterCompactionProgress(string Account, string TaskHub, int PartitionId, string Details, string Operation, long LogBegin, long LogSafeReadOnly, long LogTail, long MinimalSize, long CompactionAreaSize, double ElapsedMs, string AppName, string ExtensionVersion)
         {
             SetCurrentThreadActivityId(serviceInstanceId);
-            this.WriteEvent(266, Account, TaskHub, PartitionId, Details, Operation, Begin, SafeReadOnly, Tail, MinimalSize, CompactionAreaSize, ElapsedMs, AppName, ExtensionVersion);
+            this.WriteEvent(268, Account, TaskHub, PartitionId, Details, Operation, LogBegin, LogSafeReadOnly, LogTail, MinimalSize, CompactionAreaSize, ElapsedMs, AppName, ExtensionVersion);
         }
 
         // ----- EventHubs Transport

--- a/src/DurableTask.Netherite/Tracing/EtwSource.cs
+++ b/src/DurableTask.Netherite/Tracing/EtwSource.cs
@@ -157,11 +157,11 @@ namespace DurableTask.Netherite
             this.WriteEvent(222, Account, TaskHub, PartitionId, MessageId, Details, EventType, TaskEventId, InstanceId, ExecutionId, AppName, ExtensionVersion);
         }
 
-        [Event(223, Level = EventLevel.Verbose, Version = 2)]
-        public void WorkItemQueued(string Account, string TaskHub, int PartitionId, string WorkItemType, string WorkItemId, string InstanceId, string ExecutionType, int historySize, string ConsumedMessageIds, string AppName, string ExtensionVersion)
+        [Event(223, Level = EventLevel.Verbose, Version = 3)]
+        public void WorkItemQueued(string Account, string TaskHub, int PartitionId, string WorkItemType, string WorkItemId, string InstanceId, string ExecutionType, int EventCount, string ConsumedMessageIds, string AppName, string ExtensionVersion)
         {
             SetCurrentThreadActivityId(serviceInstanceId);
-            this.WriteEvent(223, Account, TaskHub, PartitionId, WorkItemType, WorkItemId, InstanceId, ExecutionType, historySize, ConsumedMessageIds, AppName, ExtensionVersion);
+            this.WriteEvent(223, Account, TaskHub, PartitionId, WorkItemType, WorkItemId, InstanceId, ExecutionType, EventCount, ConsumedMessageIds, AppName, ExtensionVersion);
         }
 
         [Event(224, Level = EventLevel.Informational, Version = 1)]
@@ -199,11 +199,11 @@ namespace DurableTask.Netherite
             this.WriteEvent(228, Account, TaskHub, PartitionId, InstanceId, ExecutionId, RuntimeStatus, PartitionEventId, ElapsedMs, AppName, ExtensionVersion);
         }
 
-        [Event(229, Level = EventLevel.Verbose, Version = 2)]
-        public void InstanceHistoryFetched(string Account, string TaskHub, int PartitionId, string InstanceId, string ExecutionId, int EventCount, int Episode, string PartitionEventId, double ElapsedMs, string AppName, string ExtensionVersion)
+        [Event(229, Level = EventLevel.Verbose, Version = 3)]
+        public void InstanceHistoryFetched(string Account, string TaskHub, int PartitionId, string InstanceId, string ExecutionId, int EventCount, int Episode, long HistorySize, string PartitionEventId, double ElapsedMs, string AppName, string ExtensionVersion)
         {
             SetCurrentThreadActivityId(serviceInstanceId);
-            this.WriteEvent(229, Account, TaskHub, PartitionId, InstanceId, ExecutionId, EventCount, Episode, PartitionEventId, ElapsedMs, AppName, ExtensionVersion);
+            this.WriteEvent(229, Account, TaskHub, PartitionId, InstanceId, ExecutionId, EventCount, Episode, HistorySize, PartitionEventId, ElapsedMs, AppName, ExtensionVersion);
         }
 
         // ----- general event processing and statistics

--- a/src/DurableTask.Netherite/Tracing/EventTraceHelper.cs
+++ b/src/DurableTask.Netherite/Tracing/EventTraceHelper.cs
@@ -146,7 +146,7 @@ namespace DurableTask.Netherite
             }
         }
 
-        public void TraceFetchedInstanceHistory(PartitionReadEvent evt, string instanceId, string executionId, int eventCount, int episode, double latencyMs)
+        public void TraceFetchedInstanceHistory(PartitionReadEvent evt, string instanceId, string executionId, int eventCount, int episode, long historySize, double latencyMs)
         {
             if (this.logLevelLimit <= LogLevel.Debug)
             {
@@ -155,11 +155,11 @@ namespace DurableTask.Netherite
                     (long commitLogPosition, string eventId) = EventTraceContext.Current;
 
                     string prefix = commitLogPosition > 0 ? $".{commitLogPosition:D10}   " : "";
-                    this.logger.LogDebug("Part{partition:D2}{prefix} Fetched instance history instanceId={instanceId} executionId={executionId} eventCount={eventCount} episode={episode} eventId={eventId} latencyMs={latencyMs:F0}",
-                        this.partitionId, prefix, instanceId, executionId, eventCount, episode, evt.EventIdString, latencyMs);
+                    this.logger.LogDebug("Part{partition:D2}{prefix} Fetched instance history instanceId={instanceId} executionId={executionId} eventCount={eventCount} episode={episode} historySize={historySize} eventId={eventId} latencyMs={latencyMs:F0}",
+                        this.partitionId, prefix, instanceId, executionId, eventCount, episode, historySize, evt.EventIdString, latencyMs);
                 }
 
-                this.etw?.InstanceHistoryFetched(this.account, this.taskHub, this.partitionId, instanceId, executionId ?? string.Empty, eventCount, episode, evt.EventIdString, latencyMs, TraceUtils.AppName, TraceUtils.ExtensionVersion);
+                this.etw?.InstanceHistoryFetched(this.account, this.taskHub, this.partitionId, instanceId, executionId ?? string.Empty, eventCount, episode, historySize, evt.EventIdString, latencyMs, TraceUtils.AppName, TraceUtils.ExtensionVersion);
             }
         }
 

--- a/src/DurableTask.Netherite/Tracing/WorkItemTraceHelper.cs
+++ b/src/DurableTask.Netherite/Tracing/WorkItemTraceHelper.cs
@@ -82,17 +82,17 @@ namespace DurableTask.Netherite
             this.etw = EtwSource.Log.IsEnabled() ? EtwSource.Log : null;
         }
 
-        public void TraceWorkItemQueued(uint partitionId, WorkItemType workItemType, string workItemId, string instanceId, string executionType, int historySize, string consumedMessageIds)
+        public void TraceWorkItemQueued(uint partitionId, WorkItemType workItemType, string workItemId, string instanceId, string executionType, int eventCount, string consumedMessageIds)
         {
             if (this.logLevelLimit <= LogLevel.Debug)
             {
                 if (this.logger.IsEnabled(LogLevel.Debug))
                 {
-                    this.logger.LogDebug("Part{partition:D2} queued {workItemType}WorkItem {workItemId} instanceId={instanceId} executionType={executionType} historySize={historySize} consumedMessageIds={consumedMessageIds}",
-                        partitionId, workItemType, workItemId, instanceId, executionType, historySize, consumedMessageIds);
+                    this.logger.LogDebug("Part{partition:D2} queued {workItemType}WorkItem {workItemId} instanceId={instanceId} executionType={executionType} eventCount={eventCount} consumedMessageIds={consumedMessageIds}",
+                        partitionId, workItemType, workItemId, instanceId, executionType, eventCount, consumedMessageIds);
                 }
 
-                this.etw?.WorkItemQueued(this.StorageAccountName, this.taskHub, (int)partitionId, workItemType.ToString(), workItemId, instanceId, executionType, historySize, consumedMessageIds, TraceUtils.AppName, TraceUtils.ExtensionVersion);
+                this.etw?.WorkItemQueued(this.StorageAccountName, this.taskHub, (int)partitionId, workItemType.ToString(), workItemId, instanceId, executionType, eventCount, consumedMessageIds, TraceUtils.AppName, TraceUtils.ExtensionVersion);
             }
         }
 


### PR DESCRIPTION
Three changes in this PR:
- Partitions now appear idle if the messages they process are not considered work, e.g. loadmonitor interactions or recovery events.
- Compaction ETW tracing was broken due to typo. Now fixed.
- Work item tracing is now more uniform.