### PR TITLE
fix corner case for cache size reporting

### DIFF
--- a/src/DurableTask.Netherite/StorageLayer/Faster/FasterKV.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/FasterKV.cs
@@ -973,13 +973,20 @@ namespace DurableTask.Netherite.Faster
         public long MemoryUsedWithoutObjects => this.fht.IndexSize * 64 + this.fht.Log.MemorySizeBytes + this.fht.OverflowBucketCount * 64;
 
         public override (double totalSizeMB, int fillPercentage) CacheSizeInfo {
-            get 
+            get
             {
-                double totalSize = (double)(this.cacheTracker.TrackedObjectSize + this.MemoryUsedWithoutObjects);
-                double targetSize = (double) this.cacheTracker.TargetSize;
-                int fillPercentage = (int) Math.Round(100 * (totalSize / targetSize));
+                double totalSize = (double)(Math.Min(0, this.cacheTracker.TrackedObjectSize) + this.MemoryUsedWithoutObjects);
                 double totalSizeMB = Math.Round(100 * totalSize / (1024 * 1024)) / 100;
-                return (totalSizeMB, fillPercentage);
+                if (this.cacheTracker.TargetSize == 0)
+                {
+                    return (totalSizeMB, 100);
+                }
+                else
+                {
+                    double targetSize = (double)this.cacheTracker.TargetSize;
+                    int fillPercentage = (int)Math.Round(100 * (totalSize / targetSize));
+                    return (totalSizeMB, fillPercentage);
+                }
             }
         }
 


### PR DESCRIPTION
In test cases, cache target size is sometimes set to zero. This caused incorrect formatting in some places.