### PR TITLE
Make NetheriteScaleMetrics and NetheriteScaleMonitor classes public for ScaleControllerRedesign

### DIFF
--- a/src/DurableTask.Netherite.AzureFunctions/NetheriteProvider.cs
+++ b/src/DurableTask.Netherite.AzureFunctions/NetheriteProvider.cs
@@ -111,15 +111,15 @@ namespace DurableTask.Netherite.AzureFunctions
         }
 
         public override bool TryGetScaleMonitor(
-            string functionId, 
-            string functionName, 
-            string hubName, 
-            string storageConnectionString, 
+            string functionId,
+            string functionName,
+            string hubName,
+            string storageConnectionString,
             out IScaleMonitor scaleMonitor)
         {
             if (this.Service.TryGetScalingMonitor(out var monitor))
             {
-                scaleMonitor = new ScaleMonitor(monitor);
+                scaleMonitor = new NetheriteScaleMonitor(monitor);
                 monitor.InformationTracer($"ScaleMonitor Constructed, Descriptor.Id={scaleMonitor.Descriptor.Id}");
                 return true;
             }
@@ -127,119 +127,6 @@ namespace DurableTask.Netherite.AzureFunctions
             {
                 scaleMonitor = null;
                 return false;
-            }
-        }
-
-        public class NetheriteScaleMetrics : ScaleMetrics
-        {
-            public byte[] Metrics { get; set; }
-        }
-
-        class ScaleMonitor : IScaleMonitor<NetheriteScaleMetrics>
-        {
-            readonly ScalingMonitor scalingMonitor;
-            readonly ScaleMonitorDescriptor descriptor;
-            readonly DataContractSerializer serializer  = new DataContractSerializer(typeof(ScalingMonitor.Metrics));
-            static Tuple<DateTime, NetheriteScaleMetrics> cachedMetrics;
-
-            public ScaleMonitor(ScalingMonitor scalingMonitor)
-            {
-                this.scalingMonitor = scalingMonitor;
-                this.descriptor = new ScaleMonitorDescriptor($"DurableTaskTrigger-Netherite-{this.scalingMonitor.TaskHubName}".ToLower());
-            }
-
-            public ScaleMonitorDescriptor Descriptor => this.descriptor;
-
-
-            async Task<ScaleMetrics> IScaleMonitor.GetMetricsAsync()
-            {
-                return await this.GetMetricsAsync();
-            }
-
-            public async Task<NetheriteScaleMetrics> GetMetricsAsync()
-            {
-                // if we recently collected the metrics, return the cached result now.
-                var cached = cachedMetrics;
-                if (cached != null && DateTime.UtcNow - cached.Item1 < TimeSpan.FromSeconds(1.5))
-                {
-                    this.scalingMonitor.InformationTracer?.Invoke($"ScaleMonitor returned metrics cached previously, at {cached.Item2.Timestamp:o}");
-                    return cached.Item2;
-                }
-                
-                var metrics = new NetheriteScaleMetrics();
-
-                try
-                {
-                    Stopwatch sw = new Stopwatch();
-                    sw.Start();
-                    var collectedMetrics = await this.scalingMonitor.CollectMetrics();
-                    sw.Stop();
-
-                    var stream = new MemoryStream();
-                    this.serializer.WriteObject(stream, collectedMetrics);
-                    metrics.Metrics = stream.ToArray();
-
-                    this.scalingMonitor.InformationTracer?.Invoke(
-                        $"ScaleMonitor collected metrics for {collectedMetrics.LoadInformation.Count} partitions at {collectedMetrics.Timestamp:o} in {sw.Elapsed.TotalMilliseconds:F2}ms.");
-                }
-                catch (Exception e)
-                {
-                    this.scalingMonitor.ErrorTracer?.Invoke("ScaleMonitor failed to collect metrics", e);
-                }
-
-                cachedMetrics = new Tuple<DateTime, NetheriteScaleMetrics>(DateTime.UtcNow, metrics);
-                return metrics;
-            }
-
-            ScaleStatus IScaleMonitor.GetScaleStatus(ScaleStatusContext context)
-            {
-                return this.GetScaleStatusCore(context.WorkerCount, context.Metrics?.Cast<NetheriteScaleMetrics>().ToArray());
-            }
-
-            public ScaleStatus GetScaleStatus(ScaleStatusContext<NetheriteScaleMetrics> context)
-            {
-                return this.GetScaleStatusCore(context.WorkerCount, context.Metrics?.ToArray());
-            }
-
-            ScaleStatus GetScaleStatusCore(int workerCount, NetheriteScaleMetrics[] metrics)
-            {
-                ScaleRecommendation recommendation;               
-                try
-                { 
-                    if (metrics == null || metrics.Length == 0)
-                    {
-                        recommendation = new ScaleRecommendation(ScaleAction.None, keepWorkersAlive: true, reason: "missing metrics");
-                    }
-                    else
-                    {
-                        var stream = new MemoryStream(metrics[metrics.Length - 1].Metrics);
-                        var collectedMetrics = (ScalingMonitor.Metrics) this.serializer.ReadObject(stream);                 
-                        recommendation = this.scalingMonitor.GetScaleRecommendation(workerCount, collectedMetrics);
-                    }
-                }
-                catch (Exception e) when (!Utils.IsFatal(e))
-                {
-                    this.scalingMonitor.ErrorTracer?.Invoke("ScaleMonitor failed to compute scale recommendation", e);
-                    recommendation = new ScaleRecommendation(ScaleAction.None, keepWorkersAlive: true, reason: "unexpected error");
-                }
-               
-                this.scalingMonitor.RecommendationTracer?.Invoke(recommendation.Action.ToString(), workerCount, recommendation.Reason);
-
-                ScaleStatus scaleStatus = new ScaleStatus();
-                switch (recommendation?.Action)
-                {
-                    case ScaleAction.AddWorker:
-                        scaleStatus.Vote = ScaleVote.ScaleOut;
-                        break;
-                    case ScaleAction.RemoveWorker:
-                        scaleStatus.Vote = ScaleVote.ScaleIn;
-                        break;
-                    default:
-                        scaleStatus.Vote = ScaleVote.None;
-                        break;
-                }
-
-                return scaleStatus;
             }
         }
     }

