### PR TITLE
update benchmarks for corpus connection, periodic test

### DIFF
--- a/test/PerformanceTests/Benchmarks/FileHash/FileOrchestration.cs
+++ b/test/PerformanceTests/Benchmarks/FileHash/FileOrchestration.cs
@@ -17,7 +17,6 @@ namespace PerformanceTests.FileHash
     /// </summary>
     public static class FileOrchestration
     {
-
         [FunctionName(nameof(FileOrchestration))]
         public static async Task<double> Run([OrchestrationTrigger] IDurableOrchestrationContext context, ILogger log)
         {

--- a/test/PerformanceTests/Benchmarks/Periodic/HttpTriggers.cs
+++ b/test/PerformanceTests/Benchmarks/Periodic/HttpTriggers.cs
@@ -20,15 +20,16 @@ namespace PerformanceTests.Periodic
     {
         [FunctionName(nameof(Periodic))]
         public static async Task<IActionResult> Run(
-           [HttpTrigger(AuthorizationLevel.Anonymous, "get")] HttpRequest req,
+           [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = "periodic/{iterations}/{minutes}/")] HttpRequest req,
            [DurableClient] IDurableClient client,
+           int iterations,
+           double minutes,
            ILogger log)
         {
             // start the orchestration
-            string orchestrationInstanceId = await client.StartNewAsync(nameof(PeriodicOrchestration));
+            string orchestrationInstanceId = await client.StartNewAsync(nameof(PeriodicOrchestration), null, (iterations, minutes));
 
-            // wait for it to complete and return the result
-            return await client.WaitForCompletionOrCreateCheckStatusResponseAsync(req, orchestrationInstanceId, TimeSpan.FromSeconds(200));
-        }   
+            return client.CreateCheckStatusResponse(req, orchestrationInstanceId, false);
+        }
     }
 }

--- a/test/PerformanceTests/Benchmarks/Periodic/PeriodicOrchestration.cs
+++ b/test/PerformanceTests/Benchmarks/Periodic/PeriodicOrchestration.cs
@@ -19,20 +19,22 @@ namespace PerformanceTests.Periodic
         [FunctionName(nameof(PeriodicOrchestration))]
         public static async Task Run([OrchestrationTrigger] IDurableOrchestrationContext context, ILogger log)
         {
-            for (int i = 0; i < 5; i++)
+            (int iterations, double minutes) = context.GetInput<(int,double)>();
+            
+            for (int i = 0; i < iterations; i++)
             {
-                DateTime fireAt = context.CurrentUtcDateTime + TimeSpan.FromSeconds(60);
+                DateTime fireAt = context.CurrentUtcDateTime + TimeSpan.FromMinutes(minutes);
 
                 if (!context.IsReplaying)
                 {
-                    log.LogWarning($"{context.InstanceId}: starting timer for iteration {i}, to fire at {fireAt}");
+                    log.LogWarning("{instanceId}: periodic timer: starting iteration {iteration}, to fire at {fireAt}", context.InstanceId, i, fireAt);
                 }
 
                 await context.CreateTimer(fireAt, CancellationToken.None);
 
                 if (!context.IsReplaying)
                 {
-                    log.LogWarning($"{context.InstanceId}: timer for iteration {i} fired at {(UtcNowWithNoWarning() - fireAt).TotalMilliseconds:F2}ms relative to deadline");
+                    log.LogWarning("{instanceId}: periodic timer: iteration {iteration} fired at {accuracyMs:F2}ms relative to deadline", context.InstanceId, i, (UtcNowWithNoWarning() - fireAt).TotalMilliseconds);
                 }
             };
         }


### PR DESCRIPTION
Because anonymous public blob access is discouraged, benchmarks need to once more use a connection string when connecting to the Gutenberg corpus.

Also, updated the periodic test to make it suitable for testing timer-induced scale-from-zero on consumption plans.