### PR TITLE
Generalize placement specifications for instances

### DIFF
--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
@@ -517,12 +517,14 @@ namespace DurableTask.Netherite
         /// <returns>The partition id.</returns>
         public uint GetPartitionId(string instanceId)
         {
+            int placementSeparatorPosition = instanceId.LastIndexOf('!');
+
             // if the instance id ends with !nn, where nn is a two-digit number, it indicates explicit partition placement
-            if (instanceId.Length >= 3 
-                && instanceId[instanceId.Length - 3] == '!'
-                && uint.TryParse(instanceId.Substring(instanceId.Length - 2), out uint nn))
+            if (placementSeparatorPosition != -1 
+                && placementSeparatorPosition <= instanceId.Length - 2
+                && uint.TryParse(instanceId.Substring(placementSeparatorPosition + 1), out uint index))
             {
-                var partitionId = nn % this.NumberPartitions;
+                var partitionId = index % this.NumberPartitions;
                 //this.Logger.LogTrace($"Instance: {instanceId} was explicitly placed on partition: {partitionId}");
                 return partitionId;
             }

--- a/test/PerformanceTests/Benchmarks/CollisionSearch/DivideAndConquerSearch.cs
+++ b/test/PerformanceTests/Benchmarks/CollisionSearch/DivideAndConquerSearch.cs
@@ -43,7 +43,7 @@ namespace PerformanceTests.CollisionSearch
                 {
                     subOrchestratorTasks[i] = context.CallSubOrchestratorAsync<List<long>>(
                         nameof(DivideAndConquerSearch),
-                        // $"{context.InstanceId}!{i:D2}",
+                        // $"{context.InstanceId}!{i}",
                         new IntervalSearchParameters()
                         {
                             Target = input.Target,

--- a/test/PerformanceTests/Benchmarks/Counter/HttpTriggers.cs
+++ b/test/PerformanceTests/Benchmarks/Counter/HttpTriggers.cs
@@ -123,7 +123,7 @@ namespace PerformanceTests.Orchestrations.Counter
                 int numberSignals = int.Parse(input.Substring(0, commaPosition));
                 int numberEntities = int.Parse(input.Substring(commaPosition + 1));
                 var entityPrefix = Guid.NewGuid().ToString("N");
-                EntityId MakeEntityId(int i) => new EntityId("Counter", $"{entityPrefix}-{i/100:D6}!{i%100:D2}");
+                EntityId MakeEntityId(int i) => new EntityId("Counter", $"{entityPrefix}-!{i:D6}");
                 DateTime startTime = DateTime.UtcNow;
 
                 if (numberSignals % numberEntities != 0)

--- a/test/PerformanceTests/Benchmarks/WordCount/Mapper.cs
+++ b/test/PerformanceTests/Benchmarks/WordCount/Mapper.cs
@@ -28,7 +28,7 @@ namespace PerformanceTests.WordCount
 
         public static EntityId GetEntityId(int number)
         {
-            return new EntityId(nameof(Mapper), $"{number}!{number % 100:D2}");
+            return new EntityId(nameof(Mapper), $"!{number}");
         }
 
         [FunctionName(nameof(Mapper))]

--- a/test/PerformanceTests/Benchmarks/WordCount/Reducer.cs
+++ b/test/PerformanceTests/Benchmarks/WordCount/Reducer.cs
@@ -15,7 +15,7 @@ namespace PerformanceTests.WordCount
     {
         public static EntityId GetEntityId(int number)
         {
-            return new EntityId(nameof(Reducer), $"{number}!{number % 100:D2}");
+            return new EntityId(nameof(Reducer), $"!{number}");
         }
 
         public enum Ops

--- a/test/PerformanceTests/Common/ManyOrchestrations.cs
+++ b/test/PerformanceTests/Common/ManyOrchestrations.cs
@@ -107,7 +107,7 @@ namespace PerformanceTests
                     while (pos < numberOrchestrations)
                     {
                         int portion = Math.Min(portionSize.Value, (numberOrchestrations - pos));
-                        var entityId = new EntityId(nameof(LauncherEntity), $"launcher{launcher / 100:D6}!{launcher % 100:D2}");
+                        var entityId = new EntityId(nameof(LauncherEntity), $"launcher!{launcher:D6}");
                         tasks.Add(client.SignalEntityAsync(entityId, nameof(LauncherEntity.Launch), (orchestrationName, prefix, portion, pos, input)));
                         pos += portion;
                         launcher++;

--- a/test/PerformanceTests/Common/Ping.cs
+++ b/test/PerformanceTests/Common/Ping.cs
@@ -43,7 +43,7 @@ namespace PerformanceTests
 
                     async Task<string> Ping(int partition)
                     {
-                        string instanceId = $"ping!{partition:D2}";
+                        string instanceId = $"ping!{partition}";
 
                         var timeoutTask = Task.Delay(timeout);
                         var startTask = client.StartNewAsync(nameof(Pingee), instanceId);


### PR DESCRIPTION
Previously, instance placement suffixes required precisely two digits. 
That seems unnecessarily specific. This PR generalizes it to any number of digits.