### PR TITLE
Fix ignored tuning parameter

### DIFF
--- a/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/BlobManager.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/BlobManager.cs
@@ -144,7 +144,7 @@ namespace DurableTask.Netherite.Faster
         {
             int pageSizeBits =    tuningParameters?.StoreLogPageSizeBits    ?? 10; // 1kB
             int segmentSizeBits = tuningParameters?.StoreLogSegmentSizeBits ?? 19; // 512 kB
-            int memorySizeBits = 29; // 512 MB - that is just the max, not what we actually use
+            int memorySizeBits = tuningParameters?.StoreLogMemorySizeBits ?? 29; // 512 MB - that is just the max, not what we actually use
 
             return (pageSizeBits, segmentSizeBits, memorySizeBits);
         }


### PR DESCRIPTION
This was an oversight when committing #235.

It means that the memory is not being correctly set, but always uses the default. This may have also inadvertently caused recovery failures when opening task hubs created with an older version.