--- a/src/DurableTask.Netherite.AzureFunctions/NetheriteScaleMetrics.cs
+++ b/src/DurableTask.Netherite.AzureFunctions/NetheriteScaleMetrics.cs
@@ -1,0 +1,14 @@
+﻿#if !NETCOREAPP2_2
+namespace DurableTask.Netherite.AzureFunctions
+{
+    using Microsoft.Azure.WebJobs.Host.Scale;
+
+    /// <summary>
+    /// Contains metrics used in scaling for Durable Triggers using a Netherite backend.
+    /// </summary>
+    public class NetheriteScaleMetrics : ScaleMetrics
+    {
+        public byte[] Metrics { get; set; }
+    }
+}
+#endif

--- a/src/DurableTask.Netherite.AzureFunctions/NetheriteScaleMonitor.cs
+++ b/src/DurableTask.Netherite.AzureFunctions/NetheriteScaleMonitor.cs
@@ -1,0 +1,130 @@
+﻿#if !NETCOREAPP2_2
+namespace DurableTask.Netherite.AzureFunctions
+{
+    using System;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Runtime.Serialization;
+    using DurableTask.Core.Common;
+    using DurableTask.Netherite.Scaling;
+    using Microsoft.Azure.WebJobs.Host.Scale;
+    using static DurableTask.Netherite.AzureFunctions.NetheriteProvider;
+    using System.Threading.Tasks;
+    using System.Linq;
+
+    /// <summary>
+    /// Scale monitor for Durable Functions using Netherite backend.
+    /// </summary>
+    public class NetheriteScaleMonitor : IScaleMonitor<NetheriteScaleMetrics>
+    {
+        readonly ScalingMonitor scalingMonitor;
+        readonly ScaleMonitorDescriptor descriptor;
+        readonly DataContractSerializer serializer = new DataContractSerializer(typeof(ScalingMonitor.Metrics));
+        static Tuple<DateTime, NetheriteScaleMetrics> cachedMetrics;
+
+        /// <summary>
+        /// Creates a new instance of the NetheriteScaleMonitor.
+        /// </summary>
+        /// <param name="scalingMonitor">Inner scaling monitor that the NetheriteScaleMonitor uses for scale decisions.</param>
+        public NetheriteScaleMonitor(ScalingMonitor scalingMonitor)
+        {
+            this.scalingMonitor = scalingMonitor;
+            this.descriptor = new ScaleMonitorDescriptor($"DurableTaskTrigger-Netherite-{this.scalingMonitor.TaskHubName}".ToLower());
+        }
+
+        public ScaleMonitorDescriptor Descriptor => this.descriptor;
+
+
+        async Task<ScaleMetrics> IScaleMonitor.GetMetricsAsync()
+        {
+            return await this.GetMetricsAsync();
+        }
+
+        public async Task<NetheriteScaleMetrics> GetMetricsAsync()
+        {
+            // if we recently collected the metrics, return the cached result now.
+            var cached = cachedMetrics;
+            if (cached != null && DateTime.UtcNow - cached.Item1 < TimeSpan.FromSeconds(1.5))
+            {
+                this.scalingMonitor.InformationTracer?.Invoke($"ScaleMonitor returned metrics cached previously, at {cached.Item2.Timestamp:o}");
+                return cached.Item2;
+            }
+
+            var metrics = new NetheriteScaleMetrics();
+
+            try
+            {
+                Stopwatch sw = new Stopwatch();
+                sw.Start();
+                var collectedMetrics = await this.scalingMonitor.CollectMetrics();
+                sw.Stop();
+
+                var stream = new MemoryStream();
+                this.serializer.WriteObject(stream, collectedMetrics);
+                metrics.Metrics = stream.ToArray();
+
+                this.scalingMonitor.InformationTracer?.Invoke(
+                    $"ScaleMonitor collected metrics for {collectedMetrics.LoadInformation.Count} partitions at {collectedMetrics.Timestamp:o} in {sw.Elapsed.TotalMilliseconds:F2}ms.");
+            }
+            catch (Exception e)
+            {
+                this.scalingMonitor.ErrorTracer?.Invoke("ScaleMonitor failed to collect metrics", e);
+            }
+
+            cachedMetrics = new Tuple<DateTime, NetheriteScaleMetrics>(DateTime.UtcNow, metrics);
+            return metrics;
+        }
+
+        ScaleStatus IScaleMonitor.GetScaleStatus(ScaleStatusContext context)
+        {
+            return this.GetScaleStatusCore(context.WorkerCount, context.Metrics?.Cast<NetheriteScaleMetrics>().ToArray());
+        }
+
+        public ScaleStatus GetScaleStatus(ScaleStatusContext<NetheriteScaleMetrics> context)
+        {
+            return this.GetScaleStatusCore(context.WorkerCount, context.Metrics?.ToArray());
+        }
+
+        ScaleStatus GetScaleStatusCore(int workerCount, NetheriteScaleMetrics[] metrics)
+        {
+            ScaleRecommendation recommendation;
+            try
+            {
+                if (metrics == null || metrics.Length == 0)
+                {
+                    recommendation = new ScaleRecommendation(ScaleAction.None, keepWorkersAlive: true, reason: "missing metrics");
+                }
+                else
+                {
+                    var stream = new MemoryStream(metrics[metrics.Length - 1].Metrics);
+                    var collectedMetrics = (ScalingMonitor.Metrics)this.serializer.ReadObject(stream);
+                    recommendation = this.scalingMonitor.GetScaleRecommendation(workerCount, collectedMetrics);
+                }
+            }
+            catch (Exception e) when (!Utils.IsFatal(e))
+            {
+                this.scalingMonitor.ErrorTracer?.Invoke("ScaleMonitor failed to compute scale recommendation", e);
+                recommendation = new ScaleRecommendation(ScaleAction.None, keepWorkersAlive: true, reason: "unexpected error");
+            }
+
+            this.scalingMonitor.RecommendationTracer?.Invoke(recommendation.Action.ToString(), workerCount, recommendation.Reason);
+
+            ScaleStatus scaleStatus = new ScaleStatus();
+            switch (recommendation?.Action)
+            {
+                case ScaleAction.AddWorker:
+                    scaleStatus.Vote = ScaleVote.ScaleOut;
+                    break;
+                case ScaleAction.RemoveWorker:
+                    scaleStatus.Vote = ScaleVote.ScaleIn;
+                    break;
+                default:
+                    scaleStatus.Vote = ScaleVote.None;
+                    break;
+            }
+
+            return scaleStatus;
+        }
+    }
+}
+#endif


