### PR TITLE
Fix inconsistent handling of expiration for partition event fragments

### DIFF
--- a/src/DurableTask.Netherite/Events/PartitionEvents/Internal/RecoveryCompleted.cs
+++ b/src/DurableTask.Netherite/Events/PartitionEvents/Internal/RecoveryCompleted.cs
@@ -29,6 +29,9 @@ namespace DurableTask.Netherite
         [DataMember]
         public bool KeepInstanceIdsInMemory { get; set; }
 
+        [DataMember]
+        public bool UseExpirationHorizonForFragments { get; set; }
+
         [IgnoreDataMember]
         public override bool ResetInputQueue => !string.IsNullOrEmpty(this.ChangedFingerprint);
 

--- a/src/DurableTask.Netherite/StorageLayer/Faster/StoreWorker.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/StoreWorker.cs
@@ -602,6 +602,7 @@ namespace DurableTask.Netherite.Faster
                 Timestamp = incarnationTimestamp,
                 WorkerId = this.partition.Settings.WorkerId,
                 KeepInstanceIdsInMemory = this.partition.Settings.KeepInstanceIdsInMemory,
+                UseExpirationHorizonForFragments = true,
                 ChangedFingerprint = queueChange ? inputQueueFingerprint : null,
             };
 


### PR DESCRIPTION
In my testing I noticed that defragmentation of events was failing occasionally.

After some analysis I found that the existing code was handling the expiration of fragments inconsistently:
- during recovery, fragments deemed irrelevant (because they belong to already-timed out client requests or already-processed messages from other partitions) were removed from the `ReassemblyState` tracked object. This is a correct idea that is necessary to avoid keeping such fragments forever in circumstances where the group will never be completed.
- but incoming fragments were still always looking up previous fragments in the group, causing crashes because what they were looking for had already been removed.

This PR fixes these crashes by remembering the horizon of what it has removed; it can the throw away incoming fragments whose group was already removed immediately instead of looking them up.