### PR TITLE
Fix race condition on WorkItem commit

### DIFF
--- a/src/DurableTask.Netherite.AzureFunctions/DurableTask.Netherite.AzureFunctions.csproj
+++ b/src/DurableTask.Netherite.AzureFunctions/DurableTask.Netherite.AzureFunctions.csproj
@@ -51,7 +51,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.9.0" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.9.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.7.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
   </ItemGroup>

--- a/src/DurableTask.Netherite/DurableTask.Netherite.csproj
+++ b/src/DurableTask.Netherite/DurableTask.Netherite.csproj
@@ -55,7 +55,7 @@
     <PackageReference Include="Microsoft.Azure.EventHubs.Processor" Version="4.3.2" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.2.3" />
     <PackageReference Include="Microsoft.FASTER.Core" Version="2.0.3" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.9.0" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.9.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="System.Threading.Channels" Version="4.7.1" />

--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
@@ -752,11 +752,6 @@ namespace DurableTask.Netherite
             List<TaskMessage> localMessages = null;
             List<TaskMessage> remoteMessages = null;
 
-            // DurableTask.Core keeps the original runtime state in the work item until after this call returns
-            // but we want it to contain the latest runtime state now (otherwise IsExecutableInstance returns incorrect results)
-            // so we update it now.
-            workItem.OrchestrationRuntimeState = newOrchestrationRuntimeState;
-
             // all continue as new requests are processed immediately (DurableTask.Core always uses "fast" continue-as-new)
             // so by the time we get here, it is not a continue as new
             partition.Assert(continuedAsNewMessage == null, "unexpected continueAsNew message");

--- a/src/DurableTask.Netherite/OrchestrationService/OrchestrationWorkItem.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/OrchestrationWorkItem.cs
@@ -30,6 +30,8 @@ namespace DurableTask.Netherite
 
         public string CustomStatus { get; set; }
 
+        public override bool RestoreOriginalRuntimeStateDuringCompletion => false;
+
         public OrchestrationWorkItem(Partition partition, OrchestrationMessageBatch messageBatch, List<HistoryEvent> previousHistory = null, string customStatus = null)
         {
             this.Partition = partition;

--- a/test/DurableTask.Netherite.AzureFunctions.Tests/DurableTask.Netherite.AzureFunctions.Tests.csproj
+++ b/test/DurableTask.Netherite.AzureFunctions.Tests/DurableTask.Netherite.AzureFunctions.Tests.csproj
@@ -24,7 +24,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\DurableTask.Netherite.AzureFunctions\DurableTask.Netherite.AzureFunctions.csproj" />
     <ProjectReference Include="..\DurableTask.Netherite.Tests\DurableTask.Netherite.Tests.csproj" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.9.0" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.9.1" />
   </ItemGroup>
 
 </Project>

--- a/test/PerformanceTests/PerformanceTests.csproj
+++ b/test/PerformanceTests/PerformanceTests.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.EventHubs" Version="5.7.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="4.0.1" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.9.0" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.9.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.7.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="4.2.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.13" />


### PR DESCRIPTION
DurableTask.Core was updating the `OrchestrationRuntimeState` field on `TaskOrchestrationWorkItem` in a convoluted way that created a race condition. The race condition could then corrupt the runtime state in somewhat unpredictable ways, such as by losing progress.

With DurableTask.Core 2.9.1 I can now turn off this behavior, which fixes the race condition.