### PR DESCRIPTION
We are currently redesigning the scale controller to unify the duplicate scaling logic that resides in each of the extensions (CosmosDB, ServiceBus, EventHubs, Storage, etc.) and the scale controller. As a part of this redesign, scale controller will directly instantiate the ScaleMonitors for each of the above extensions, and call into the GetMetricsAsync and GetScaleStatus methods directly. To support this, we need to make ScaleMonitors, and any dependent classes public in each of the extensions. 

Resources:
- [Azure Functions Scale Controller Redesign.docx](https://microsoft.sharepoint.com/:w:/r/teams/Antares/Shared%20Documents/Functions/Azure%20Functions%20Scale%20Controller%20Redesign.docx?d=wf9ab8e165f9644229184af0bc429587b&csf=1&web=1&e=bpERSt)
- [Azure Functions WebJobs SDK scaling changes.docx](https://microsoft.sharepoint.com/:w:/r/teams/Antares/Shared%20Documents/Functions/Azure%20Functions%20WebJobs%20SDK%20scaling%20changes.docx?d=w52e54eca0ff5459eb2312428921b6e46&csf=1&web=1&e=wMDf8Y)
- [WebJobsSDK that calls into each scale monitor](https://github.com/Azure/azure-webjobs-sdk/pull/2937)
- [Code snippet in v3.x that uses public scale monitor]