### PR TITLE
Fix data race in memory tracker

### DIFF
--- a/src/DurableTask.Netherite/StorageLayer/Faster/MemoryTracker.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/MemoryTracker.cs
@@ -41,7 +41,8 @@ namespace DurableTask.Netherite.Faster
 
         public void UpdateTargetSizes()
         {
-            if (this.stores.Count > 0)
+            int numberOfStores = this.stores.Count;
+            if (numberOfStores > 0)
             {
                 long targetSize = this.maxCacheSize / this.stores.Count;
                 foreach (var s in this.stores.Keys)


### PR DESCRIPTION
Can cause divide-by-zero exceptions. It happens quite rarely. 

I observed this during long-running testing in the consumption plan.
