### PR TITLE
limit frequency of failing partition starts

### DIFF
--- a/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsProcessor.cs
+++ b/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsProcessor.cs
@@ -244,7 +244,7 @@ namespace DurableTask.Netherite.EventHubsTransport
                 // the partition startup was canceled
                 this.traceHelper.LogDebug("EventHubsProcessor {eventHubName}/{eventHubPartition} canceled partition startup (incarnation {incarnation})", this.eventHubName, this.eventHubPartition, c.Incarnation);
             }
-            catch (Exception e)
+            catch (Exception e) when (!Utils.IsFatal(e))
             {
                 c.SuccessiveStartupFailures = 1 + (prior?.SuccessiveStartupFailures ?? 0);
                 c.ErrorHandler.HandleError("EventHubsProcessor.StartPartitionAsync", "failed to start partition", e, true, false);

--- a/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsProcessor.cs
+++ b/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsProcessor.cs
@@ -158,7 +158,7 @@ namespace DurableTask.Netherite.EventHubsTransport
                     this.currentIncarnation = prior.Next;
 
                     // sometimes we can get stuck into a loop of failing attempts to reincarnate a partition. 
-                    // We don't want to waste CPU  and pollute the logs, but we als can't just give up because
+                    // We don't want to waste CPU  and pollute the logs, but we also can't just give up because
                     // the failures can be transient. Thus we back off the retry pace.
                     TimeSpan addedDelay = 
                           (prior.SuccessiveStartupFailures < 2)   ? TimeSpan.Zero


### PR DESCRIPTION
I observed cases where partitions fail to start repeatedly. To reduce CPU waste and log pollution in those situations, this PR adds a backoff delay between retries.