### PR TITLE
Fix race condition in OutboxState

### DIFF
--- a/src/DurableTask.Netherite/PartitionState/OutboxState.cs
+++ b/src/DurableTask.Netherite/PartitionState/OutboxState.cs
@@ -108,7 +108,8 @@ namespace DurableTask.Netherite
 
             if (batch.OutgoingResponses.Count > 0)
             {
-                foreach (var outresponse in batch.OutgoingResponses.ToArray())
+                var outgoingResponses = batch.OutgoingResponses.ToArray(); //copy for safe iteration
+                foreach (var outresponse in outgoingResponses )
                 {
                     DurabilityListeners.Register(outresponse, batch);
                     this.Partition.Send(outresponse);
@@ -116,7 +117,8 @@ namespace DurableTask.Netherite
             }
             if (batch.OutgoingMessages.Count > 0)
             {
-                foreach (var outmessage in batch.OutgoingMessages.ToArray())
+                var outgoingMessages =  batch.OutgoingMessages.ToArray(); // copy for safe iteration
+                foreach (var outmessage in outgoingMessages)
                 {
                     DurabilityListeners.Register(outmessage, batch);
                     this.Partition.Send(outmessage);


### PR DESCRIPTION
Fixes a problem discovered during testing.

While iterating over the collection of messages to send, even if this is just a single message, the send can actually complete, and the send confirmation can also complete, at which point the element may be removed from the collection, which causes a conflict with the initial loop iteration as we see here:
```
System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
   at DurableTask.Netherite.OutboxState.Send(Batch batch) in D:\git\durabletask-netherite\src\DurableTask.Netherite\PartitionState\OutboxState.cs:line 112
   at DurableTask.Netherite.DurabilityListeners.ConfirmDurable(Event evt) in D:\git\durabletask-netherite\src\DurableTask.Netherite\Util\DurabilityListeners.cs:line 79
   at DurableTask.Netherite.Faster.LogWorker.Process(IList`1 batch) in D:\git\durabletask-netherite\src\DurableTask.Netherite\StorageLayer\Faster\LogWorker.cs:line 168
```

This PR fixes the problem by copying the collection into an array before iterating over it.