### PR TITLE
limit compaction size by absolute size, not relative size

### DIFF
--- a/src/DurableTask.Netherite/StorageLayer/Faster/FasterKV.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/FasterKV.cs
@@ -454,7 +454,7 @@ namespace DurableTask.Netherite.Faster
             long compactionAreaSize = Math.Min(50000, this.fht.Log.SafeReadOnlyAddress - this.fht.Log.BeginAddress);
 
             if (actualLogSize > 2 * minimalLogSize            // there must be significant bloat
-                && compactionAreaSize >= 500)                 // and enough compaction area to justify the overhead
+                && compactionAreaSize >= 5000)                // and enough compaction area to justify the overhead
             {
                 return this.fht.Log.BeginAddress + compactionAreaSize;
             }

--- a/src/DurableTask.Netherite/StorageLayer/Faster/FasterKV.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/FasterKV.cs
@@ -451,11 +451,10 @@ namespace DurableTask.Netherite.Faster
             var stats = (StatsState) this.singletons[(int)TrackedObjectKey.Stats.ObjectType];
             long actualLogSize = this.fht.Log.TailAddress - this.fht.Log.BeginAddress;
             long minimalLogSize = this.MinimalLogSize;
-            long compactionAreaSize = (long)(0.5 * (this.fht.Log.SafeReadOnlyAddress - this.fht.Log.BeginAddress));
-            long mutableSectionSize = (this.fht.Log.TailAddress - this.fht.Log.SafeReadOnlyAddress);
+            long compactionAreaSize = Math.Min(50000, this.fht.Log.SafeReadOnlyAddress - this.fht.Log.BeginAddress);
 
             if (actualLogSize > 2 * minimalLogSize            // there must be significant bloat
-               && mutableSectionSize < compactionAreaSize)   // the potential size reduction must outweigh the cost of a foldover
+                && compactionAreaSize >= 500)                 // and enough compaction area to justify the overhead
             {
                 return this.fht.Log.BeginAddress + compactionAreaSize;
             }


### PR DESCRIPTION
Addresses observed issue where compaction sizes grew too large, causing out of memory.

The fix is to adjust the heuristics so that they never compact more than a fixed limit.

Also, the heuristics no longer suppress compaction based on the size of the mutable section since that can have unpredictable effects on log size management. Instead, compaction is now gated by a minimum on the area being compacted.