### PR TITLE
Fix null metrics exceptions

### DIFF
--- a/src/DurableTask.Netherite.AzureFunctions/NetheriteProvider.cs
+++ b/src/DurableTask.Netherite.AzureFunctions/NetheriteProvider.cs
@@ -205,14 +205,16 @@ namespace DurableTask.Netherite.AzureFunctions
             {
                 ScaleRecommendation recommendation;               
                 try
-                { 
-                    if (metrics == null || metrics.Length == 0)
+                {
+                    var lastMetric = metrics?.LastOrDefault(m => m?.Metrics != null);
+
+                    if (lastMetric == null)
                     {
                         recommendation = new ScaleRecommendation(ScaleAction.None, keepWorkersAlive: true, reason: "missing metrics");
                     }
                     else
                     {
-                        var stream = new MemoryStream(metrics[metrics.Length - 1].Metrics);
+                        var stream = new MemoryStream(lastMetric.Metrics);
                         var collectedMetrics = (ScalingMonitor.Metrics) this.serializer.ReadObject(stream);                 
                         recommendation = this.scalingMonitor.GetScaleRecommendation(workerCount, collectedMetrics);
                     }


### PR DESCRIPTION
Sometimes the scale monitor is called with null metrics. These are transient occurrences. Instead of throwing an exception, we handle this gracefully.

Fixes #246.