### PR TITLE
Add semaphore example to PerformanceBenchmarks

### DIFF
--- a/test/PerformanceTests/Benchmarks/Semaphore/HttpTriggers.cs
+++ b/test/PerformanceTests/Benchmarks/Semaphore/HttpTriggers.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace PerformanceTests.HelloCities
+{
+    using System;
+    using System.IO;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.Http;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.Extensions.Logging;
+    using Newtonsoft.Json;
+    using System.Collections.Generic;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+    using System.Linq;
+    using System.Collections.Concurrent;
+    using System.Threading;
+
+    /// <summary>
+    /// A simple microbenchmark orchestration that some trivial activities in a sequence.
+    /// </summary>
+    public static class SemaphoreHttpTriggers
+    {
+        [FunctionName(nameof(SemaphoreOrchestration))]
+        public static async Task<IActionResult> SemaphoreOrchestration(
+           [HttpTrigger(AuthorizationLevel.Anonymous, "get")] HttpRequest req,
+           [DurableClient] IDurableClient client,
+           ILogger log)
+        {
+            // start the orchestration
+            string orchestrationInstanceId = await client.StartNewAsync("OrchestrationWithSemaphore");
+
+            // wait for it to complete and return the result
+            return await client.WaitForCompletionOrCreateCheckStatusResponseAsync(req, orchestrationInstanceId, TimeSpan.FromSeconds(400));
+        }
+
+        [FunctionName(nameof(Semaphore))]
+        public static async Task<IActionResult> Semaphore(
+          [HttpTrigger(AuthorizationLevel.Anonymous, "get")] HttpRequest req,
+          [DurableClient] IDurableClient client,
+          ILogger log)
+        {
+            var response = await client.ReadEntityStateAsync<SemaphoreTest.SemaphoreEntity>(new EntityId("SemaphoreEntity", "MySemaphoreInstance"));
+            return new OkObjectResult(response);
+        }
+    }
+}

--- a/test/PerformanceTests/Benchmarks/Semaphore/Semaphore.cs
+++ b/test/PerformanceTests/Benchmarks/Semaphore/Semaphore.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace PerformanceTests.HelloCities
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using System.Threading;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+    using Microsoft.Extensions.Logging;
+
+    /// <summary>
+    /// A simple microbenchmark orchestration that executes several simple "hello" activities in a sequence.
+    /// </summary>
+    public static partial class SemaphoreTest
+    {
+        [FunctionName("OrchestrationWithSemaphore")]
+        public static async Task<string> OrchestrationWithSemaphore([OrchestrationTrigger] IDurableOrchestrationContext context)
+        {
+            EntityId semaphore = new EntityId("SemaphoreEntity", "MySemaphoreInstance");
+            Guid requestId = context.NewGuid();
+            DateTime startTime = context.CurrentUtcDateTime;
+            TimeSpan timeOut = TimeSpan.FromMinutes(5);
+            try
+            {
+                while (true)
+                {
+                    if (await context.CallEntityAsync<bool>(semaphore, "TryAcquire", requestId))
+                    {
+                        break; // we have acquired the semaphore
+                    }
+                    if (context.CurrentUtcDateTime > startTime + timeOut)
+                    {
+                        throw new Exception("timed out while waiting for semaphore");               
+                    }
+                    else
+                    {
+                        await context.CreateTimer(context.CurrentUtcDateTime + TimeSpan.FromSeconds(1), CancellationToken.None);
+                    }             
+                }           
+                await context.CallActivityAsync("ActivityThatRequiresSemaphore", null);
+
+                return "Completed successfully.";
+            }
+            finally
+            {
+                context.SignalEntity(semaphore, "Release", requestId);
+            }
+        }
+
+        [FunctionName("SemaphoreEntity")]
+        public static Task Run([EntityTrigger] IDurableEntityContext ctx) 
+            => ctx.DispatchAsync<SemaphoreEntity>();
+
+        public class SemaphoreEntity
+        {
+            public List<Guid> Requests { get; set; } = new List<Guid>();
+
+            public int MaxCount { get; set; } = 50;
+
+            public bool TryAcquire(Guid id)
+            {
+                int position = this.Requests.IndexOf(id);
+                if (position == -1)
+                {
+                    this.Requests.Add(id);
+                    position = this.Requests.Count - 1;
+                }
+                return (position < this.MaxCount);
+            }
+ 
+            public void Release(Guid id)
+            {
+                this.Requests.Remove(id);
+            }
+        }
+
+        [FunctionName("ActivityThatRequiresSemaphore")]
+        public static Task ActivityThatRequiresSemaphore([ActivityTrigger] IDurableActivityContext context, ILogger logger)
+        {
+            logger.LogInformation("Entering");
+            Thread.Sleep(100);
+            logger.LogInformation("Exiting");
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
This example demonstrates how one can use an entity to implement a semaphore that acts as a global concurrency-limiter for activities.

This was motivated by the discussion in https://github.com/Azure/azure-functions-durable-extension/issues/2434.

To run the tests locally,

1. Modify host.json in the PerfomanceTests project if you want to use AzureStorage provider instead of Netherite
2.  Set environment variables for `AzureWebJobsStorage` and `EventHubsConnection` (don't need the latter unless using Netherite)
3. Start PerformanceTests function app 
4. Launch 1000 orchestrations by `curl http://localhost:7071/start -d OrchestrationWithSemaphore.1000`
5. Observe progress of the orchestrations by calling `curl http://localhost:7071/query`
6. Observe state of the semaphore by calling  `curl http://localhost:7071/semaphore`

FYI, when I ran quick tests on my local machine, Netherite completed all the orchestrations in 38 seconds and Azure Storage backend completed them in 190 seconds.