### PR TITLE
retry blob deletion when taskhubs are deleted.

### DIFF
--- a/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/BlobManager.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/BlobManager.cs
@@ -419,7 +419,7 @@ namespace DurableTask.Netherite.Faster
             else
             {
                 var blockBlobAccount = BlobUtilsV12.GetServiceClients(settings.BlobStorageConnection);
-                await DeleteContainerContents(blockBlobAccount.Default);
+                await DeleteContainerContents(blockBlobAccount.WithRetries);
 
                 if (settings.PageBlobStorageConnection != null)
                 {


### PR DESCRIPTION
When changing to sdk v12 retries were inadvertently disabled for blob deletions during task hub deletions. This PR re-enables them.