### PR TITLE
Fix empty batch in outbox

### DIFF
--- a/src/DurableTask.Netherite/StorageProviders/Faster/FasterKV.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/FasterKV.cs
@@ -105,7 +105,14 @@ namespace DurableTask.Netherite.Faster
                 }
 
                 this.TraceHelper.FasterProgress("Disposing Main Session");
-                this.mainSession?.Dispose();
+                try
+                {
+                    this.mainSession?.Dispose();
+                }
+                catch(OperationCanceledException)
+                {
+                    // can happen during shutdown
+                }
 
                 this.TraceHelper.FasterProgress("Disposing FasterKV");
                 this.fht.Dispose();


### PR DESCRIPTION
Fixes a bug in a condition that was creating a batch in the outbox with no messages in it, which would then hang around forever because it could not get confirmed.