### PR TITLE
improve lease management

### DIFF
--- a/src/DurableTask.Netherite/StorageProviders/Faster/AzureBlobs/AzureStorageDevice.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/AzureBlobs/AzureStorageDevice.cs
@@ -104,16 +104,11 @@ namespace DurableTask.Netherite.Faster
                 BlobContinuationToken continuationToken = null;
                 do
                 {
-                    if (this.underLease)
-                    {
-                        await this.BlobManager.ConfirmLeaseIsGoodForAWhileAsync();
-                    }
-
                     BlobResultSegment response = null;
 
                     await this.BlobManager.PerformWithRetriesAsync(
                         BlobManager.AsynchronousStorageReadMaxConcurrency,
-                        true,
+                        this.underLease,
                         "PageBlobDirectory.ListBlobsSegmentedAsync",
                         "RecoverDevice",
                         $"continuationToken={continuationToken}",


### PR DESCRIPTION
Makes several fixes to the lease management to improve behavior in high-churn situations.

- When shutting down a partition cleanly, release the lease even if there is an error present, by waiting for lease-using accesses to complete.
- catch exceptions in a cancellation scenario without generating excessive tracing for them