### PR TITLE
Improve trace messages for non-executable instances

### DIFF
--- a/src/DurableTask.Netherite/Tracing/ClientTraceHelper.cs
+++ b/src/DurableTask.Netherite/Tracing/ClientTraceHelper.cs
@@ -111,11 +111,11 @@ namespace DurableTask.Netherite
             {
                 if (this.logger.IsEnabled(LogLevel.Debug))
                 {
-                    this.logger.LogDebug("{client} Sending event {eventId}: {event}", this.tracePrefix, @event.EventIdString, @event);
+                    this.logger.LogDebug("{client} Sending event {eventId} to partition {partitionId}: {event}", this.tracePrefix, @event.EventIdString, @event.PartitionId, @event);
                 }
                 if (EtwSource.Log.IsEnabled())
                 {
-                    EtwSource.Log.ClientSentEvent(this.account, this.taskHub, this.clientId, @event.EventIdString, @event.ToString(), TraceUtils.AppName, TraceUtils.ExtensionVersion);
+                    EtwSource.Log.ClientSentEvent(this.account, this.taskHub, this.clientId, (int) @event.PartitionId, @event.EventIdString, @event.ToString(), TraceUtils.AppName, TraceUtils.ExtensionVersion);
                 }
             }
         }

--- a/src/DurableTask.Netherite/Tracing/EtwSource.cs
+++ b/src/DurableTask.Netherite/Tracing/EtwSource.cs
@@ -243,11 +243,11 @@ namespace DurableTask.Netherite
             this.WriteEvent(243, Account, TaskHub, ClientId, PartitionEventId, status, EventInfo, AppName, ExtensionVersion);
         }
 
-        [Event(244, Level = EventLevel.Verbose, Version = 1)]
-        public void ClientSentEvent(string Account, string TaskHub, Guid ClientId, string PartitionEventId, string EventInfo, string AppName, string ExtensionVersion)
+        [Event(244, Level = EventLevel.Verbose, Version = 2)]
+        public void ClientSentEvent(string Account, string TaskHub, Guid ClientId, int PartitionId, string PartitionEventId, string EventInfo, string AppName, string ExtensionVersion)
         {
             SetCurrentThreadActivityId(serviceInstanceId);
-            this.WriteEvent(244, Account, TaskHub, ClientId, PartitionEventId, EventInfo, AppName, ExtensionVersion);
+            this.WriteEvent(244, Account, TaskHub, ClientId, PartitionId, PartitionEventId, EventInfo, AppName, ExtensionVersion);
         }
 
         [Event(245, Level = EventLevel.Informational, Version = 1)]


### PR DESCRIPTION
Makes several changes to how non-executable instances create warnings, to help users interpret them:
- distinguishes between entities and orchestrations in the error message
- uses clearer message text for describing the situation
- does not create any warnings for the common case where a TimerFiredEvent targets a completed orchestration, because this happens commonly for canceled timers