### PR TITLE
Suppress warning for netcoreapp2.2

### DIFF
--- a/src/DurableTask.Netherite.AzureFunctions/DurableTask.Netherite.AzureFunctions.csproj
+++ b/src/DurableTask.Netherite.AzureFunctions/DurableTask.Netherite.AzureFunctions.csproj
@@ -33,6 +33,11 @@
     <BuildSuffix Condition="'$(GITHUB_RUN_NUMBER)' != ''">.$(GITHUB_RUN_NUMBER)</BuildSuffix>
     <FileVersion>$(VersionPrefix)$(BuildSuffix)</FileVersion>
   </PropertyGroup>
+
+  <!-- Our netcoreapp2.2 target is a non-functional dummy target, so we don't need the warning -->
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.2' ">
+	<NoWarn>NETSDK1138</NoWarn>
+  </PropertyGroup>
   
   <ItemGroup>
     <None Include="icon.png" Pack="true" PackagePath="\" />


### PR DESCRIPTION
This warning is superfluous because we are not actually building a useable library, just a stub that creates an error message at runtime when used.