### PR TITLE
fix suppression of load publishing

### DIFF
--- a/src/DurableTask.Netherite/StorageProviders/Faster/FasterKV.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/FasterKV.cs
@@ -105,7 +105,14 @@ namespace DurableTask.Netherite.Faster
                 }
 
                 this.TraceHelper.FasterProgress("Disposing Main Session");
-                this.mainSession?.Dispose();
+                try
+                {
+                    this.mainSession?.Dispose();
+                }
+                catch(OperationCanceledException)
+                {
+                    // can happen during shutdown
+                }
 
                 this.TraceHelper.FasterProgress("Disposing FasterKV");
                 this.fht.Dispose();


### PR DESCRIPTION
Fixes a bug in the load publishing which meant that the load keeps being published even if there are no changes.

Also, handle cancellation during shutdown to avoid generating errors in the log.