### PR TITLE
Fixes to azure storage calls

### DIFF
--- a/src/DurableTask.Netherite/Scaling/AzureTableLoadPublisher.cs
+++ b/src/DurableTask.Netherite/Scaling/AzureTableLoadPublisher.cs
@@ -38,7 +38,12 @@ namespace DurableTask.Netherite.Scaling
                 }
                 if (tableBatch.Count > 0)
                 {
-                    await this.table.SubmitTransactionAsync(tableBatch, cancellationToken).ConfigureAwait(false);
+                    var response = await this.table.SubmitTransactionAsync(tableBatch, cancellationToken).ConfigureAwait(false);
+
+                    foreach(var responseItem in response.Value)
+                    {
+                        responseItem.Dispose();
+                    }
                 }
             }
             catch(Azure.RequestFailedException e) when (e.Status == 404) // table may not exist
@@ -51,7 +56,7 @@ namespace DurableTask.Netherite.Scaling
             return this.table.CreateIfNotExistsAsync(cancellationToken);
         }
 
-        public Task PublishAsync(Dictionary<uint, PartitionLoadInfo> info, CancellationToken cancellationToken)
+        public async Task PublishAsync(Dictionary<uint, PartitionLoadInfo> info, CancellationToken cancellationToken)
         {
             var tableBatch = new List<TableTransactionAction>();
             foreach(var kvp in info)
@@ -60,11 +65,11 @@ namespace DurableTask.Netherite.Scaling
             }
             if (tableBatch.Count > 0)
             {
-                return this.table.SubmitTransactionAsync(tableBatch, cancellationToken);
-            }
-            else
-            {
-                return Task.CompletedTask;
+                var response = await this.table.SubmitTransactionAsync(tableBatch, cancellationToken);
+                foreach(var responseItem in response.Value)
+                {
+                    responseItem.Dispose();
+                }
             }
         }
 

--- a/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/AzureStorageDevice.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/AzureStorageDevice.cs
@@ -292,8 +292,16 @@ namespace DurableTask.Netherite.Faster
                     async (numAttempts) =>
                     {
                         var client = (numAttempts > 1) ? entry.PageBlob.Default : entry.PageBlob.Aggressive;
-                        await client.DeleteAsync(cancellationToken: this.PartitionErrorHandler.Token);
-                        return 1;
+                        try
+                        {
+                            await client.DeleteAsync(cancellationToken: this.PartitionErrorHandler.Token);
+                            return 1;
+                        }
+                        catch (Azure.RequestFailedException ex) when (numAttempts > 1 && BlobUtilsV12.BlobDoesNotExist(ex))
+                        {
+                            // blob may have already been deleted by the previous attempt
+                            return 0;
+                        }
                     });
             }
                 
@@ -327,8 +335,16 @@ namespace DurableTask.Netherite.Faster
                     async (numAttempts) =>
                     {
                         var client = (numAttempts > 1) ? entry.PageBlob.Default : entry.PageBlob.Aggressive;
-                        await client.DeleteAsync(cancellationToken: this.PartitionErrorHandler.Token);
-                        return 1;
+                        try
+                        {
+                            await client.DeleteAsync(cancellationToken: this.PartitionErrorHandler.Token);
+                            return 1;
+                        }
+                        catch (Azure.RequestFailedException ex) when (numAttempts > 1 && BlobUtilsV12.BlobDoesNotExist(ex))
+                        {
+                            // blob may have already been deleted by the previous attempt
+                            return 0;
+                        }
                     });
             }
 

--- a/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/AzureStorageDevice.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/AzureStorageDevice.cs
@@ -294,7 +294,7 @@ namespace DurableTask.Netherite.Faster
                         var client = (numAttempts > 1) ? entry.PageBlob.Default : entry.PageBlob.Aggressive;
                         try
                         {
-                            await client.DeleteAsync(cancellationToken: this.PartitionErrorHandler.Token);
+                            using var response = await client.DeleteAsync(cancellationToken: this.PartitionErrorHandler.Token);
                             return 1;
                         }
                         catch (Azure.RequestFailedException ex) when (numAttempts > 1 && BlobUtilsV12.BlobDoesNotExist(ex))
@@ -337,7 +337,7 @@ namespace DurableTask.Netherite.Faster
                         var client = (numAttempts > 1) ? entry.PageBlob.Default : entry.PageBlob.Aggressive;
                         try
                         {
-                            await client.DeleteAsync(cancellationToken: this.PartitionErrorHandler.Token);
+                            using var response = await client.DeleteAsync(cancellationToken: this.PartitionErrorHandler.Token);
                             return 1;
                         }
                         catch (Azure.RequestFailedException ex) when (numAttempts > 1 && BlobUtilsV12.BlobDoesNotExist(ex))
@@ -530,7 +530,10 @@ namespace DurableTask.Netherite.Faster
                                     cancellationToken: this.PartitionErrorHandler.Token)
                                     .ConfigureAwait(false);
 
-                                await response.Value.Content.CopyToAsync(stream).ConfigureAwait(false);
+                                using (var streamingResult = response.Value)
+                                {
+                                    await streamingResult.Content.CopyToAsync(stream).ConfigureAwait(false);
+                                }
                             }
 
                             if (stream.Position != offset + length)

--- a/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/AzureStorageDevice.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/AzureStorageDevice.cs
@@ -106,7 +106,7 @@ namespace DurableTask.Netherite.Faster
                 var prefix = $"{this.blockBlobDirectory}{this.blobName}.";
 
                 string continuationToken = null;
