### PR TITLE
fix various issues with client shutdown

### DIFF
--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
@@ -466,9 +466,6 @@ namespace DurableTask.Netherite
 
                 this.OnStopping?.Invoke();
 
-                this.checkedClient = null;
-                this.client = null;
-
                 if (this.serviceShutdownSource != null)
                 {
                     this.serviceShutdownSource.Cancel();

--- a/src/DurableTask.Netherite/OrchestrationService/Partition.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/Partition.cs
@@ -175,6 +175,9 @@ namespace DurableTask.Netherite
 
                 bool takeCheckpoint = this.Settings.TakeStateCheckpointWhenStoppingPartition && !quickly;
 
+                // wait for the timer loop to be stopped so we don't have timers firing during shutdown
+                await this.PendingTimers.StopAsync();
+
                 // for a clean shutdown we try to save some of the latest progress to storage and then release the lease
                 bool clean = true;
                 try

--- a/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsTransport.cs
+++ b/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsTransport.cs
@@ -292,9 +292,6 @@ namespace DurableTask.Netherite.EventHubsTransport
             this.traceHelper.LogInformation("Shutting down EventHubsBackend");
             this.shutdownSource.Cancel(); // initiates shutdown of client and of all partitions
 
-            this.traceHelper.LogDebug("Stopping client");
-            await this.client.StopAsync();
-
             if (this.hasWorkers)
             {
                 this.traceHelper.LogDebug("Stopping partition and loadmonitor hosts");
@@ -305,6 +302,9 @@ namespace DurableTask.Netherite.EventHubsTransport
 
             this.traceHelper.LogDebug("Stopping client process loop");
             await this.clientProcessTask;
+
+            this.traceHelper.LogDebug("Stopping client");
+            await this.client.StopAsync();
 
             this.traceHelper.LogDebug("Closing connections");
             await this.connections.StopAsync();


### PR DESCRIPTION
There are currently various issues with how the client behaves when the orchestration service shuts down, including a null reference being thrown as reported in #223.

This PR fixes these issues, making the following changes:

- The orchestration service no longer sets the client to null when stopping. This avoids the null-reference exception.
- The client is stopped after stopping the workers. This helps to keep the client operational for a longer time.
- BatchTimer now shuts down cleanly: has a StopAsync() that waits for the expiration-check loop to exit before returning.
- The client now shuts down cleanly: the StopAsync() goes through all pending client requests and throws a descriptive OperationCanceledException.
- The client now checks for shutdown right after issuing a request. This means it is guaranteed to receive an OperationCanceledException regardless of any races with the exact timing when StopAsync() is called.
- The Client.PerformRequestWithTimeoutAndCancellation had an irrelevant argument (doneWhenSent) which was removed.  
- The Client.PerformRequestWithTimeoutAndCancellation was ignoring the passed-in cancellationToken argument. This was fixed by adding the logic to cancel the request appropriately. Since this incurs an additional allocation (and only very few calls actually need it), an overload Client.PerformRequestWithTimeout was added which does not take a cancellation token argument.

