### PR TITLE
Implement clean shutdown of Event Hubs senders

### DIFF
--- a/src/DurableTask.Netherite/OrchestrationService/Client.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/Client.cs
@@ -80,8 +80,6 @@ namespace DurableTask.Netherite
             // cancel the token, if not already cancelled.
             this.cts.Cancel();
 
-            await this.ResponseTimeouts.StopAsync();
-
             // We now enter the final stage of client shutdown, where we forcefully cancel
             // all requests that have not completed yet. 
             this.allRemainingRequestsAreNowBeingCancelled = true;
@@ -97,6 +95,8 @@ namespace DurableTask.Netherite
                     break;
                 }
             }
+
+            await this.ResponseTimeouts.StopAsync();
 
             this.cts.Dispose();
 

--- a/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsClientSender.cs
+++ b/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsClientSender.cs
@@ -19,12 +19,12 @@ namespace DurableTask.Netherite.EventHubsTransport
         readonly EventHubsSender<ClientEvent>[] channels;
         int roundRobin;
 
-        public EventHubsClientSender(TransportAbstraction.IHost host, byte[] taskHubGuid, Guid clientId, PartitionSender[] senders, EventHubsTraceHelper traceHelper)
+        public EventHubsClientSender(TransportAbstraction.IHost host, byte[] taskHubGuid, Guid clientId, PartitionSender[] senders, CancellationToken shutdownToken, EventHubsTraceHelper traceHelper)
         {
             this.channels = new Netherite.EventHubsTransport.EventHubsSender<ClientEvent>[senders.Length];
             for (int i = 0; i < senders.Length; i++)
             {
-                this.channels[i] = new EventHubsSender<ClientEvent>(host, taskHubGuid, senders[i], traceHelper);
+                this.channels[i] = new EventHubsSender<ClientEvent>(host, taskHubGuid, senders[i], shutdownToken, traceHelper);
             }
         }
 
@@ -40,6 +40,11 @@ namespace DurableTask.Netherite.EventHubsTransport
         {
             var channel = this.channels.FirstOrDefault(this.Idle) ?? this.NextChannel();
             channel.Submit(toSend);
+        }
+
+        public Task WaitForShutdownAsync()
+        {
+            return Task.WhenAll(this.channels.Select(sender => sender.WaitForShutdownAsync()));
         }
     }
 }

--- a/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsTransport.cs
+++ b/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsTransport.cs
@@ -102,7 +102,7 @@ namespace DurableTask.Netherite.EventHubsTransport
             // check that the storage format is supported, and load the relevant FASTER tuning parameters
             BlobManager.LoadAndCheckStorageFormat(this.parameters.StorageFormat, this.settings, this.host.TraceWarning);
 
-            this.connections = new EventHubsConnections(this.settings.EventHubsConnection, EventHubsTransport.PartitionHub, EventHubsTransport.ClientHubs, EventHubsTransport.LoadMonitorHub)
+            this.connections = new EventHubsConnections(this.settings.EventHubsConnection, EventHubsTransport.PartitionHub, EventHubsTransport.ClientHubs, EventHubsTransport.LoadMonitorHub, this.shutdownSource.Token)
             {
                 Host = host,
                 TraceHelper = this.traceHelper,

--- a/src/DurableTask.Netherite/Util/BatchWorker.cs
+++ b/src/DurableTask.Netherite/Util/BatchWorker.cs
@@ -39,6 +39,8 @@ namespace DurableTask.Netherite
         bool processingBatch;
         public TimeSpan? ProcessingBatchSince => this.processingBatch ? this.stopwatch.Elapsed : null;
 
+        volatile TaskCompletionSource<object> shutdownCompletionSource;
+
         /// <summary>
         /// Constructor including a cancellation token.
         /// </summary>
@@ -91,6 +93,22 @@ namespace DurableTask.Netherite
             this.work.Enqueue(tcs);
             this.Notify();
             return tcs.Task;
+        }
+
+        public Task WaitForShutdownAsync()
+        {
+            if (!this.cancellationToken.IsCancellationRequested)
+            {
+                throw new InvalidOperationException("must call this only after canceling the token");
+            }
+
+            if (this.shutdownCompletionSource == null)
+            {
+                Interlocked.CompareExchange(ref this.shutdownCompletionSource, new TaskCompletionSource<object>(), null);
+                this.NotifyInternal();
+            }
+
+            return this.shutdownCompletionSource.Task;
         }
 
         readonly List<T> batch = new List<T>();
@@ -225,6 +243,11 @@ namespace DurableTask.Netherite
                 this.stopwatch.Stop();
                 this.processingBatch = false;
                 previousBatch = this.batch.Count;
+            }
+
+            if (this.cancellationToken.IsCancellationRequested)
+            {
+                this.shutdownCompletionSource?.TrySetResult(null);
             }
         }
 


### PR DESCRIPTION
To avoid exceptions during host shutdowns, this PR adds code that cleanly terminates the event hubs senders before stopping the event hub clients.

It works as follows:
- a cancellation token is passed to the batchworker that performs the sending.
- this token is triggered as the first thing when a host is shutting down.
- from that point on, the batchworker will no longer process new events.
- at some point during shutdown, we call `WaitForShutdownAsync()`.
- only after that do we destruct the event hub client that constructed the sender.

This guarantees that the sender is no longer active by the time we close the client.