### PR TITLE
update fatal exception handling

### DIFF
--- a/src/DurableTask.Netherite/Abstractions/PartitionState/EffectTracker.cs
+++ b/src/DurableTask.Netherite/Abstractions/PartitionState/EffectTracker.cs
@@ -84,11 +84,20 @@ namespace DurableTask.Netherite
                     trackedObject.LastUpdate = this.currentUpdate.NextCommitLogPosition;
                 }
             }
-            catch (Exception exception) when (!Utils.IsFatal(exception))
+            catch (Exception exception)
             {
-                // for robustness, we swallow exceptions inside event processing.
-                // It does not mean they are not serious. We still report them as errors.
-                this.HandleError(nameof(ProcessUpdate), $"Encountered exception on {trackedObject} when applying update event {this.currentUpdate} eventId={this.currentUpdate?.EventId}", exception, false, false);
+                if (!Utils.IsFatal(exception))
+                {
+                    // for robustness, we swallow non-fatal exceptions inside event processing
+                    // It does not mean they are not serious. We still report them as errors.
+                    // (an incorrectly functioning partition is still better than a permanently dead one)
+                    this.HandleError(nameof(ProcessEffectOn), $"Encountered exception on {trackedObject} when applying update event {this.currentUpdate} eventId={this.currentUpdate?.EventId}", exception, false, false);
+                }
+                else
+                {
+                    // since fatal exeptions are transient, we terminate the partition immediately, so the next incarnation can continue correctly
+                    this.HandleError(nameof(ProcessEffectOn), $"Encountered fatal exception while applying update event eventId={this.currentUpdate?.EventId}", exception, true, false);
+                }
             }
         }
 
@@ -153,11 +162,20 @@ namespace DurableTask.Netherite
                 {
                     // o.k. during termination
                 }
