### PR TITLE
Fix fragmentation/reassembly logic

### DIFF
--- a/src/DurableTask.Netherite/Events/Fragments/ClientEventFragment.cs
+++ b/src/DurableTask.Netherite/Events/Fragments/ClientEventFragment.cs
@@ -3,6 +3,7 @@
 
 namespace DurableTask.Netherite
 {
+    using System;
     using System.Runtime.Serialization;
 
     [DataContract]
@@ -10,6 +11,9 @@ namespace DurableTask.Netherite
     {
         [DataMember]
         public EventId OriginalEventId {  get; set; }
+
+        [DataMember]
+        public Guid? GroupId { get; set; } // we now use a group id for tracking fragments, to fix issue #231
 
         [DataMember]
         public byte[] Bytes { get; set; }

--- a/src/DurableTask.Netherite/Events/Fragments/PartitionEventFragment.cs
+++ b/src/DurableTask.Netherite/Events/Fragments/PartitionEventFragment.cs
@@ -16,6 +16,9 @@ namespace DurableTask.Netherite
         public EventId OriginalEventId { get; set; }
 
         [DataMember]
+        public Guid? GroupId { get; set; } // we now use a group id for tracking fragments, to fix issue #231
+
+        [DataMember]
         public byte[] Bytes { get; set; }
 
         [DataMember]
@@ -38,6 +41,11 @@ namespace DurableTask.Netherite
         protected override void ExtraTraceInformation(StringBuilder s)
         {
             s.Append(' ');
+            if (this.GroupId.HasValue)
+            {
+                s.Append(this.GroupId.Value.ToString("N"));
+                s.Append(' ');
+            }
             s.Append(this.Bytes.Length);
             if (this.IsLast)
             {

--- a/src/DurableTask.Netherite/OrchestrationService/Client.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/Client.cs
@@ -87,10 +87,9 @@ namespace DurableTask.Netherite
             if (clientEvent is ClientEventFragment fragment)
             {
                 var originalEventString = fragment.OriginalEventId.ToString();
-
                 var group = fragment.GroupId.HasValue
                   ? fragment.GroupId.Value.ToString()       // groups are now the way we track fragments
-                  : $"{fragment.OriginalEventId}-{fragment.ReceiveChannel}";  // prior to introducing groups, we used event id and channel, which is not always good enough
+                  : $"{originalEventString}-{fragment.ReceiveChannel}";  // prior to introducing groups, we used event id and channel, which is not always good enough
 
                 if (this.traceHelper.LogLevelLimit == Microsoft.Extensions.Logging.LogLevel.Trace)
                 {

--- a/src/DurableTask.Netherite/OrchestrationService/Client.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/Client.cs
@@ -39,7 +39,7 @@ namespace DurableTask.Netherite
 
         readonly BatchTimer<PendingRequest> ResponseTimeouts;
         readonly ConcurrentDictionary<long, PendingRequest> ResponseWaiters;
-        readonly Dictionary<(string,int), (MemoryStream, int)> Fragments;
+        readonly Dictionary<string, (MemoryStream, int)> Fragments;
         readonly Dictionary<long, QueryResponseReceived> QueryResponses;
 
         public static string GetShortId(Guid clientId) => clientId.ToString("N").Substring(0, 7);
@@ -62,7 +62,7 @@ namespace DurableTask.Netherite
             this.shutdownToken = shutdownToken;
             this.ResponseTimeouts = new BatchTimer<PendingRequest>(this.shutdownToken, this.Timeout, this.traceHelper.TraceTimerProgress);
             this.ResponseWaiters = new ConcurrentDictionary<long, PendingRequest>();
-            this.Fragments = new Dictionary<(string,int), (MemoryStream, int)>();
+            this.Fragments = new Dictionary<string, (MemoryStream, int)>();
             this.QueryResponses = new Dictionary<long, QueryResponseReceived>();
             this.ResponseTimeouts.Start("ClientTimer");
             this.workItemStopwatch = new Stopwatch();
@@ -87,7 +87,10 @@ namespace DurableTask.Netherite
             if (clientEvent is ClientEventFragment fragment)
             {
                 var originalEventString = fragment.OriginalEventId.ToString();
-                var index = (originalEventString, clientEvent.ReceiveChannel);
+
+                var group = fragment.GroupId.HasValue
+                  ? fragment.GroupId.Value.ToString()       // groups are now the way we track fragments
+                  : $"{fragment.OriginalEventId}-{fragment.ReceiveChannel}";  // prior to introducing groups, we used event id and channel, which is not always good enough
 
                 if (this.traceHelper.LogLevelLimit == Microsoft.Extensions.Logging.LogLevel.Trace)
                 {
@@ -96,7 +99,7 @@ namespace DurableTask.Netherite
 
                 if (fragment.IsLast)
                 {
-                    (MemoryStream stream, int last) = this.Fragments[index];
+                    (MemoryStream stream, int last) = this.Fragments[group];
 
                     if (last != fragment.Fragment)
                     {
@@ -104,6 +107,8 @@ namespace DurableTask.Netherite
                     }
 
                     var reassembledEvent = FragmentationAndReassembly.Reassemble<ClientEvent>(stream, fragment);
+
+                    this.Fragments.Remove(group);
 
                     this.Process(reassembledEvent);
                 }
@@ -113,11 +118,11 @@ namespace DurableTask.Netherite
 
                     if (fragment.Fragment == 0)
                     {
-                        this.Fragments[index] = streamAndPosition = (new MemoryStream(), 0);
+                        this.Fragments[group] = streamAndPosition = (new MemoryStream(), 0);
                     }
                     else
                     {
-                        streamAndPosition = this.Fragments[index];
+                        streamAndPosition = this.Fragments[group];
                     }
                     
                     if (streamAndPosition.Item2 != fragment.Fragment)
@@ -128,13 +133,11 @@ namespace DurableTask.Netherite
                     streamAndPosition.Item1.Write(fragment.Bytes, 0, fragment.Bytes.Length);
                     streamAndPosition.Item2++;
 
-                    this.Fragments[index] = streamAndPosition;
+                    this.Fragments[group] = streamAndPosition;
                 }
             }
             else
             {
-                this.Fragments.Remove((clientEvent.EventIdString, clientEvent.ReceiveChannel));
-
                 if (clientEvent is QueryResponseReceived queryResponseReceived)
                 {
                     queryResponseReceived.DeserializeOrchestrationStates();

--- a/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsSender.cs
+++ b/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsSender.cs
@@ -98,8 +98,9 @@ namespace DurableTask.Netherite.EventHubsTransport
                         if (tooBig)
                         {
                             // the message is too big. Break it into fragments, and send each individually.
-                            this.traceHelper.LogDebug("EventHubsSender {eventHubName}/{eventHubPartitionId} fragmenting large event ({size} bytes) id={eventId}", this.eventHubName, this.eventHubPartition, length, evt.EventIdString);
-                            var fragments = FragmentationAndReassembly.Fragment(arraySegment, evt, this.maxFragmentSize);
+                            Guid groupId = Guid.NewGuid();
+                            this.traceHelper.LogDebug("EventHubsSender {eventHubName}/{eventHubPartitionId} fragmenting large event ({size} bytes) id={eventId} groupId={group:N}", this.eventHubName, this.eventHubPartition, length, evt.EventIdString, groupId);
+                            var fragments = FragmentationAndReassembly.Fragment(arraySegment, evt, groupId, this.maxFragmentSize);
                             maybeSent = i;
                             for (int k = 0; k < fragments.Count; k++)
                             {

--- a/src/DurableTask.Netherite/Util/FragmentationAndReassembly.cs
+++ b/src/DurableTask.Netherite/Util/FragmentationAndReassembly.cs
@@ -24,7 +24,7 @@ namespace DurableTask.Netherite
             int Fragment { get; }
         }
 
-        public static List<IEventFragment> Fragment(ArraySegment<byte> segment, Event original, int maxFragmentSize)
+        public static List<IEventFragment> Fragment(ArraySegment<byte> segment, Event original, Guid groupId, int maxFragmentSize)
         {
             if (segment.Count <= maxFragmentSize)
                 throw new ArgumentException(nameof(segment), "segment must be larger than max fragment size");
@@ -40,6 +40,7 @@ namespace DurableTask.Netherite
                 {
                     list.Add(new ClientEventFragment()
                     {
+                        GroupId = groupId,
                         ClientId = clientEvent.ClientId,
                         RequestId = clientEvent.RequestId,
                         OriginalEventId = original.EventId,
@@ -52,6 +53,7 @@ namespace DurableTask.Netherite
                 {
                     list.Add(new PartitionEventFragment()
                     {
+                        GroupId = groupId,
                         PartitionId = partitionEvent.PartitionId,
                         OriginalEventId = original.EventId,
                         Timeout = (partitionEvent as ClientRequestEvent)?.TimeoutUtc,


### PR DESCRIPTION
As discovered in #231, there is a bug in the fragmentation/reassembly logic that is exposed in situations where a partition is moved to a different node while it is sending a fragmented event. In that case, fragments of the old sequence can interleave with fragments of the new sequence, which breaks the reassembly logic. 

To fix this, this PR changes the logic so it uses a unique identifier Guid, instead of the event id, to track groups of fragments that belong together. This guarantees that even in interleaving situations, we correctly track each sequence separately.

For compatibility, this change adds the Guid as a nullable new field to the fragment. Old fragments can thus still be deserialized as before, and are treated the same way as before (which is important for not breaking existing task hubs since the event sourcing may replay events with the expectation of deterministic results).