### PR TITLE
fix minor bug in AzureStorageDevice

### DIFF
--- a/src/DurableTask.Netherite/StorageProviders/Faster/AzureBlobs/AzureStorageDevice.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/AzureBlobs/AzureStorageDevice.cs
@@ -159,7 +159,7 @@ namespace DurableTask.Netherite.Faster
                 else
                 {
                     keys.Sort();
-                    this.endSegment = keys.Last();
+                    this.endSegment = this.startSegment = keys[keys.Count - 1];
                     for (int i = keys.Count - 2; i >= 0; i--)
                     {
                         if (keys[i] == keys[i + 1] - 1)


### PR DESCRIPTION
Fix a bug in the code that determines the segment range.

I noticed in the log that the start segment was wrong; it does not appear to cause actual problems.