### PR TITLE
Fix double application of partition events on tracked objects

### DIFF
--- a/src/DurableTask.Netherite/Abstractions/PartitionState/EffectTracker.cs
+++ b/src/DurableTask.Netherite/Abstractions/PartitionState/EffectTracker.cs
@@ -77,8 +77,12 @@ namespace DurableTask.Netherite
         {
             try
             {
-                this.currentUpdate.ApplyTo(trackedObject, this);
-                trackedObject.Version++;
+                if (trackedObject.LastUpdate < this.currentUpdate.NextCommitLogPosition)
+                {
+                    this.currentUpdate.ApplyTo(trackedObject, this);
+                    trackedObject.Version++;
+                    trackedObject.LastUpdate = this.currentUpdate.NextCommitLogPosition;
+                }
             }
             catch (Exception exception) when (!Utils.IsFatal(exception))
             {

--- a/src/DurableTask.Netherite/Abstractions/PartitionState/TrackedObject.cs
+++ b/src/DurableTask.Netherite/Abstractions/PartitionState/TrackedObject.cs
@@ -30,6 +30,9 @@ namespace DurableTask.Netherite
         [DataMember]
         public int Version { get; set;  } // we use this validate consistency of read/write updates in FASTER, it is not otherwise needed
 
+        [IgnoreDataMember]
+        public long LastUpdate { get; set; } // workaround for filtering out occasional duplicate RMW invocations (#236)
+
         /// <summary>
         /// The collection of all types of tracked objects and polymorphic members of tracked objects. Can be
         /// used by serializers to compute a type map.


### PR DESCRIPTION
fix bug where an effect is applied twice due to an RMW executing twice in FASTER, as discovered and discussed in #236. The results are pretty unpredictable, state can get corrupted.

The fix is to record the log commit number of the last-applied event in the tracked object, and then use that to filter duplicate applications of the same event. It is not necessary to store this number with the tracked object, in-memory-only is sufficient (since the double RMW does not actually get committed).

This may also have had other manifestations that went undetected.