### PR TITLE
Add runtime check for batch workers that are stuck

### DIFF
--- a/src/DurableTask.Netherite/StorageProviders/Faster/FasterStorage.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/FasterStorage.cs
@@ -145,9 +145,12 @@ namespace DurableTask.Netherite.Faster
 
             this.TraceHelper.FasterProgress("Creating LogWorker");
             this.logWorker = this.storeWorker.LogWorker = new LogWorker(this.blobManager, this.log, this.partition, this.storeWorker, this.TraceHelper, this.terminationToken);
-
-            this.hangCheckTimer = new Timer(this.CheckForStuckWorkers, null, 0, 20000);
-            errorHandler.OnShutdown += () => this.hangCheckTimer.Dispose();
+             
+            if (this.partition.Settings.TestHooks?.ReplayChecker == null) 
+            {
+                this.hangCheckTimer = new Timer(this.CheckForStuckWorkers, null, 0, 20000);
+                errorHandler.OnShutdown += () => this.hangCheckTimer.Dispose();
+            }
 
             if (this.log.TailAddress == this.log.BeginAddress)
             {

--- a/src/DurableTask.Netherite/StorageProviders/Faster/LogWorker.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/LogWorker.cs
@@ -51,6 +51,8 @@ namespace DurableTask.Netherite.Faster
 
         public long LastCommittedInputQueuePosition { get; private set; }
 
+        public TimeSpan? IntakeWorkerProcessingBatchSince => this.intakeWorker.ProcessingBatchSince;
+
         class IntakeWorker : BatchWorker<PartitionEvent>
         {
             readonly LogWorker logWorker;
@@ -165,7 +167,7 @@ namespace DurableTask.Netherite.Faster
                             {
                                 DurabilityListeners.ConfirmDurable(evt);
                             }
-                            catch (Exception exception) when (!(exception is OutOfMemoryException))
+                            catch (Exception exception)
                             {
                                 // for robustness, swallow exceptions, but report them
                                 this.partition.ErrorHandler.HandleError("LogWorker.Process", $"Encountered exception while notifying persistence listeners for event {evt} id={evt.EventIdString}", exception, false, false);
@@ -178,7 +180,7 @@ namespace DurableTask.Netherite.Faster
             {
                 // o.k. during shutdown
             }
-            catch (Exception e) when (!(e is OutOfMemoryException))
+            catch (Exception e)
             {
                 this.partition.ErrorHandler.HandleError("LogWorker.Process", "Encountered exception while working on commit log", e, true, false);
             }

--- a/src/DurableTask.Netherite/Util/BatchWorker.cs
+++ b/src/DurableTask.Netherite/Util/BatchWorker.cs
@@ -36,6 +36,9 @@ namespace DurableTask.Netherite
         const int MAXBATCHSIZE = 500;
         readonly object dummyEntry = new object();
 
+        bool processingBatch;
+        public TimeSpan? ProcessingBatchSince => this.processingBatch ? this.stopwatch.Elapsed : null;
+
         /// <summary>
         /// Constructor including a cancellation token.
         /// </summary>
@@ -192,6 +195,7 @@ namespace DurableTask.Netherite
 
                 this.Tracer?.Invoke("processing batch");
                 this.stopwatch.Restart();
+                this.processingBatch = true;
 
                 try
                 {
@@ -219,6 +223,7 @@ namespace DurableTask.Netherite
 
                 this.Tracer?.Invoke("done processing batch");
                 this.stopwatch.Stop();
+                this.processingBatch = false;
                 previousBatch = this.batch.Count;
             }
         }


### PR DESCRIPTION
This PR adds a check to detect whether workers are taking an inordinate amount of time to process a batch.

This is intended to catch observed issues like rare hangs in the synchronous Azure Storage SDK calls.