### PR TITLE
fix LoadPublisher.FlushAsync

### DIFF
--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
@@ -422,7 +422,7 @@ namespace DurableTask.Netherite
                 if (this.storage.LoadPublisher != null)
                 {
                     this.TraceHelper.TraceProgress("Starting Load Publisher");
-                    this.LoadPublisher = new LoadPublishWorker(this.storage.LoadPublisher, CancellationToken.None, this.TraceHelper);
+                    this.LoadPublisher = new LoadPublishWorker(this.storage.LoadPublisher, this.TraceHelper);
                 }
 
                 await this.transport.StartWorkersAsync();

--- a/src/DurableTask.Netherite/Scaling/LoadPublishWorker.cs
+++ b/src/DurableTask.Netherite/Scaling/LoadPublishWorker.cs
@@ -26,6 +26,8 @@ namespace DurableTask.Netherite.Scaling
 
         public Task FlushAsync()
         {
+            // wait for the worker to complete, but cancel the timed wait so it goes quicker
+            // correct order of these two is important, see discussion at https://github.com/microsoft/durabletask-netherite/pull/262#discussion_r1185209501// 
             var task = this.WaitForCompletionAsync();
             this.CancelCurrentWait();
             return task;

--- a/src/DurableTask.Netherite/Scaling/LoadPublishWorker.cs
+++ b/src/DurableTask.Netherite/Scaling/LoadPublishWorker.cs
@@ -64,13 +64,7 @@ namespace DurableTask.Netherite.Scaling
                 }
             }
 
-            try
-            {
-                await Task.WhenAny(Task.Delay(AggregatePublishInterval), this.cancelWait.Task).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-            }
+            await Task.WhenAny(Task.Delay(AggregatePublishInterval), this.cancelWait.Task).ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
The load publisher contained a bug where the `FlushAsync` basically only worked the first time, because it was using a single cancellationTokenSource. After that, the load publisher would run much too frequently. Also, this source was not properly disposed.

We fix this by using a TaskCompletionSource instead, and creating a new one for every invocation of FlushAsync.