### PR TITLE
Remove serialization cache

### DIFF
--- a/src/DurableTask.Netherite/Abstractions/PartitionState/TrackedObject.cs
+++ b/src/DurableTask.Netherite/Abstractions/PartitionState/TrackedObject.cs
@@ -27,12 +27,6 @@ namespace DurableTask.Netherite
         [IgnoreDataMember]
         public abstract TrackedObjectKey Key { get; }
 
-        /// <summary>
-        /// The current value in serialized form, or null
-        /// </summary>
-        [IgnoreDataMember]
-        internal byte[] SerializationCache { get; set; }
-
         [DataMember]
         public int Version { get; set;  } // we use this validate consistency of read/write updates in FASTER, it is not otherwise needed
 

--- a/src/DurableTask.Netherite/StorageProviders/Faster/FasterAlt.cs
+++ b/src/DurableTask.Netherite/StorageProviders/Faster/FasterAlt.cs
@@ -187,7 +187,6 @@ namespace DurableTask.Netherite.Faster
         {
             // update the positions
             var dedupState = this.cache[TrackedObjectKey.Dedup];
-            dedupState.TrackedObject.SerializationCache = null;
             ((DedupState)dedupState.TrackedObject).Positions = (commitLogPosition, inputQueuePosition);
             if (!dedupState.Modified)
             {
@@ -199,14 +198,14 @@ namespace DurableTask.Netherite.Faster
             var toWrite = new List<ToWrite>();
             foreach (var cacheEntry in this.modified)
             {
-                Serializer.SerializeTrackedObject(cacheEntry.TrackedObject);
+                byte[] bytes = Serializer.SerializeTrackedObject(cacheEntry.TrackedObject);
                 toWrite.Add(new ToWrite()
                 {
                     Key = cacheEntry.TrackedObject.Key,
                     PreviousValue = cacheEntry.LastCheckpointed,
-                    NewValue = cacheEntry.TrackedObject.SerializationCache,
+                    NewValue = bytes,
                 });
-                cacheEntry.LastCheckpointed = cacheEntry.TrackedObject.SerializationCache;
+                cacheEntry.LastCheckpointed = bytes;
                 cacheEntry.Modified = false;
             }
             this.modified.Clear();
@@ -377,7 +376,6 @@ namespace DurableTask.Netherite.Faster
                 this.cache.Add(key, cacheEntry);
             }
             var trackedObject = cacheEntry.TrackedObject;
-            trackedObject.SerializationCache = null;
             effectTracker.ProcessEffectOn(trackedObject);
             if (!cacheEntry.Modified)
             {

--- a/src/DurableTask.Netherite/Util/Serializer.cs
+++ b/src/DurableTask.Netherite/Util/Serializer.cs
@@ -58,21 +58,17 @@ namespace DurableTask.Netherite
             return (Event)eventSerializer.ReadObject(stream);
         }
 
-        public static void SerializeTrackedObject(TrackedObject trackedObject)
+        public static byte[] SerializeTrackedObject(TrackedObject trackedObject)
         {
-            if (trackedObject.SerializationCache == null)
-            {
-                var stream = new MemoryStream();
-                trackedObjectSerializer.WriteObject(stream, trackedObject);
-                trackedObject.SerializationCache = stream.ToArray();
-            }
+            var stream = new MemoryStream();
+            trackedObjectSerializer.WriteObject(stream, trackedObject);
+            return stream.ToArray();
         }
 
         public static TrackedObject DeserializeTrackedObject(byte[] bytes)
         {
             var stream = new MemoryStream(bytes);
             var result = (TrackedObject)trackedObjectSerializer.ReadObject(stream);
-            result.SerializationCache = bytes;
             return result;
         }
 


### PR DESCRIPTION
Removes the serialization cache because the benefit is unclear with the current design, and it wastes memory.