### PR TITLE
Overhaul FASTER page and segment size parameters

### DIFF
--- a/src/DurableTask.Netherite/Abstractions/TransportAbstraction.cs
+++ b/src/DurableTask.Netherite/Abstractions/TransportAbstraction.cs
@@ -56,6 +56,12 @@ namespace DurableTask.Netherite
             /// </summary>
             /// <param name="partitionId">The partition id.</param>
             IPartitionErrorHandler CreateErrorHandler(uint partitionId);
+
+            /// <summary>
+            /// Trace a warning to the host logs
+            /// </summary>
+            /// <param name="message"></param>
+            void TraceWarning(string message);
         }
 
         /// <summary>

--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
@@ -366,6 +366,11 @@ namespace DurableTask.Netherite
                 (this.ContainerName, this.PathPrefix) = this.storage.GetTaskhubPathPrefix(this.TaskhubParameters);
                 this.NumberPartitions = (uint) this.TaskhubParameters.PartitionCount;
 
+                if (this.Settings.PartitionCount != this.NumberPartitions)
+                {
+                    this.TraceHelper.TraceWarning($"Ignoring configuration setting partitionCount={this.Settings.PartitionCount} because existing TaskHub has {this.NumberPartitions} partitions");
+                }
+
                 await this.transport.StartClientAsync();
 
                 System.Diagnostics.Debug.Assert(this.client != null, "transport layer should have added client");
@@ -421,11 +426,6 @@ namespace DurableTask.Netherite
                 }
 
                 await this.transport.StartWorkersAsync();
-
-                if (this.Settings.PartitionCount != this.NumberPartitions)
-                {
-                    this.TraceHelper.TraceWarning($"Ignoring configuration setting partitionCount={this.Settings.PartitionCount} because existing TaskHub has {this.NumberPartitions} partitions");
-                }
 
                 if (this.threadWatcher == null)
                 {

--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
@@ -557,6 +557,11 @@ namespace DurableTask.Netherite
             return new PartitionErrorHandler((int) partitionId, this.TraceHelper.Logger, this.Settings.LogLevelLimit, this.StorageAccountName, this.Settings.HubName);
         }
 
+        void TransportAbstraction.IHost.TraceWarning(string message)
+        {
+            this.TraceHelper.TraceWarning(message);
+        }
+
         /******************************/
         // client methods
         /******************************/

--- a/src/DurableTask.Netherite/StorageLayer/Faster/FasterKV.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/FasterKV.cs
@@ -86,7 +86,7 @@ namespace DurableTask.Netherite.Faster
 
             partition.ErrorHandler.Token.ThrowIfCancellationRequested();
 
-            this.storelogsettings = blobManager.GetDefaultStoreLogSettings(
+            this.storelogsettings = blobManager.GetStoreLogSettings(
                 partition.Settings.UseSeparatePageBlobStorage,
                 memoryTracker.MaxCacheSize,
                 partition.Settings.FasterTuningParameters);

--- a/src/DurableTask.Netherite/StorageLayer/Faster/FasterLog.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/FasterLog.cs
@@ -18,7 +18,7 @@ namespace DurableTask.Netherite.Faster
         public FasterLog(BlobManager blobManager, NetheriteOrchestrationServiceSettings settings)
         {
             this.blobManager = blobManager;
-            var eventlogsettings = blobManager.GetDefaultEventLogSettings(settings.UseSeparatePageBlobStorage, settings.FasterTuningParameters);
+            var eventlogsettings = blobManager.GetEventLogSettings(settings.UseSeparatePageBlobStorage, settings.FasterTuningParameters);
             this.log = new FASTER.core.FasterLog(eventlogsettings);
             blobManager.PartitionErrorHandler.OnShutdown += this.Shutdown;
             this.terminationToken = blobManager.PartitionErrorHandler.Token;

--- a/src/DurableTask.Netherite/StorageLayer/Faster/LogWorker.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/LogWorker.cs
@@ -35,7 +35,7 @@ namespace DurableTask.Netherite.Faster
             this.traceHelper = traceHelper;
             this.intakeWorker = new IntakeWorker(cancellationToken, this, partition.TraceHelper);
 
-            this.maxFragmentSize = (int) this.blobManager.GetDefaultEventLogSettings(partition.Settings.UseSeparatePageBlobStorage, partition.Settings.FasterTuningParameters).PageSize - 64; // faster needs some room for header, 64 bytes is conservative
+            this.maxFragmentSize = (int) this.blobManager.GetEventLogSettings(partition.Settings.UseSeparatePageBlobStorage, partition.Settings.FasterTuningParameters).PageSize - 64; // faster needs some room for header, 64 bytes is conservative
         }
 
         public const byte first = 0x1;

--- a/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsTransport.cs
+++ b/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsTransport.cs
@@ -99,8 +99,8 @@ namespace DurableTask.Netherite.EventHubsTransport
             this.cloudBlobContainer = cloudBlobClient.GetContainerReference(containerName);
             this.partitionScript = this.cloudBlobContainer.GetBlockBlobReference("partitionscript.json");
 
-            // check that the storage format is supported
-            BlobManager.CheckStorageFormat(this.parameters.StorageFormat, this.settings);
+            // check that the storage format is supported, and load immutable FASTER parameters
+            BlobManager.CheckAndLoadStorageFormat(this.parameters.StorageFormat, this.settings);
 
             this.connections = new EventHubsConnections(this.settings.EventHubsConnection, EventHubsTransport.PartitionHub, EventHubsTransport.ClientHubs, EventHubsTransport.LoadMonitorHub)
             {

--- a/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsTransport.cs
+++ b/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsTransport.cs
@@ -99,8 +99,8 @@ namespace DurableTask.Netherite.EventHubsTransport
             this.cloudBlobContainer = cloudBlobClient.GetContainerReference(containerName);
             this.partitionScript = this.cloudBlobContainer.GetBlockBlobReference("partitionscript.json");
 
-            // check that the storage format is supported, and load immutable FASTER parameters
-            BlobManager.CheckAndLoadStorageFormat(this.parameters.StorageFormat, this.settings);
+            // check that the storage format is supported, and load the relevant FASTER tuning parameters
+            BlobManager.LoadAndCheckStorageFormat(this.parameters.StorageFormat, this.settings, this.host.TraceWarning);
 
             this.connections = new EventHubsConnections(this.settings.EventHubsConnection, EventHubsTransport.PartitionHub, EventHubsTransport.ClientHubs, EventHubsTransport.LoadMonitorHub)
             {


### PR DESCRIPTION
The following FASTER tuning parameters are immutable, i.e. must not be changed after a task hub is created (or else the storage provider cannot start any more):
- hybrid log page size
- hybrid log segment size
- event log page size
- event log segment size

However, sometimes we *do* need to change these parameters. Most recently (#229), we found that object logs are not collected aggressively enough after compaction, because they hybrid log segment size is much too large. Therefore, we want to change this default.

In this PR, we
- record the above sizes in the `taskhubparameters.json` file of the task hub, so that we can restore them when loading a task hub, which guarantees that parameters *always* match what is in storage even if the defaults change or the user explicitly changes them.
- change the default hybrid log page size to 512k to allow more aggressive collection of the object logs after compaction.

For compatibility, if loading a task hub that has no sizes recorded, we assume it uses the default sizes (as of the time of this PR). 