### PR TITLE
Validate partition table name on consumption plan

### DIFF
--- a/src/DurableTask.Netherite.AzureFunctions/NetheriteProviderFactory.cs
+++ b/src/DurableTask.Netherite.AzureFunctions/NetheriteProviderFactory.cs
@@ -141,6 +141,12 @@ namespace DurableTask.Netherite.AzureFunctions
                 netheriteSettings.HubName = taskHubNameOverride;
             }
 
+            // blob load published is currently disabled for consumption plan
+            if (netheriteSettings.LoadInformationAzureTableName == null && this.inConsumption)
+            {
+                throw new NotSupportedException("The Netherite setting LoadInformationAzureTableName must not be null when running on a consumption plan");
+            }
+
             // connections for Netherite are resolved either via an injected custom resolver, or otherwise by resolving connection names to connection strings
             
             if (!string.IsNullOrEmpty(connectionName))

--- a/src/DurableTask.Netherite.AzureFunctions/NetheriteProviderFactory.cs
+++ b/src/DurableTask.Netherite.AzureFunctions/NetheriteProviderFactory.cs
@@ -141,12 +141,6 @@ namespace DurableTask.Netherite.AzureFunctions
                 netheriteSettings.HubName = taskHubNameOverride;
             }
 
-            // blob load published is currently disabled for consumption plan
-            if (netheriteSettings.LoadInformationAzureTableName == null && this.inConsumption)
-            {
-                throw new NotSupportedException("The Netherite setting LoadInformationAzureTableName must not be null when running on a consumption plan");
-            }
-
             // connections for Netherite are resolved either via an injected custom resolver, or otherwise by resolving connection names to connection strings
             
             if (!string.IsNullOrEmpty(connectionName))
@@ -180,6 +174,12 @@ namespace DurableTask.Netherite.AzureFunctions
 
             // validate the settings and resolve the connections
             netheriteSettings.Validate(this.connectionResolver);
+
+            // must always use AzureTableLoadPublisher on consumption plans
+            if (string.IsNullOrEmpty(netheriteSettings.LoadInformationAzureTableName) && this.inConsumption)
+            {
+                throw new NetheriteConfigurationException("The Netherite setting LoadInformationAzureTableName must not be null or empty when running on a consumption plan");
+            }
 
             int randomProbability = 0;
             bool attachFaultInjector =

--- a/src/DurableTask.Netherite/Connections/ConnectionResolver.cs
+++ b/src/DurableTask.Netherite/Connections/ConnectionResolver.cs
@@ -31,7 +31,7 @@ namespace DurableTask.Netherite
 
             /// <summary>
             /// The table storage account, used for publishing load information. 
-            /// Not required if <see cref="NetheriteOrchestrationServiceSettings.LoadInformationAzureTableName"/> is set to null, or if
+            /// Not required if <see cref="NetheriteOrchestrationServiceSettings.LoadInformationAzureTableName"/> is set to null or empty, or if
             /// the layer configuration uses <see cref="StorageChoices.Memory"/>.
             /// </summary>
             TableStorage,

--- a/src/DurableTask.Netherite/LoadMonitor/LoadMonitorTraceHelper.cs
+++ b/src/DurableTask.Netherite/LoadMonitor/LoadMonitorTraceHelper.cs
@@ -29,7 +29,7 @@ namespace DurableTask.Netherite
             {
                 if (this.logger.IsEnabled(LogLevel.Debug))
                 {
-                    this.logger.LogInformation("LoadMonitor {details}", details);
+                    this.logger.LogDebug("LoadMonitor {details}", details);
                 }
                 if (EtwSource.Log.IsEnabled())
                 {

--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationServiceSettings.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationServiceSettings.cs
@@ -47,7 +47,7 @@ namespace DurableTask.Netherite
 
         /// <summary>
         /// Optionally, a name for an Azure Table to use for publishing load information. If set to null or empty,
-        /// then Azure blobs are used instead.
+        /// then Azure blobs are used instead. The use of Azure blobs is currently not supported on consumption plans, or on elastic premium plans without runtime scaling.
         /// </summary>
         public string LoadInformationAzureTableName { get; set; } = "DurableTaskPartitions";
 

--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationServiceSettings.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationServiceSettings.cs
@@ -419,7 +419,7 @@ namespace DurableTask.Netherite
                 }
             }
 
-            if (this.StorageChoice == StorageChoices.Faster && this.LoadInformationAzureTableName != null)
+            if (this.StorageChoice == StorageChoices.Faster && !string.IsNullOrEmpty(this.LoadInformationAzureTableName))
             {
                 // we need a valid table storage connection
                 try

--- a/test/PerformanceTests/host.json
+++ b/test/PerformanceTests/host.json
@@ -87,6 +87,9 @@
         // set this to true to attach replay checker
         //"AttachCacheDebugger": true,
 
+        // can change this to use a different table, or blobs
+        //"LoadInformationAzureTableName": "",
+
         // set this to "Scripted" to control the scenario with a partition script
         // or to "ClientOnly" to run only the client
         "PartitionManagement": "EventProcessorHost",


### PR DESCRIPTION
- throw an exception if Azure table name for load publishing is null or empty on a consumption plan (because using blobs for load publishing is not currently supported on the consumption plan).

- fix several places where the test was checking for null, instead of for null or empty.

- update blob load publisher to use the correct partition directories to publish the load.