-                catch (Exception exception) when (!Utils.IsFatal(exception))
+                catch (Exception exception)
                 {
-                    // for robustness, we swallow exceptions inside event processing.
-                    // It does not mean they are not serious. We still report them as errors.
-                    this.HandleError(nameof(ProcessUpdate), $"Encountered exception while processing update event {updateEvent} eventId={updateEvent?.EventId}", exception, false, false);
+                    if (!Utils.IsFatal(exception))
+                    {
+                        // for robustness, we swallow non-fatal exceptions inside event processing
+                        // It does not mean they are not serious. We still report them as errors.
+                        // (an incorrectly functioning partition is still better than a permanently dead one)
+                        this.HandleError(nameof(ProcessUpdate), $"Encountered exception while processing update event {updateEvent} eventId={updateEvent?.EventId}", exception, false, false);
+                    }
+                    else
+                    {
+                        // since fatal exeptions are transient, we terminate the partition immediately, so the next incarnation can continue correctly
+                        this.HandleError(nameof(ProcessUpdate), $"Encountered fatal exception while processing update event eventId={this.currentUpdate?.EventId}", exception, true, false);
+                    }
                 }
                 finally
                 {
@@ -212,11 +230,19 @@ namespace DurableTask.Netherite
                 {
                     // o.k. during termination
                 }
-                catch (Exception exception) when (!Utils.IsFatal(exception))
+                catch (Exception exception)
                 {
-                    // for robustness, we swallow exceptions inside event processing.
-                    // It does not mean they are not serious. We still report them as errors.
-                    this.HandleError(nameof(ProcessReadResult), $"Encountered exception while processing read event {readEvent} eventId={readEvent?.EventId}", exception, false, false);
+                    if (!Utils.IsFatal(exception))
+                    {
+                        // for robustness, we swallow non-fatal exceptions inside event processing
+                        // It does not mean they are not serious. We still report them as errors.
+                        this.HandleError(nameof(ProcessReadResult), $"Encountered exception while processing read event {readEvent} eventId={readEvent?.EventId}", exception, false, false);
+                    }
+                    else
+                    {
+                        // since fatal exeptions are transient, we terminate the partition immediately, so the next incarnation can continue correctly
+                        this.HandleError(nameof(ProcessReadResult), $"Encountered fatal exception while processing read event eventId={readEvent?.EventId}", exception, true, false);
+                    }
                 }
                 finally
                 {
@@ -243,11 +269,19 @@ namespace DurableTask.Netherite
                 {
                     // o.k. during termination
                 }
-                catch (Exception exception) when (!Utils.IsFatal(exception))
+                catch (Exception exception)
                 {
-                    // for robustness, we swallow exceptions inside event processing.
-                    // It does not mean they are not serious. We still report them as errors.
-                    this.HandleError(nameof(ProcessQueryResultAsync), $"Encountered exception while processing query event {queryEvent} eventId={queryEvent?.EventId}", exception, false, false);
+                    if (!Utils.IsFatal(exception))
+                    {
+                        // for robustness, we swallow non-fatal exceptions inside event processing
+                        // It does not mean they are not serious. We still report them as errors.
+                        this.HandleError(nameof(ProcessQueryResultAsync), $"Encountered exception while processing query event {queryEvent} eventId={queryEvent?.EventId}", exception, false, false);
+                    }
+                    else
+                    {
+                        // since fatal exeptions are transient, we terminate the partition immediately, so the next incarnation can continue correctly
+                        this.HandleError(nameof(ProcessQueryResultAsync), $"Encountered fatal exception while processing query event eventId={queryEvent?.EventId}", exception, true, false);
+                    }
                 }
                 finally
                 {

--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
@@ -193,7 +193,7 @@ namespace DurableTask.Netherite
                     this.Settings.TestHooks.OnError += (string message) => this.TraceHelper.TraceError("TestHook error", message);
                 }
             }
-            catch (Exception e) when (!Utils.IsFatal(e))
+            catch (Exception e)
             {
                 this.TraceHelper.TraceError("Could not create NetheriteOrchestrationService", e);
                 throw;
@@ -384,7 +384,7 @@ namespace DurableTask.Netherite
 
                 return ServiceState.Client;
             }
-            catch (Exception e) when (!Utils.IsFatal(e))
+            catch (Exception e)
             {
                 this.startupException = e;
 
@@ -436,7 +436,7 @@ namespace DurableTask.Netherite
 
                 return ServiceState.Full;
             }
-            catch (Exception e) when (!Utils.IsFatal(e))
+            catch (Exception e)
             {
                 this.startupException = e;
 
@@ -485,7 +485,7 @@ namespace DurableTask.Netherite
 
                 return ServiceState.None;
             }
-            catch (Exception e) when (!Utils.IsFatal(e))
+            catch (Exception e)
             {
                 this.TraceHelper.TraceError($"Failed to stop cleanly: {e.Message}", e);
                 throw;

--- a/src/DurableTask.Netherite/OrchestrationService/Partition.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/Partition.cs
@@ -137,7 +137,7 @@ namespace DurableTask.Netherite
                 // this happens when startup is canceled
                 throw;
             }
-            catch (Exception e) when (!Utils.IsFatal(e))
+            catch (Exception e)
             {
                 this.ErrorHandler.HandleError(nameof(CreateOrRestoreAsync), "Could not start partition", e, true, false);
                 throw;


### PR DESCRIPTION
The current implementation has many exception handlers that deliberately exclude fatal exceptions. While testing in the cloud, I noticed that this has some real disadvantages in some cases:

- The out of memory exception is typically not getting logged anywhere, so we have no infomation on what happened. This is not a good idea because sometimes a single stack trace can reveal some bug or configuration error and help us diagnose and fix the problem. If we are not logging anything, we are much less likely to be able to address the underlying issues.

- The out of memory exception is NOT guaranteed to instantly terminate the process. So, we still have to terminate as cleanly as we can, otherwise the application may continue to run partially, now in a bad state, and even do real damage (e.g. write incorrect things to storage). 

This PR updates the handling of fatal exceptions to:
- log information, then rethrow if appropriate
- immediately fullly terminate the partition in cases where a fatal exception is thrown during event processing