### PR TITLE
Optimize host shutdown

### DIFF
--- a/src/DurableTask.Netherite/OrchestrationService/Client.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/Client.cs
@@ -83,8 +83,7 @@ namespace DurableTask.Netherite
             await this.ResponseTimeouts.StopAsync();
 
             // We now enter the final stage of client shutdown, where we forcefully cancel
-            // all requests that have not completed yet. We do this as late as possible in the shutdown
-            // process, so that requests still have a chance to successfully complete as long as possible.
+            // all requests that have not completed yet. 
             this.allRemainingRequestsAreNowBeingCancelled = true;
             while (true)
             {

--- a/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsProcessor.cs
+++ b/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsProcessor.cs
@@ -266,14 +266,15 @@ namespace DurableTask.Netherite.EventHubsTransport
 
             using (await this.deliveryLock.LockAsync())
             {
-                this.traceHelper.LogDebug("EventHubsProcessor {eventHubName}/{eventHubPartition} starting shutdown task", this.eventHubName, this.eventHubPartition);
-
                 if (this.shutdownTask == null)
                 {
+                    this.traceHelper.LogDebug("EventHubsProcessor {eventHubName}/{eventHubPartition} starting shutdown task", this.eventHubName, this.eventHubPartition);
                     this.shutdownTask = Task.Run(() => ShutdownAsync());
                 }
-
-                this.traceHelper.LogDebug("EventHubsProcessor {eventHubName}/{eventHubPartition} started shutdown task", this.eventHubName, this.eventHubPartition);
+                else
+                {
+                    this.traceHelper.LogDebug("EventHubsProcessor {eventHubName}/{eventHubPartition} shutdown task already started", this.eventHubName, this.eventHubPartition);
+                }
             }
 
             await this.shutdownTask;


### PR DESCRIPTION
Currently, when the EventHubsTransport shuts down, it shuts down the client and closes the EH connection *only after* all the workers are shut down.

This can cause problems if the worker shut down hangs as observed in #245, because the EH client does not shut down, causing issues.

This PR modifies the shut down so that clients & connections are shut down in parallel with the workers. This fixes the problem described above, and also improves the speed of the shutdown process.