### PR TITLE
Remove obsolete uses of ConnectionStringResolver

### DIFF
--- a/src/DurableTask.Netherite.AzureFunctions/NetheriteProviderFactory.cs
+++ b/src/DurableTask.Netherite.AzureFunctions/NetheriteProviderFactory.cs
@@ -48,7 +48,7 @@ namespace DurableTask.Netherite.AzureFunctions
         public NetheriteProviderFactory(
             IOptions<DurableTaskOptions> extensionOptions,
             ILoggerFactory loggerFactory,
-            IConnectionInfoResolver connectionInfoResolver,
+            IConnectionStringResolver connectionStringResolver,
             IHostIdProvider hostIdProvider,
             INameResolver nameResolver,
 #pragma warning disable CS0612 // Type or member is obsolete

--- a/src/DurableTask.Netherite.AzureFunctions/NetheriteProviderFactory.cs
+++ b/src/DurableTask.Netherite.AzureFunctions/NetheriteProviderFactory.cs
@@ -48,7 +48,9 @@ namespace DurableTask.Netherite.AzureFunctions
         public NetheriteProviderFactory(
             IOptions<DurableTaskOptions> extensionOptions,
             ILoggerFactory loggerFactory,
+#pragma warning disable CS0618 // Type or member is obsolete
             IConnectionStringResolver connectionStringResolver,
+#pragma warning restore CS0618 // Type or member is obsolete
             IHostIdProvider hostIdProvider,
             INameResolver nameResolver,
 #pragma warning disable CS0612 // Type or member is obsolete

--- a/src/DurableTask.Netherite.AzureFunctions/NetheriteProviderFactory.cs
+++ b/src/DurableTask.Netherite.AzureFunctions/NetheriteProviderFactory.cs
@@ -48,7 +48,7 @@ namespace DurableTask.Netherite.AzureFunctions
         public NetheriteProviderFactory(
             IOptions<DurableTaskOptions> extensionOptions,
             ILoggerFactory loggerFactory,
-            IConnectionStringResolver connectionStringResolver,
+            IConnectionInfoResolver connectionInfoResolver,
             IHostIdProvider hostIdProvider,
             INameResolver nameResolver,
 #pragma warning disable CS0612 // Type or member is obsolete

--- a/src/DurableTask.Netherite.AzureFunctions/NetheriteProviderPseudoFactory.cs
+++ b/src/DurableTask.Netherite.AzureFunctions/NetheriteProviderPseudoFactory.cs
@@ -19,7 +19,9 @@ namespace DurableTask.Netherite.AzureFunctions
         public NetheriteProviderPseudoFactory(
             IOptions<DurableTaskOptions> extensionOptions,
             ILoggerFactory loggerFactory,
+#pragma warning disable CS0618 // Type or member is obsolete
             IConnectionStringResolver connectionStringResolver,
+#pragma warning restore CS0618 // Type or member is obsolete
             IHostIdProvider hostIdProvider,
             INameResolver nameResolver,
 #pragma warning disable CS0612 // Type or member is obsolete

--- a/src/DurableTask.Netherite.AzureFunctions/NetheriteProviderPseudoFactory.cs
+++ b/src/DurableTask.Netherite.AzureFunctions/NetheriteProviderPseudoFactory.cs
@@ -19,7 +19,7 @@ namespace DurableTask.Netherite.AzureFunctions
         public NetheriteProviderPseudoFactory(
             IOptions<DurableTaskOptions> extensionOptions,
             ILoggerFactory loggerFactory,
-            IConnectionStringResolver connectionStringResolver,
+            IConnectionInfoResolver connectionInfoResolver,
             IHostIdProvider hostIdProvider,
             INameResolver nameResolver,
 #pragma warning disable CS0612 // Type or member is obsolete

--- a/src/DurableTask.Netherite.AzureFunctions/NetheriteProviderPseudoFactory.cs
+++ b/src/DurableTask.Netherite.AzureFunctions/NetheriteProviderPseudoFactory.cs
@@ -19,7 +19,7 @@ namespace DurableTask.Netherite.AzureFunctions
         public NetheriteProviderPseudoFactory(
             IOptions<DurableTaskOptions> extensionOptions,
             ILoggerFactory loggerFactory,
-            IConnectionInfoResolver connectionInfoResolver,
+            IConnectionStringResolver connectionStringResolver,
             IHostIdProvider hostIdProvider,
             INameResolver nameResolver,
 #pragma warning disable CS0612 // Type or member is obsolete

--- a/src/DurableTask.Netherite/Events/EventId.cs
+++ b/src/DurableTask.Netherite/Events/EventId.cs
@@ -8,7 +8,6 @@ namespace DurableTask.Netherite
     using System.Runtime.Serialization;
     using System.Text;
     using DurableTask.Core;
-    using Dynamitey;
 
     /// <summary>
     /// A unique identifier for an event.

--- a/src/DurableTask.Netherite/Events/LoadMonitorEvents/PositionsReceived.cs
+++ b/src/DurableTask.Netherite/Events/LoadMonitorEvents/PositionsReceived.cs
@@ -6,7 +6,6 @@ namespace DurableTask.Netherite
     using System;
     using System.Collections.Generic;
     using System.Runtime.Serialization;
-    using Dynamitey.DynamicObjects;
 
     [DataContract]
     class PositionsReceived : LoadMonitorEvent

--- a/src/DurableTask.Netherite/Events/Packet.cs
+++ b/src/DurableTask.Netherite/Events/Packet.cs
@@ -5,7 +5,6 @@ namespace DurableTask.Netherite
 {
     using DurableTask.Core.Common;
     using DurableTask.Core.Exceptions;
-    using Dynamitey;
     using Newtonsoft.Json;
     using System;
     using System.Collections.Generic;

--- a/src/DurableTask.Netherite/StorageProviders/Faster/AzureBlobs/BlobManager.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/AzureBlobs/BlobManager.cs
@@ -5,7 +5,6 @@ namespace DurableTask.Netherite.Faster
 {
     using DurableTask.Core.Common;
     using FASTER.core;
-    using ImpromptuInterface;
     using Microsoft.Azure.Storage;
     using Microsoft.Azure.Storage.Blob;
     using Microsoft.Azure.Storage.RetryPolicies;

--- a/src/DurableTask.Netherite/Tracing/EventTraceHelper.cs
+++ b/src/DurableTask.Netherite/Tracing/EventTraceHelper.cs
@@ -5,7 +5,6 @@ namespace DurableTask.Netherite
 {
     using DurableTask.Core;
     using DurableTask.Core.History;
-    using Dynamitey;
     using FASTER.core;
     using Microsoft.Extensions.Logging;
     using System;

--- a/test/DurableTask.Netherite.AzureFunctions.Tests/IntegrationTestBase.cs
+++ b/test/DurableTask.Netherite.AzureFunctions.Tests/IntegrationTestBase.cs
@@ -61,6 +61,7 @@ namespace DurableTask.Netherite.AzureFunctions.Tests
                     services =>
                     {
                         services.AddSingleton<INameResolver>(this.settingsResolver);
+                        services.AddSingleton<IConnectionStringResolver>(this.settingsResolver);
                         services.AddSingleton<ITypeLocator>(this.typeLocator);
                         services.AddSingleton<IDurabilityProviderFactory, NetheriteProviderFactory>();
                     })
@@ -176,7 +177,7 @@ namespace DurableTask.Netherite.AzureFunctions.Tests
             IReadOnlyList<Type> ITypeLocator.GetTypes() => this.functionTypes.AsReadOnly();
         }
 
-        class TestSettingsResolver : INameResolver
+        class TestSettingsResolver : INameResolver, IConnectionStringResolver
         {
             readonly Dictionary<string, string> testSettings =
                 new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -184,6 +185,8 @@ namespace DurableTask.Netherite.AzureFunctions.Tests
             public void AddSetting(string name, string value) => this.testSettings.Add(name, value);
 
             string INameResolver.Resolve(string name) => this.Resolve(name);
+
+            string IConnectionStringResolver.Resolve(string connectionStringName) => this.Resolve(connectionStringName);
 
             string Resolve(string name)
             {

--- a/test/DurableTask.Netherite.AzureFunctions.Tests/IntegrationTestBase.cs
+++ b/test/DurableTask.Netherite.AzureFunctions.Tests/IntegrationTestBase.cs
@@ -61,7 +61,6 @@ namespace DurableTask.Netherite.AzureFunctions.Tests
                     services =>
                     {
                         services.AddSingleton<INameResolver>(this.settingsResolver);
-                        services.AddSingleton<IConnectionStringResolver>(this.settingsResolver);
                         services.AddSingleton<ITypeLocator>(this.typeLocator);
                         services.AddSingleton<IDurabilityProviderFactory, NetheriteProviderFactory>();
                     })
@@ -177,7 +176,7 @@ namespace DurableTask.Netherite.AzureFunctions.Tests
             IReadOnlyList<Type> ITypeLocator.GetTypes() => this.functionTypes.AsReadOnly();
         }
 
-        class TestSettingsResolver : INameResolver, IConnectionStringResolver
+        class TestSettingsResolver : INameResolver
         {
             readonly Dictionary<string, string> testSettings =
                 new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -185,8 +184,6 @@ namespace DurableTask.Netherite.AzureFunctions.Tests
             public void AddSetting(string name, string value) => this.testSettings.Add(name, value);
 
             string INameResolver.Resolve(string name) => this.Resolve(name);
-
-            string IConnectionStringResolver.Resolve(string connectionStringName) => this.Resolve(connectionStringName);
 
             string Resolve(string name)
             {

--- a/test/DurableTask.Netherite.AzureFunctions.Tests/IntegrationTestBase.cs
+++ b/test/DurableTask.Netherite.AzureFunctions.Tests/IntegrationTestBase.cs
@@ -61,7 +61,9 @@ namespace DurableTask.Netherite.AzureFunctions.Tests
                     services =>
                     {
                         services.AddSingleton<INameResolver>(this.settingsResolver);
+#pragma warning disable CS0618 // Type or member is obsolete
                         services.AddSingleton<IConnectionStringResolver>(this.settingsResolver);
+#pragma warning restore CS0618 // Type or member is obsolete
                         services.AddSingleton<ITypeLocator>(this.typeLocator);
                         services.AddSingleton<IDurabilityProviderFactory, NetheriteProviderFactory>();
                     })
@@ -177,7 +179,9 @@ namespace DurableTask.Netherite.AzureFunctions.Tests
             IReadOnlyList<Type> ITypeLocator.GetTypes() => this.functionTypes.AsReadOnly();
         }
 
-        class TestSettingsResolver : INameResolver, IConnectionStringResolver
+#pragma warning disable CS0618 // Type or member is obsolete
+       class TestSettingsResolver : INameResolver, IConnectionStringResolver
+#pragma warning restore CS0618 // Type or member is obsolete
         {
             readonly Dictionary<string, string> testSettings =
                 new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);

--- a/test/PerformanceTests/Benchmarks/Counter/Counter.cs
+++ b/test/PerformanceTests/Benchmarks/Counter/Counter.cs
@@ -14,7 +14,6 @@ namespace PerformanceTests.Orchestrations.Counter
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
-    using Dynamitey;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Azure.WebJobs;

--- a/test/PerformanceTests/Benchmarks/Lambdas/ImageRecognitionCaseStudy.cs
+++ b/test/PerformanceTests/Benchmarks/Lambdas/ImageRecognitionCaseStudy.cs
@@ -14,7 +14,6 @@ namespace PerformanceTests
     using Newtonsoft.Json;
     using System.Collections.Generic;
     using Microsoft.Azure.WebJobs.Extensions.DurableTask;
-    using Dynamitey;
     using Newtonsoft.Json.Linq;
     using System.Net.Http;
     using System.Linq;


### PR DESCRIPTION
This type was causing a compiler warning because it is declared obsolete. Since it appears to be unused, this PR simply removes its uses.