### PR TITLE
Fix Az Func dotnet-isolated extension

### DIFF
--- a/src/Functions.Worker.Extensions.DurableTask.Netherite/Functions.Worker.Extensions.DurableTask.Netherite.csproj
+++ b/src/Functions.Worker.Extensions.DurableTask.Netherite/Functions.Worker.Extensions.DurableTask.Netherite.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Netherite</AssemblyName>
     <LangVersion>latest</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
@@ -17,7 +18,7 @@
     <AssemblyOriginatorKeyFile>..\..\sign.snk</AssemblyOriginatorKeyFile>
     <Description>Netherite durability provider extension for Azure Durable Functions.</Description>
     <PackageTags>Azure Task Durable Orchestration Workflow Activity Reliable EventHubs</PackageTags>
-    <PackageId>Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Netherite</PackageId>
+    <PackageId>$(AssemblyName)</PackageId>
     <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>
 

--- a/src/Functions.Worker.Extensions.DurableTask.Netherite/Properties/AssemblyInfo.cs
+++ b/src/Functions.Worker.Extensions.DurableTask.Netherite/Properties/AssemblyInfo.cs
@@ -4,4 +4,4 @@
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
 // This must be updated when updating the version of the package
-[assembly: ExtensionInformation("Microsoft.Azure.DurableTask.Netherite.AzureFunctions", "1.3.0")]
+[assembly: ExtensionInformation("Microsoft.Azure.DurableTask.Netherite.AzureFunctions", "1.3.0", true)]


### PR DESCRIPTION
Two fixes:
1. Make sure assembly name and package name match (for consistency)
2. Add `enableImplicitRegistration = true` to the extension attribute.
    - This is because our package has 0 binding attributes in it, the build task skips it unless this is set to `true`.