### PR TITLE
Fix excessive memory use introduced in release 1.3.3

### DIFF
--- a/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/BlobManager.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/BlobManager.cs
@@ -144,7 +144,7 @@ namespace DurableTask.Netherite.Faster
         {
             int pageSizeBits =    tuningParameters?.StoreLogPageSizeBits    ?? 10; // 1kB
             int segmentSizeBits = tuningParameters?.StoreLogSegmentSizeBits ?? 19; // 512 kB
-            int memorySizeBits = tuningParameters?.StoreLogMemorySizeBits ?? 29; // 512 MB - that is just the max, not what we actually use
+            int memorySizeBits = tuningParameters?.StoreLogMemorySizeBits ?? 20; // 1 MB max. Holds 88k records.
 
             return (pageSizeBits, segmentSizeBits, memorySizeBits);
         }


### PR DESCRIPTION
Undoes a FASTER tuning parameter change that caused unexpected excessive baseline memory usage even without any significant load.

This change was introduced in release 1.3.3 and seems to have caused a lot of OOM issues (e.g. #263) and otherwise degraded performance due to the higher memory pressure.