### PR TITLE
Fix query timeouts

### DIFF
--- a/src/DurableTask.Netherite/Abstractions/PartitionState/EffectTracker.cs
+++ b/src/DurableTask.Netherite/Abstractions/PartitionState/EffectTracker.cs
@@ -222,7 +222,7 @@ namespace DurableTask.Netherite
             }
         }
         
-        public async Task ProcessQueryResultAsync(PartitionQueryEvent queryEvent, IAsyncEnumerable<OrchestrationState> instances, DateTime attempt)
+        public async Task ProcessQueryResultAsync(PartitionQueryEvent queryEvent, IAsyncEnumerable<(string, OrchestrationState)> instances, DateTime attempt)
         {
             (long commitLogPosition, long inputQueuePosition) = this.GetPositions();
             this.Assert(!this.IsReplaying, "query events are never part of the replay");

--- a/src/DurableTask.Netherite/Events/PartitionEvents/External/FromClients/ClientRequestEventWithQuery.cs
+++ b/src/DurableTask.Netherite/Events/PartitionEvents/External/FromClients/ClientRequestEventWithQuery.cs
@@ -39,7 +39,7 @@ namespace DurableTask.Netherite
             }
         }
 
-        public abstract Task OnQueryCompleteAsync(IAsyncEnumerable<OrchestrationState> result, Partition partition, DateTime attempt);
+        public abstract Task OnQueryCompleteAsync(IAsyncEnumerable<(string,OrchestrationState)> result, Partition partition, DateTime attempt);
 
         public sealed override void DetermineEffects(EffectTracker effects)
         {

--- a/src/DurableTask.Netherite/Events/PartitionEvents/External/FromClients/PurgeRequestReceived.cs
+++ b/src/DurableTask.Netherite/Events/PartitionEvents/External/FromClients/PurgeRequestReceived.cs
@@ -25,7 +25,7 @@ namespace DurableTask.Netherite
             trackedObject.Process(this, effects);
         }
 
-        public async override Task OnQueryCompleteAsync(IAsyncEnumerable<OrchestrationState> instances, Partition partition, DateTime attempt)
+        public async override Task OnQueryCompleteAsync(IAsyncEnumerable<(string,OrchestrationState)> instances, Partition partition, DateTime attempt)
         {
             int batchCount = 0;
             string continuationToken = null;
@@ -50,11 +50,11 @@ namespace DurableTask.Netherite
                 await batch.WhenProcessed.Task;
             }
 
-            await foreach (var orchestrationState in instances)
+            await foreach (var (position, instance) in instances)
             {
-                if (orchestrationState != null)
+                if (instance != null)
                 {
-                    string instanceId = orchestrationState.OrchestrationInstance.InstanceId;
+                    string instanceId = instance.OrchestrationInstance.InstanceId;
 
                     batch.InstanceIds.Add(instanceId);
 
@@ -64,11 +64,11 @@ namespace DurableTask.Netherite
                         batch = makeNewBatchObject();
                     }
 
-                    continuationToken = instanceId;
+                    continuationToken = position;
                 }
                 else
                 {
-                    continuationToken = null;
+                    continuationToken = position;
                 }
             }
 

--- a/src/DurableTask.Netherite/Events/PartitionEvents/PartitionQueryEvent.cs
+++ b/src/DurableTask.Netherite/Events/PartitionEvents/PartitionQueryEvent.cs
@@ -39,6 +39,6 @@ namespace DurableTask.Netherite
         /// <param name="exceptionTask">A task that throws an exception if the enumeration fails</param>
         /// <param name="partition">The partition</param>
         /// <param name="attempt">The timestamp for this query attempt</param>
-        public abstract Task OnQueryCompleteAsync(IAsyncEnumerable<OrchestrationState> result, Partition partition, DateTime attempt);
+        public abstract Task OnQueryCompleteAsync(IAsyncEnumerable<(string,OrchestrationState)> result, Partition partition, DateTime attempt);
     }
 }

--- a/src/DurableTask.Netherite/PartitionState/QueriesState.cs
+++ b/src/DurableTask.Netherite/PartitionState/QueriesState.cs
@@ -122,7 +122,7 @@ namespace DurableTask.Netherite
 
             public override Netherite.InstanceQuery InstanceQuery => this.request.InstanceQuery;
 
-            public override async Task OnQueryCompleteAsync(IAsyncEnumerable<OrchestrationState> result, Partition partition, DateTime attempt)
+            public override async Task OnQueryCompleteAsync(IAsyncEnumerable<(string, OrchestrationState)> result, Partition partition, DateTime attempt)
             {
                 partition.Assert(this.request.Phase == ClientRequestEventWithQuery.ProcessingPhase.Query, "wrong phase in QueriesState.OnQueryCompleteAsync");
 

--- a/test/PerformanceTests/Common/Queries.cs
+++ b/test/PerformanceTests/Common/Queries.cs
@@ -31,6 +31,7 @@ namespace PerformanceTests
             try
             {
                 var queryCondition = new OrchestrationStatusQueryCondition();
+                bool keepGoingUntilDone = true;
 
                 try
                 {
@@ -67,10 +68,24 @@ namespace PerformanceTests
                         }
                     }
                     {
+                        if (parameters.TryGetValue("keepGoingUntilDone", out string val))
+                        {
+                            parameters.Remove("keepGoingUntilDone");
+                            keepGoingUntilDone = bool.Parse(val);
+                        }
+                    }
+                    {
                         if (parameters.TryGetValue("instanceIdPrefix", out string val))
                         {
                             parameters.Remove("instanceIdPrefix");
                             queryCondition.InstanceIdPrefix = val;
+                        }
+                    }
+                    {
+                        if (parameters.TryGetValue("continuationToken", out string val))
+                        {
+                            parameters.Remove("continuationToken");
+                            queryCondition.ContinuationToken = val;
                         }
                     }
                     {
@@ -134,10 +149,11 @@ namespace PerformanceTests
                         }
                     }
 
-                } while (queryCondition.ContinuationToken != null);
+                } while (keepGoingUntilDone && queryCondition.ContinuationToken != null);
 
                 stopwatch.Stop();
                 double querySec = stopwatch.ElapsedMilliseconds / 1000.0;
+                string continuationToken = queryCondition.ContinuationToken;
 
                 var resultObject = new
                 { 
@@ -146,6 +162,7 @@ namespace PerformanceTests
                     inputchars,
                     pages,
                     querySec,
+                    continuationToken,
                     throughput = records > 0 ? (records/querySec).ToString("F2") : "n/a",
                 };
 


### PR DESCRIPTION
Fixed several issues:

- for selective queries, paged progress did not work since the query could not advance the continuation token without returning instances.

- queries with time budget did not correctly finish within the budget because it was not being checked in the right place.

- unpaged queries did not use the continuation token correctly which meant that setting pageSize=0 (to force unpaged querying on interfaces that support paged querying) did not work correctly. 