-                IReadOnlyList<BlobItem> pageResults = null;
+                IEnumerable<BlobItem> pageResults = null;
 
                 do
                 {
@@ -123,15 +123,25 @@ namespace DurableTask.Netherite.Faster
                         {
                             var client = this.pageBlobDirectory.Client.WithRetries;
 
-                            var page = await client.GetBlobsAsync(
+                            var enumerator = client.GetBlobsAsync(
                                 prefix: prefix,
                                 cancellationToken: this.PartitionErrorHandler.Token)
                                 .AsPages(continuationToken, 100)
-                                .FirstAsync();
+                                .GetAsyncEnumerator(cancellationToken: this.PartitionErrorHandler.Token);
 
-                            pageResults = page.Values;
-                            continuationToken = page.ContinuationToken;
-                            return page.Values.Count; // not accurate, in terms of bytes, but still useful for tracing purposes
+                            if (await enumerator.MoveNextAsync())
+                            {
+                                var page = enumerator.Current;
+                                pageResults = page.Values;
+                                continuationToken = page.ContinuationToken;
+                                return page.Values.Count; // not accurate, in terms of bytes, but still useful for tracing purposes
+                            }
+                            else
+                            {
+                                pageResults = Enumerable.Empty<BlobItem>();
+                                continuationToken = null;
+                                return 0;
+                            };
                         });
 
                     foreach (var item in pageResults)

--- a/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/AzureStorageDevice.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/AzureStorageDevice.cs
@@ -302,16 +302,8 @@ namespace DurableTask.Netherite.Faster
                     async (numAttempts) =>
                     {
                         var client = (numAttempts > 1) ? entry.PageBlob.Default : entry.PageBlob.Aggressive;
-                        try
-                        {
-                            using var response = await client.DeleteAsync(cancellationToken: this.PartitionErrorHandler.Token);
-                            return 1;
-                        }
-                        catch (Azure.RequestFailedException ex) when (numAttempts > 1 && BlobUtilsV12.BlobDoesNotExist(ex))
-                        {
-                            // blob may have already been deleted by the previous attempt
-                            return 0;
-                        }
+                        var response = await client.DeleteIfExistsAsync(cancellationToken: this.PartitionErrorHandler.Token);
+                        return response ? 1 : 0;
                     });
             }
                 

--- a/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/BlobManager.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/BlobManager.cs
@@ -983,7 +983,7 @@ namespace DurableTask.Netherite.Faster
                        {
                            var client = numAttempts > 2 ? this.eventLogCommitBlob.Default : this.eventLogCommitBlob.Aggressive;
 
-                           client.DownloadTo(
+                           using var response = client.DownloadTo(
                                destination: stream,
                                conditions: new BlobRequestConditions() { LeaseId = this.leaseClient.LeaseId },
                                cancellationToken: this.PartitionErrorHandler.Token);

--- a/src/DurableTask.Netherite/StorageLayer/Faster/FasterAlt.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/FasterAlt.cs
@@ -438,7 +438,7 @@ namespace DurableTask.Netherite.Faster
 
                         using var stream = new MemoryStream();
                         this.detailTracer?.FasterStorageProgress($"starting download target={blob.Name} attempt={numAttempts}");
-                        await blob.WithRetries.DownloadToAsync(stream, cancellationToken: this.blobManager.PartitionErrorHandler.Token).ConfigureAwait(false);
+                        using var response = await blob.WithRetries.DownloadToAsync(stream, cancellationToken: this.blobManager.PartitionErrorHandler.Token).ConfigureAwait(false);
                         this.detailTracer?.FasterStorageProgress($"finished download target={blob.Name} readLength={stream.Position}");
 
                         // parse the content and return it
@@ -586,7 +586,7 @@ namespace DurableTask.Netherite.Faster
                 Interlocked.Increment(ref this.blobManager.LeaseUsers);
                 var blob = BlobUtilsV12.GetBlockBlobClients(this.blobManager.BlockBlobContainer, $"p{this.partition.PartitionId:D2}/incomplete-checkpoints/{guid}");
                 await this.blobManager.ConfirmLeaseIsGoodForAWhileAsync().ConfigureAwait(false);
-                await blob.WithRetries.DeleteAsync(cancellationToken: this.blobManager.PartitionErrorHandler.Token);
+                using var response = await blob.WithRetries.DeleteAsync(cancellationToken: this.blobManager.PartitionErrorHandler.Token);
             }
             catch (Azure.RequestFailedException) when (this.terminationToken.IsCancellationRequested)
             {
@@ -610,7 +610,7 @@ namespace DurableTask.Netherite.Faster
                 Interlocked.Increment(ref this.blobManager.LeaseUsers);
                 var blob = BlobUtilsV12.GetBlockBlobClients(this.blobManager.BlockBlobContainer, $"p{this.partition.PartitionId:D2}/incomplete-checkpoints/{guid}");
                 await this.blobManager.ConfirmLeaseIsGoodForAWhileAsync().ConfigureAwait(false);
-                await blob.WithRetries.DeleteAsync(cancellationToken: this.blobManager.PartitionErrorHandler.Token);
+                using var response = await blob.WithRetries.DeleteAsync(cancellationToken: this.blobManager.PartitionErrorHandler.Token);
             }
             catch (Azure.RequestFailedException) when (this.terminationToken.IsCancellationRequested)
             {


### PR DESCRIPTION
Fixes a few omissions in code that uses the Azure Storage SDK:

1. do not report an error when retrying a delete and the blob was already deleted.
2. make sure to call Dispose() on all Azure responses that are IDisposable. This is a new requirement for Azure v12 SDK; previously, there was no such obligation on behalf of the caller.

Also, this PR removes a dependency on `FirstAsync` (a LINQ utility function for AsyncEnumberables) because this caused dependency issues for some .NET targets. 