### PR TITLE
implement blob batching to improve EH sender throughput

### DIFF
--- a/src/DurableTask.Netherite/Abstractions/PartitionState/EffectTracker.cs
+++ b/src/DurableTask.Netherite/Abstractions/PartitionState/EffectTracker.cs
@@ -49,7 +49,7 @@ namespace DurableTask.Netherite
 
         public abstract ValueTask RemoveFromStore(IEnumerable<TrackedObjectKey> keys);
         
-        public abstract (long, long) GetPositions();
+        public abstract (long, (long,int)) GetPositions();
 
         public abstract Partition Partition { get; }
 
@@ -187,7 +187,7 @@ namespace DurableTask.Netherite
 
         public void ProcessReadResult(PartitionReadEvent readEvent, TrackedObjectKey key, TrackedObject target)
         {
-            (long commitLogPosition, long inputQueuePosition) = this.GetPositions();
+            (long commitLogPosition, (long,int) inputQueuePosition) = this.GetPositions();
             this.Assert(!this.IsReplaying, "read events are not part of the replay");
             double startedTimestamp = this.CurrentTimeMs;
 
@@ -254,7 +254,7 @@ namespace DurableTask.Netherite
         
         public async Task ProcessQueryResultAsync(PartitionQueryEvent queryEvent, IAsyncEnumerable<(string, OrchestrationState)> instances, DateTime attempt)
         {
-            (long commitLogPosition, long inputQueuePosition) = this.GetPositions();
+            (long commitLogPosition, (long,int) inputQueuePosition) = this.GetPositions();
             this.Assert(!this.IsReplaying, "query events are never part of the replay");
             double startedTimestamp = this.CurrentTimeMs;
 

--- a/src/DurableTask.Netherite/Abstractions/PartitionState/IPartitionState.cs
+++ b/src/DurableTask.Netherite/Abstractions/PartitionState/IPartitionState.cs
@@ -21,7 +21,7 @@ namespace DurableTask.Netherite
         /// <param name="inputQueueFingerprint">A fingerprint for the input queue.</param>
         /// <returns>the input queue position from which to resume input processing</returns>
         /// <exception cref="OperationCanceledException">Indicates that termination was signaled before the operation completed.</exception>
-        Task<long> CreateOrRestoreAsync(Partition localPartition, IPartitionErrorHandler errorHandler, string inputQueueFingerprint);
+        Task<(long,int)> CreateOrRestoreAsync(Partition localPartition, IPartitionErrorHandler errorHandler, string inputQueueFingerprint);
 
         /// <summary>
         /// Starts processing, after creating or restoring the partition state.

--- a/src/DurableTask.Netherite/Abstractions/TransportAbstraction.cs
+++ b/src/DurableTask.Netherite/Abstractions/TransportAbstraction.cs
@@ -85,7 +85,7 @@ namespace DurableTask.Netherite
             /// Also, it can be used to detect that the partition has terminated for any other reason, 
             /// be it cleanly (after StopAsync) or uncleanly (after losing a lease or hitting a fatal error).
             /// </remarks>
-            Task<long> CreateOrRestoreAsync(IPartitionErrorHandler termination, TaskhubParameters parameters, string inputQueueFingerprint);
+            Task<(long,int)> CreateOrRestoreAsync(IPartitionErrorHandler termination, TaskhubParameters parameters, string inputQueueFingerprint);
 
             /// <summary>
             /// Clean shutdown: stop processing, save partition state to storage, and release ownership.

--- a/src/DurableTask.Netherite/Events/Packet.cs
+++ b/src/DurableTask.Netherite/Events/Packet.cs
@@ -3,6 +3,7 @@
 
 namespace DurableTask.Netherite
 {
+    using Azure.Storage.Blobs.Models;
     using DurableTask.Core.Common;
     using DurableTask.Core.Exceptions;
     using Newtonsoft.Json;
@@ -18,15 +19,18 @@ namespace DurableTask.Netherite
     /// </summary>
     static class Packet
     {
-        // we prefix packets with a byte indicating the version, to facilitate format changes in the future
-        static readonly byte version = 2;
+        // we prefix packets with a byte indicating the packet type and whether it contains a guid
+        // (we can also use this for version changes over time)
+        static readonly byte eventWithGuid = 2;
+        static readonly byte batchWithGuid = 3;
+        static readonly byte eventWithoutGuid = 4;
 
         public static void Serialize(Event evt, Stream stream, byte[] taskHubGuid)
         {
             var writer = new BinaryWriter(stream, Encoding.UTF8);
 
-            // first come the version and the taskhub
-            writer.Write(Packet.version);
+            // first write the packet type and the taskhub
+            writer.Write(Packet.eventWithGuid);
             writer.Write(taskHubGuid);
             writer.Flush();
 
@@ -34,33 +38,95 @@ namespace DurableTask.Netherite
             Serializer.SerializeEvent(evt, stream);
         }
 
-        public static void Deserialize<TEvent>(Stream stream, out TEvent evt, byte[] taskHubGuid) where TEvent : Event
+        public static void Serialize(Event evt, Stream stream)
+        {
+            var writer = new BinaryWriter(stream, Encoding.UTF8);
+
+            // first write the packet type and the taskhub
+            writer.Write(Packet.eventWithoutGuid);
+            writer.Flush();
+
+            // then we write the binary serialization to the stream
+            Serializer.SerializeEvent(evt, stream);
+        }
+
+        public static void Serialize(string blobAddress, List<int> packetOffsets, Stream stream, byte[] taskHubGuid)
+        {
+            var writer = new BinaryWriter(stream, Encoding.UTF8);
+
+            // first write the packet type and the taskhub
+            writer.Write(Packet.batchWithGuid);
+            writer.Write(taskHubGuid);
+
+            // then write the blob Address and the positions
+            writer.Write(blobAddress);
+            writer.Write(packetOffsets.Count);
+            foreach(var p in packetOffsets)
+            {
+                writer.Write(p);
+            }
+            writer.Flush();
+        }
+
+
+        public class BlobReference
+        {
+            public string BlobName;
+            public List<int> PacketOffsets;
+        }
+
+
+        public static void Deserialize<TEvent>(Stream stream, out TEvent evt, out BlobReference blobReference, byte[] taskHubGuid) where TEvent : Event
         {
             var reader = new BinaryReader(stream);
-            var version = reader.ReadByte();
-            var destinationTaskHubGuid = reader.ReadBytes(16);
+            var packetType = reader.ReadByte();
+            evt = null;
+            blobReference = null;
 
-            if (taskHubGuid != null && !GuidMatches(taskHubGuid, destinationTaskHubGuid))
+            if (packetType == Packet.eventWithGuid)
             {
-                evt = null;
-                return;
+                byte[] destinationTaskHubId = reader.ReadBytes(16);
+                if (taskHubGuid != null && !GuidMatches(taskHubGuid, destinationTaskHubId))
+                {
+                    return;
+                }
+                evt = (TEvent)Serializer.DeserializeEvent(stream);
             }
-
-            if (version == Packet.version)
+            else if (packetType == Packet.batchWithGuid)
+            {
+                byte[] destinationTaskHubId = reader.ReadBytes(16);
+                if (taskHubGuid != null && !GuidMatches(taskHubGuid, destinationTaskHubId))
+                {
+                    return;
+                }
+                string blobName = reader.ReadString();
+                int numEvents = reader.ReadInt32();
+                List<int> packetOffsets = new List<int>(numEvents);
+                for (int i = 0; i < numEvents; i++)
+                {
+                    packetOffsets.Add(reader.ReadInt32());
+                }
+                blobReference = new BlobReference()
+                {
+                    BlobName = blobName,
+                    PacketOffsets = packetOffsets
+                };
+            }
+            else if (packetType == Packet.eventWithoutGuid)
             {
                 evt = (TEvent)Serializer.DeserializeEvent(stream);
             }
             else
             {
-                throw new VersionNotFoundException($"Received packet with unsupported version {version} - likely a versioning issue");
-            }
+                throw new VersionNotFoundException($"Received packet with unsupported packet type {packetType} - likely a versioning issue");
+            }           
         }
 
-        public static void Deserialize<TEvent>(ArraySegment<byte> arraySegment, out TEvent evt, byte[] taskHubGuid) where TEvent : Event
+        public static void Deserialize<TEvent>(ArraySegment<byte> arraySegment, out TEvent evt, out BlobReference blobReference, byte[] taskHubGuid) where TEvent : Event
         {
             using (var stream = new MemoryStream(arraySegment.Array, arraySegment.Offset, arraySegment.Count, false))
             {
-                Packet.Deserialize(stream, out evt, taskHubGuid);
+                Packet.Deserialize(stream, out evt, out blobReference, taskHubGuid);
             }
         }
 

--- a/src/DurableTask.Netherite/Events/Packet.cs
+++ b/src/DurableTask.Netherite/Events/Packet.cs
@@ -25,13 +25,13 @@ namespace DurableTask.Netherite
         static readonly byte batchWithGuid = 3;
         static readonly byte eventWithoutGuid = 4;
 
-        public static void Serialize(Event evt, Stream stream, byte[] taskHubGuid)
+        public static void Serialize(Event evt, Stream stream, byte[] guid)
         {
             var writer = new BinaryWriter(stream, Encoding.UTF8);
 
             // first write the packet type and the taskhub
             writer.Write(Packet.eventWithGuid);
-            writer.Write(taskHubGuid);
+            writer.Write(guid);
             writer.Flush();
 
             // then we write the binary serialization to the stream
@@ -50,13 +50,13 @@ namespace DurableTask.Netherite
             Serializer.SerializeEvent(evt, stream);
         }
 
-        public static void Serialize(string blobAddress, List<int> packetOffsets, Stream stream, byte[] taskHubGuid)
+        public static void Serialize(string blobAddress, List<int> packetOffsets, Stream stream, byte[] guid)
         {
             var writer = new BinaryWriter(stream, Encoding.UTF8);
 
             // first write the packet type and the taskhub
             writer.Write(Packet.batchWithGuid);
-            writer.Write(taskHubGuid);
+            writer.Write(guid);
 
             // then write the blob Address and the positions
             writer.Write(blobAddress);
@@ -76,7 +76,7 @@ namespace DurableTask.Netherite
         }
 
 
-        public static void Deserialize<TEvent>(Stream stream, out TEvent evt, out BlobReference blobReference, byte[] taskHubGuid) where TEvent : Event
+        public static void Deserialize<TEvent>(Stream stream, out TEvent evt, out BlobReference blobReference, byte[] guid) where TEvent : Event
         {
             var reader = new BinaryReader(stream);
             var packetType = reader.ReadByte();
@@ -86,7 +86,7 @@ namespace DurableTask.Netherite
             if (packetType == Packet.eventWithGuid)
             {
                 byte[] destinationTaskHubId = reader.ReadBytes(16);
-                if (taskHubGuid != null && !GuidMatches(taskHubGuid, destinationTaskHubId))
+                if (guid != null && !GuidMatches(guid, destinationTaskHubId))
                 {
                     return;
                 }
@@ -95,7 +95,7 @@ namespace DurableTask.Netherite
             else if (packetType == Packet.batchWithGuid)
             {
                 byte[] destinationTaskHubId = reader.ReadBytes(16);
-                if (taskHubGuid != null && !GuidMatches(taskHubGuid, destinationTaskHubId))
+                if (guid != null && !GuidMatches(guid, destinationTaskHubId))
                 {
                     return;
                 }

--- a/src/DurableTask.Netherite/Events/PartitionEvents/PartitionEvent.cs
+++ b/src/DurableTask.Netherite/Events/PartitionEvents/PartitionEvent.cs
@@ -21,6 +21,15 @@ namespace DurableTask.Netherite
         [DataMember]
         public long NextInputQueuePosition { get; set; }
 
+        /// <summary>
+        /// For events coming from batches in the input queue, the batch position.
+        /// </summary>
+        [DataMember(EmitDefaultValue = false)]
+        public int NextInputQueueBatchPosition { get; set; }
+
+        [IgnoreDataMember]
+        public (long,int) NextInputQueuePositionTuple => (this.NextInputQueuePosition, this.NextInputQueueBatchPosition);
+
         [IgnoreDataMember]
         public double ReceivedTimestamp { get; set; }
 

--- a/src/DurableTask.Netherite/OrchestrationService/Partition.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/Partition.cs
@@ -88,7 +88,7 @@ namespace DurableTask.Netherite
             this.LastTransition = this.CurrentTimeMs;
         }
 
-        public async Task<long> CreateOrRestoreAsync(IPartitionErrorHandler errorHandler, TaskhubParameters parameters, string inputQueueFingerprint)
+        public async Task<(long, int)> CreateOrRestoreAsync(IPartitionErrorHandler errorHandler, TaskhubParameters parameters, string inputQueueFingerprint)
         {
             EventTraceContext.Clear();
 
@@ -129,7 +129,7 @@ namespace DurableTask.Netherite
                 // start processing the worker queues
                 this.State.StartProcessing();
 
-                this.TraceHelper.TracePartitionProgress("Started", ref this.LastTransition, this.CurrentTimeMs, $"nextInputQueuePosition={inputQueuePosition}");
+                this.TraceHelper.TracePartitionProgress("Started", ref this.LastTransition, this.CurrentTimeMs, $"nextInputQueuePosition={inputQueuePosition.Item1}.{inputQueuePosition.Item2}");
                 return inputQueuePosition;
             }
             catch (OperationCanceledException) when (errorHandler.IsTerminated)

--- a/src/DurableTask.Netherite/PartitionState/DedupState.cs
+++ b/src/DurableTask.Netherite/PartitionState/DedupState.cs
@@ -19,7 +19,7 @@ namespace DurableTask.Netherite
         public Dictionary<uint, (long Position, int SubPosition)> LastProcessed { get; set; } = new Dictionary<uint, (long,int)>();
 
         [DataMember]
-        public (long, long) Positions; // used by FasterAlt to persist positions
+        public (long, (long,int)) Positions; // used by FasterAlt to persist positions
 
         [IgnoreDataMember]
         public override TrackedObjectKey Key => new TrackedObjectKey(TrackedObjectKey.TrackedObjectType.Dedup);

--- a/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/CheckpointInfo.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/CheckpointInfo.cs
@@ -23,6 +23,9 @@ namespace DurableTask.Netherite.Faster
         public long InputQueuePosition { get; set; }
 
         [JsonProperty]
+        public int InputQueueBatchPosition { get; set; }
+
+        [JsonProperty]
         public string InputQueueFingerprint { get; set; }
 
         [JsonProperty]

--- a/src/DurableTask.Netherite/StorageLayer/Faster/FasterAlt.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/FasterAlt.cs
@@ -103,7 +103,7 @@ namespace DurableTask.Netherite.Faster
             return Task.FromResult(!logIsEmpty);
         }
 
-        public override Task<(long commitLogPosition, long inputQueuePosition, string inputQueueFingerprint)> RecoverAsync()
+        public override Task<(long commitLogPosition, (long,int) inputQueuePosition, string inputQueueFingerprint)> RecoverAsync()
         {
             foreach (var guid in this.ReadCheckpointIntentions())
             {
@@ -157,7 +157,7 @@ namespace DurableTask.Netherite.Faster
             }
         }
 
-        public override bool TakeFullCheckpoint(long commitLogPosition, long inputQueuePosition, string inputQueueFingerprint, out Guid checkpointGuid)
+        public override bool TakeFullCheckpoint(long commitLogPosition, (long,int) inputQueuePosition, string inputQueueFingerprint, out Guid checkpointGuid)
         {
             checkpointGuid = Guid.NewGuid();
             this.StartStoreCheckpoint(commitLogPosition, inputQueuePosition, checkpointGuid);
@@ -181,14 +181,14 @@ namespace DurableTask.Netherite.Faster
             return default;
         }
 
-        public override Guid? StartStoreCheckpoint(long commitLogPosition, long inputQueuePosition, string inputQueueFingerprint, long? shiftBeginAddress)
+        public override Guid? StartStoreCheckpoint(long commitLogPosition, (long,int) inputQueuePosition, string inputQueueFingerprint, long? shiftBeginAddress)
         {
             var guid = Guid.NewGuid();
             this.StartStoreCheckpoint(commitLogPosition, inputQueuePosition, guid);
             return guid;
         }
 
-        internal void StartStoreCheckpoint(long commitLogPosition, long inputQueuePosition, Guid guid)
+        internal void StartStoreCheckpoint(long commitLogPosition, (long,int) inputQueuePosition, Guid guid)
         {
             // update the positions
             var dedupState = this.cache[TrackedObjectKey.Dedup];

--- a/src/DurableTask.Netherite/StorageLayer/Faster/FasterTraceHelper.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/FasterTraceHelper.cs
@@ -29,29 +29,29 @@ namespace DurableTask.Netherite.Faster
 
         // ----- faster storage layer events
 
-        public void FasterStoreCreated(long inputQueuePosition, long latencyMs)
+        public void FasterStoreCreated((long,int) inputQueuePosition, long latencyMs)
         {
             if (this.logLevelLimit <= LogLevel.Information)
             {
-                this.logger.LogInformation("Part{partition:D2} Created Store, inputQueuePosition={inputQueuePosition} latencyMs={latencyMs}", this.partitionId, inputQueuePosition, latencyMs);
-                EtwSource.Log.FasterStoreCreated(this.account, this.taskHub, this.partitionId, inputQueuePosition, latencyMs, TraceUtils.AppName, TraceUtils.ExtensionVersion);
+                this.logger.LogInformation("Part{partition:D2} Created Store, inputQueuePosition={inputQueuePosition}.{inputQueueBatchPosition} latencyMs={latencyMs}", this.partitionId, inputQueuePosition.Item1, inputQueuePosition.Item2, latencyMs);
+                EtwSource.Log.FasterStoreCreated(this.account, this.taskHub, this.partitionId, inputQueuePosition.Item1, inputQueuePosition.Item2, latencyMs, TraceUtils.AppName, TraceUtils.ExtensionVersion);
             }
         }
-        public void FasterCheckpointStarted(Guid checkpointId, string details, string storeStats, long commitLogPosition, long inputQueuePosition)
+        public void FasterCheckpointStarted(Guid checkpointId, string details, string storeStats, long commitLogPosition, (long, int) inputQueuePosition)
         {
             if (this.logLevelLimit <= LogLevel.Information)
             {
-                this.logger.LogInformation("Part{partition:D2} Started Checkpoint {checkpointId}, details={details}, storeStats={storeStats}, commitLogPosition={commitLogPosition} inputQueuePosition={inputQueuePosition}", this.partitionId, checkpointId, details, storeStats, commitLogPosition, inputQueuePosition);
-                EtwSource.Log.FasterCheckpointStarted(this.account, this.taskHub, this.partitionId, checkpointId, details, storeStats, commitLogPosition, inputQueuePosition, TraceUtils.AppName, TraceUtils.ExtensionVersion);
+                this.logger.LogInformation("Part{partition:D2} Started Checkpoint {checkpointId}, details={details}, storeStats={storeStats}, commitLogPosition={commitLogPosition} inputQueuePosition={inputQueuePosition}.{inputQueueBatchPosition}", this.partitionId, checkpointId, details, storeStats, commitLogPosition, inputQueuePosition.Item1, inputQueuePosition.Item2);
+                EtwSource.Log.FasterCheckpointStarted(this.account, this.taskHub, this.partitionId, checkpointId, details, storeStats, commitLogPosition, inputQueuePosition.Item1, inputQueuePosition.Item2, TraceUtils.AppName, TraceUtils.ExtensionVersion);
             }
         }
 
-        public void FasterCheckpointPersisted(Guid checkpointId, string details, long commitLogPosition, long inputQueuePosition, long latencyMs)
+        public void FasterCheckpointPersisted(Guid checkpointId, string details, long commitLogPosition, (long,int) inputQueuePosition, long latencyMs)
         {
             if (this.logLevelLimit <= LogLevel.Information)
             {
-                this.logger.LogInformation("Part{partition:D2} Persisted Checkpoint {checkpointId}, details={details}, commitLogPosition={commitLogPosition} inputQueuePosition={inputQueuePosition} latencyMs={latencyMs}", this.partitionId, checkpointId, details, commitLogPosition, inputQueuePosition, latencyMs);
-                EtwSource.Log.FasterCheckpointPersisted(this.account, this.taskHub, this.partitionId, checkpointId, details, commitLogPosition, inputQueuePosition, latencyMs, TraceUtils.AppName, TraceUtils.ExtensionVersion);
+                this.logger.LogInformation("Part{partition:D2} Persisted Checkpoint {checkpointId}, details={details}, commitLogPosition={commitLogPosition} inputQueuePosition={inputQueuePosition}.{inputQueueBatchPosition} latencyMs={latencyMs}", this.partitionId, checkpointId, details, commitLogPosition, inputQueuePosition.Item1, inputQueuePosition.Item2, latencyMs);
+                EtwSource.Log.FasterCheckpointPersisted(this.account, this.taskHub, this.partitionId, checkpointId, details, commitLogPosition, inputQueuePosition.Item1, inputQueuePosition.Item2, latencyMs, TraceUtils.AppName, TraceUtils.ExtensionVersion);
             }
 
             if (latencyMs > 10000)
@@ -83,21 +83,21 @@ namespace DurableTask.Netherite.Faster
             }
         }
 
-        public void FasterCheckpointLoaded(long commitLogPosition, long inputQueuePosition, string storeStats, long latencyMs)
+        public void FasterCheckpointLoaded(long commitLogPosition, (long,int) inputQueuePosition, string storeStats, long latencyMs)
         {
             if (this.logLevelLimit <= LogLevel.Information)
             {
-                this.logger.LogInformation("Part{partition:D2} Loaded Checkpoint, commitLogPosition={commitLogPosition} inputQueuePosition={inputQueuePosition}  storeStats={storeStats} latencyMs={latencyMs}", this.partitionId, commitLogPosition, inputQueuePosition, storeStats, latencyMs);
-                EtwSource.Log.FasterCheckpointLoaded(this.account, this.taskHub, this.partitionId, commitLogPosition, inputQueuePosition, storeStats, latencyMs, TraceUtils.AppName, TraceUtils.ExtensionVersion);
+                this.logger.LogInformation("Part{partition:D2} Loaded Checkpoint, commitLogPosition={commitLogPosition} inputQueuePosition={inputQueuePosition}.{inputQueueBatchPosition}  storeStats={storeStats} latencyMs={latencyMs}", this.partitionId, commitLogPosition, inputQueuePosition.Item1, inputQueuePosition.Item2, storeStats, latencyMs);
+                EtwSource.Log.FasterCheckpointLoaded(this.account, this.taskHub, this.partitionId, commitLogPosition, inputQueuePosition.Item1, inputQueuePosition.Item2, storeStats, latencyMs, TraceUtils.AppName, TraceUtils.ExtensionVersion);
             }
         }
 
-        public void FasterLogReplayed(long commitLogPosition, long inputQueuePosition, long numberEvents, long sizeInBytes, string storeStats, long latencyMs)
+        public void FasterLogReplayed(long commitLogPosition, (long,int) inputQueuePosition, long numberEvents, long sizeInBytes, string storeStats, long latencyMs)
         {
             if (this.logLevelLimit <= LogLevel.Information)
             {
-                this.logger.LogInformation("Part{partition:D2} Replayed CommitLog, commitLogPosition={commitLogPosition} inputQueuePosition={inputQueuePosition} numberEvents={numberEvents} sizeInBytes={sizeInBytes} storeStats={storeStats} latencyMs={latencyMs}", this.partitionId, commitLogPosition, inputQueuePosition, numberEvents, sizeInBytes, storeStats, latencyMs);
-                EtwSource.Log.FasterLogReplayed(this.account, this.taskHub, this.partitionId, commitLogPosition, inputQueuePosition, numberEvents, sizeInBytes, storeStats, latencyMs, TraceUtils.AppName, TraceUtils.ExtensionVersion);
+                this.logger.LogInformation("Part{partition:D2} Replayed CommitLog, commitLogPosition={commitLogPosition} inputQueuePosition={inputQueuePosition}.{inputQueueBatchPosition} numberEvents={numberEvents} sizeInBytes={sizeInBytes} storeStats={storeStats} latencyMs={latencyMs}", this.partitionId, commitLogPosition, inputQueuePosition.Item1, inputQueuePosition.Item2, numberEvents, sizeInBytes, storeStats, latencyMs);
+                EtwSource.Log.FasterLogReplayed(this.account, this.taskHub, this.partitionId, commitLogPosition, inputQueuePosition.Item1, inputQueuePosition.Item2, numberEvents, sizeInBytes, storeStats, latencyMs, TraceUtils.AppName, TraceUtils.ExtensionVersion);
             }
         }
 

--- a/src/DurableTask.Netherite/StorageLayer/Faster/PartitionStorage.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/PartitionStorage.cs
@@ -72,7 +72,7 @@ namespace DurableTask.Netherite.Faster
             await what;
         }
 
-        public async Task<long> CreateOrRestoreAsync(Partition partition, IPartitionErrorHandler errorHandler, string inputQueueFingerprint)
+        public async Task<(long,int)> CreateOrRestoreAsync(Partition partition, IPartitionErrorHandler errorHandler, string inputQueueFingerprint)
         {
             this.partition = partition;
             this.terminationToken = errorHandler.Token;

--- a/src/DurableTask.Netherite/StorageLayer/Faster/ReplayChecker.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/ReplayChecker.cs
@@ -35,7 +35,7 @@ namespace DurableTask.Netherite.Faster
             public Partition Partition;
             public Dictionary<TrackedObjectKey, string> Store;
             public long CommitLogPosition;
-            public long InputQueuePosition;
+            public (long,int) InputQueuePosition;
             public EffectTracker EffectTracker;
         }
 
@@ -131,7 +131,7 @@ namespace DurableTask.Netherite.Faster
         PartitionUpdateEvent DeserializePartitionUpdateEvent(string content)
             => (PartitionUpdateEvent) JsonConvert.DeserializeObject(content, this.settings);
 
-        internal void PartitionStarting(Partition partition, TrackedObjectStore store, long CommitLogPosition, long InputQueuePosition)
+        internal void PartitionStarting(Partition partition, TrackedObjectStore store, long CommitLogPosition, (long,int) InputQueuePosition)
         {
             var info = new Info()
             {
@@ -286,7 +286,7 @@ namespace DurableTask.Netherite.Faster
                 return default;
             }
 
-            public override (long, long) GetPositions()
+            public override (long, (long,int)) GetPositions()
             {
                 return (this.info.CommitLogPosition, this.info.InputQueuePosition);
             }

--- a/src/DurableTask.Netherite/StorageLayer/Faster/TrackedObjectStore.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/TrackedObjectStore.cs
@@ -17,7 +17,7 @@ namespace DurableTask.Netherite.Faster
 
         public abstract Task<bool> FindCheckpointAsync(bool logIsEmpty);
 
-        public abstract Task<(long commitLogPosition, long inputQueuePosition, string inputQueueFingerprint)> RecoverAsync();
+        public abstract Task<(long commitLogPosition, (long,int) inputQueuePosition, string inputQueueFingerprint)> RecoverAsync();
 
         public abstract bool CompletePending();
 
@@ -25,13 +25,13 @@ namespace DurableTask.Netherite.Faster
 
         public abstract void AdjustCacheSize();
 
-        public abstract bool TakeFullCheckpoint(long commitLogPosition, long inputQueuePosition, string inputQueueFingerprint, out Guid checkpointGuid);
+        public abstract bool TakeFullCheckpoint(long commitLogPosition, (long,int) inputQueuePosition, string inputQueueFingerprint, out Guid checkpointGuid);
 
         public abstract Task RemoveObsoleteCheckpoints();
 
         public abstract Guid? StartIndexCheckpoint();
 
-        public abstract Guid? StartStoreCheckpoint(long commitLogPosition, long inputQueuePosition, string inputQueueFingerprint, long? shiftBeginAddress);
+        public abstract Guid? StartStoreCheckpoint(long commitLogPosition, (long,int) inputQueuePosition, string inputQueueFingerprint, long? shiftBeginAddress);
 
         public abstract ValueTask CompleteCheckpointAsync();
 

--- a/src/DurableTask.Netherite/StorageLayer/Faster/TrackedObjectStoreEffectTracker.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/TrackedObjectStoreEffectTracker.cs
@@ -26,7 +26,7 @@ namespace DurableTask.Netherite.Faster
             return this.store.ProcessEffectOnTrackedObject(key, tracker);
         }
 
-        public override (long, long) GetPositions()
+        public override (long,(long,int)) GetPositions()
         {
             return (this.storeWorker.CommitLogPosition, this.storeWorker.InputQueuePosition);
         }

--- a/src/DurableTask.Netherite/Tracing/EtwSource.cs
+++ b/src/DurableTask.Netherite/Tracing/EtwSource.cs
@@ -273,25 +273,25 @@ namespace DurableTask.Netherite
 
         // ----- Faster Storage
 
-        [Event(250, Level = EventLevel.Informational, Version = 2)]
-        public void FasterStoreCreated(string Account, string TaskHub, int PartitionId, long InputQueuePosition, long ElapsedMs, string AppName, string ExtensionVersion)
+        [Event(250, Level = EventLevel.Informational, Version = 3)]
+        public void FasterStoreCreated(string Account, string TaskHub, int PartitionId, long InputQueuePosition, long InputQueueBatchPosition, long ElapsedMs, string AppName, string ExtensionVersion)
         {
             SetCurrentThreadActivityId(serviceInstanceId);
-            this.WriteEvent(250, Account, TaskHub, PartitionId, InputQueuePosition, ElapsedMs, AppName, ExtensionVersion);
+            this.WriteEvent(250, Account, TaskHub, PartitionId, InputQueuePosition, InputQueueBatchPosition, ElapsedMs, AppName, ExtensionVersion);
         }
 
-        [Event(251, Level = EventLevel.Informational, Version = 1)]
-        public void FasterCheckpointStarted(string Account, string TaskHub, int PartitionId, Guid CheckpointId, string Details, string StoreStats, long CommitLogPosition, long InputQueuePosition, string AppName, string ExtensionVersion)
+        [Event(251, Level = EventLevel.Informational, Version = 2)]
+        public void FasterCheckpointStarted(string Account, string TaskHub, int PartitionId, Guid CheckpointId, string Details, string StoreStats, long CommitLogPosition, long InputQueuePosition, long InputQueueBatchPosition, string AppName, string ExtensionVersion)
         {
             SetCurrentThreadActivityId(serviceInstanceId);
-            this.WriteEvent(251, Account, TaskHub, PartitionId, CheckpointId, Details, StoreStats, CommitLogPosition, InputQueuePosition, AppName, ExtensionVersion);
+            this.WriteEvent(251, Account, TaskHub, PartitionId, CheckpointId, Details, StoreStats, CommitLogPosition, InputQueuePosition, InputQueueBatchPosition, AppName, ExtensionVersion);
         }
 
-        [Event(252, Level = EventLevel.Informational, Version = 2)]
-        public void FasterCheckpointPersisted(string Account, string TaskHub, int PartitionId, Guid CheckpointId, string Details, long CommitLogPosition, long InputQueuePosition, long ElapsedMs, string AppName, string ExtensionVersion)
+        [Event(252, Level = EventLevel.Informational, Version = 3)]
+        public void FasterCheckpointPersisted(string Account, string TaskHub, int PartitionId, Guid CheckpointId, string Details, long CommitLogPosition, long InputQueuePosition, long InputQueueBatchPosition, long ElapsedMs, string AppName, string ExtensionVersion)
         {
             SetCurrentThreadActivityId(serviceInstanceId);
-            this.WriteEvent(252, Account, TaskHub, PartitionId, CheckpointId, Details, CommitLogPosition, InputQueuePosition, ElapsedMs, AppName, ExtensionVersion);
+            this.WriteEvent(252, Account, TaskHub, PartitionId, CheckpointId, Details, CommitLogPosition, InputQueuePosition, InputQueueBatchPosition, ElapsedMs, AppName, ExtensionVersion);
         }
 
         [Event(253, Level = EventLevel.Verbose, Version = 2)]
@@ -301,18 +301,18 @@ namespace DurableTask.Netherite
             this.WriteEvent(253, Account, TaskHub, PartitionId, CommitLogPosition, NumberEvents, SizeInBytes, ElapsedMs, AppName, ExtensionVersion);
         }
 
-        [Event(254, Level = EventLevel.Informational, Version = 2)]
-        public void FasterCheckpointLoaded(string Account, string TaskHub, int PartitionId, long CommitLogPosition, long InputQueuePosition, string StoreStats, long ElapsedMs, string AppName, string ExtensionVersion)
+        [Event(254, Level = EventLevel.Informational, Version = 3)]
+        public void FasterCheckpointLoaded(string Account, string TaskHub, int PartitionId, long CommitLogPosition, long InputQueuePosition, long InputQueueBatchPosition, string StoreStats, long ElapsedMs, string AppName, string ExtensionVersion)
         {
             SetCurrentThreadActivityId(serviceInstanceId);
-            this.WriteEvent(254, Account, TaskHub, PartitionId, CommitLogPosition, InputQueuePosition, StoreStats, ElapsedMs, AppName, ExtensionVersion);
+            this.WriteEvent(254, Account, TaskHub, PartitionId, CommitLogPosition, InputQueuePosition, InputQueueBatchPosition, StoreStats, ElapsedMs, AppName, ExtensionVersion);
         }
 
-        [Event(255, Level = EventLevel.Informational, Version = 2)]
-        public void FasterLogReplayed(string Account, string TaskHub, int PartitionId, long CommitLogPosition, long InputQueuePosition, long NumberEvents, long SizeInBytes, string StoreStats, long ElapsedMs, string AppName, string ExtensionVersion)
+        [Event(255, Level = EventLevel.Informational, Version = 3)]
+        public void FasterLogReplayed(string Account, string TaskHub, int PartitionId, long CommitLogPosition, long InputQueuePosition, long InputQueueBatchPosition, long NumberEvents, long SizeInBytes, string StoreStats, long ElapsedMs, string AppName, string ExtensionVersion)
         {
             SetCurrentThreadActivityId(serviceInstanceId);
-            this.WriteEvent(255, Account, TaskHub, PartitionId, CommitLogPosition, InputQueuePosition, NumberEvents, SizeInBytes, StoreStats, ElapsedMs, AppName, ExtensionVersion);
+            this.WriteEvent(255, Account, TaskHub, PartitionId, CommitLogPosition, InputQueuePosition, InputQueueBatchPosition, NumberEvents, SizeInBytes, StoreStats, ElapsedMs, AppName, ExtensionVersion);
         }
 
         [Event(256, Level = EventLevel.Error, Version = 1)]

--- a/src/DurableTask.Netherite/TransportLayer/EventHubs/BlobBatchReceiver.cs
+++ b/src/DurableTask.Netherite/TransportLayer/EventHubs/BlobBatchReceiver.cs
@@ -1,0 +1,346 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace DurableTask.Netherite.EventHubsTransport
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Runtime.CompilerServices;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Storage.Blobs;
+    using Azure.Storage.Blobs.Models;
+    using Azure.Storage.Blobs.Specialized;
+    using DurableTask.Netherite.Faster;
+    using Microsoft.Azure.EventHubs;
+    using Microsoft.Azure.Storage;
+    using Microsoft.Extensions.Azure;
+    using Microsoft.Extensions.Logging;
+
+    class BlobBatchReceiver<TEvent> where TEvent : Event
+    {
+        readonly string traceContext;
+        readonly EventHubsTraceHelper traceHelper;
+        readonly EventHubsTraceHelper lowestTraceLevel;
+        readonly BlobContainerClient containerClient;
+        readonly bool keepUntilConfirmed;
+
+        // Event Hubs discards messages after 24h, so we can throw away batches that are older than that
+        readonly static TimeSpan expirationTimeSpan = TimeSpan.FromHours(24) + TimeSpan.FromMinutes(1);
+
+        BlobDeletions blobDeletions;
+
+        public BlobBatchReceiver(string traceContext, EventHubsTraceHelper traceHelper, NetheriteOrchestrationServiceSettings settings, bool keepUntilConfirmed)
+        {
+            this.traceContext = traceContext;
+            this.traceHelper = traceHelper;
+            this.lowestTraceLevel = traceHelper.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Trace) ? traceHelper : null;
+            var serviceClient = BlobUtilsV12.GetServiceClients(settings.BlobStorageConnection).WithRetries;
+            string containerName = BlobManager.GetContainerName(settings.HubName);
+            this.containerClient = serviceClient.GetBlobContainerClient(containerName);
+            this.keepUntilConfirmed = keepUntilConfirmed;
+            this.blobDeletions = this.keepUntilConfirmed ? new BlobDeletions(this) : null;
+        }
+
+        public async IAsyncEnumerable<(EventData eventData, TEvent[] events, long)> ReceiveEventsAsync(
+            byte[] taskHubGuid, 
+            IEnumerable<EventData> hubMessages,
+            [EnumeratorCancellation] CancellationToken token,
+            long? nextPacketToReceive = null)
+        {
+            foreach (var eventData in hubMessages)
+            {
+                var seqno = eventData.SystemProperties.SequenceNumber;
+
+                if (nextPacketToReceive.HasValue)
+                {
+                    if (seqno < nextPacketToReceive.Value)
+                    {
+                        this.lowestTraceLevel?.LogTrace("{context} discarded packet #{seqno} because it is already processed", this.traceContext, seqno);
+                        continue;
+                    }
+                    else if (seqno > nextPacketToReceive.Value)
+                    {
+                        this.traceHelper.LogError("{context} received wrong packet, #{seqno} instead of #{expected} ", this.traceContext, seqno, nextPacketToReceive.Value);
+                        // this should never happen, as EventHubs guarantees in-order delivery of packets
+                        throw new InvalidOperationException("EventHubs Out-Of-Order Packet");
+                    }
+                }
+                
+                TEvent evt;
+                Packet.BlobReference blobReference;
+
+                try
+                {
+                    Packet.Deserialize(eventData.Body, out evt, out blobReference, taskHubGuid);
+                }
+                catch (Exception)
+                {
+                    this.traceHelper.LogError("{context} could not deserialize packet #{seqno} ({size} bytes)", this.traceContext, seqno, eventData.Body.Count);
+                    throw;
+                }
+
+                if (blobReference == null)
+                {
+                    if (evt == null)
+                    {
+                        this.traceHelper.LogWarning("{context} ignored packet #{seqno} for different taskhub", this.traceContext, seqno);
+                    }
+                    else
+                    {
+                        yield return (eventData, new TEvent[1] { evt }, seqno);
+                    }
+                }
+                else // we have to read messages from a blob batch
+                {
+                    string blobPath = $"{BlobBatchSender.PathPrefix}{blobReference.BlobName}";
+
+                    BlockBlobClient blobClient = this.containerClient.GetBlockBlobClient(blobPath);
+
+                    await BlobManager.AsynchronousStorageReadMaxConcurrency.WaitAsync();
+
+                    byte[] blobContent;
+
+                    token.ThrowIfCancellationRequested();
+
+                    try
+                    {
+                        this.lowestTraceLevel?.LogTrace("{context} downloading blob {blobName}", this.traceContext, blobClient.Name);
+
+                        Azure.Response<BlobDownloadResult> downloadResult = await blobClient.DownloadContentAsync(token);
+                        blobContent = downloadResult.Value.Content.ToArray();
+
+                        this.lowestTraceLevel?.LogTrace("{context} downloaded blob {blobName} ({size} bytes, {count} packets)", this.traceContext, blobClient.Name, blobContent.Length, blobReference.PacketOffsets.Count + 1);
+                    }
+                    catch (OperationCanceledException) when (token.IsCancellationRequested)
+                    {
+                        // normal during shutdown
+                        throw;
+                    }
+                    catch (Exception exception)
+                    {
+                        this.traceHelper.LogError("{context} failed to read blob {blobName} for #{seqno}: {exception}", this.traceContext, blobClient.Name, seqno, exception);
+                        throw;
+                    }
+                    finally
+                    {
+                        BlobManager.AsynchronousStorageReadMaxConcurrency.Release();
+                    }
+
+                    TEvent[] result = new TEvent[blobReference.PacketOffsets.Count + 1];
+                    for (int i = 0; i < result.Length; i++)
+                    {
+                        var offset = i == 0 ? 0 : blobReference.PacketOffsets[i - 1];
+                        var nextOffset = i < blobReference.PacketOffsets.Count ? blobReference.PacketOffsets[i] : blobContent.Length;
+                        var length = nextOffset - offset;
+                        using var m = new MemoryStream(blobContent, offset, length, writable: false);
+
+                        token.ThrowIfCancellationRequested();
+
+                        try
+                        {
+                            Packet.Deserialize(m, out result[i], out _, null); // no need to check task hub match again
+                        }
+                        catch (Exception)
+                        {
+                            this.traceHelper.LogError("{context} could not deserialize packet from blob {blobName} at #{seqno}.{subSeqNo} offset={offset} length={length}", this.traceContext, blobClient.Name, seqno, i, offset, length);
+                            throw;
+                        }
+                    }
+                    yield return (eventData, result, seqno);
+
+                    // we issue a deletion task; there is no strong guarantee that deletion will successfully complete
+                    // which means some blobs can be left behind temporarily.
+                    // This is fine because we have a second deletion path, a scan that removes old 
+                    // blobs that are past EH's expiration date.
+
+                    if (!this.keepUntilConfirmed)
+                    {
+                        var bgTask = Task.Run(() => this.DeleteBlobAsync(new BlockBlobClient[1] { blobClient }));
+                    }
+                    else
+                    {
+                        // we cannot delete the blob until the partition has persisted an input queue position
+                        // past this blob, so that we know we will not need to read it again
+                        if (this.blobDeletions.TryRegister(result, blobClient))
+                        {
+                            this.blobDeletions = new BlobDeletions(this);
+                        }
+                        else
+                        {
+                            // the current batch will be registered along with the next
+                            // batch that successfully registers
+                        }
+                    }
+                }
+
+                if (nextPacketToReceive.HasValue)
+                {
+                    nextPacketToReceive = seqno + 1;
+                }
+            }
+        }
+
+        public async Task<int> DeleteBlobAsync(IEnumerable<BlockBlobClient> blobClients)
+        {
+            int deletedCount = 0;
+
+            foreach (var blobClient in blobClients)
+            {
+                await BlobManager.AsynchronousStorageWriteMaxConcurrency.WaitAsync();
+
+                try
+                {
+                    this.lowestTraceLevel?.LogTrace("{context} deleting blob {blobName}", this.traceContext, blobClient.Name);
+                    Azure.Response response = await blobClient.DeleteAsync();
+                    this.lowestTraceLevel?.LogTrace("{context} deleted blob {blobName}", this.traceContext, blobClient.Name);
+                    deletedCount++;
+                }
+                catch (Azure.RequestFailedException e) when (BlobUtilsV12.BlobDoesNotExist(e))
+                {
+                    this.lowestTraceLevel?.LogTrace("{context} blob {blobName} was already deleted", this.traceContext, blobClient.Name);
+                }
+                catch (Exception exception)
+                {
+                    this.traceHelper.LogError("{context} failed to delete blob {blobName} : {exception}", this.traceContext, blobClient.Name, exception);
+                }
+                finally
+                {
+                    BlobManager.AsynchronousStorageWriteMaxConcurrency.Release();
+                }
+            }
+
+            return deletedCount;
+        }
+
+        class BlobDeletions : TransportAbstraction.IDurabilityListener
+        {
+            readonly BlobBatchReceiver<TEvent> blobBatchReceiver;
+            readonly List<BlockBlobClient> blobClients;
+
+            public BlobDeletions(BlobBatchReceiver<TEvent> blobBatchReceiver)
+            {
+                this.blobBatchReceiver = blobBatchReceiver;
+                this.blobClients = new List<BlockBlobClient>();
+            }
+
+            public bool TryRegister(TEvent[] events, BlockBlobClient blobClient)
+            {
+                this.blobClients.Add(blobClient);
+
+                for(int i = events.Length - 1; i >= 0; i--)
+                {
+                    if (events[i] is PartitionUpdateEvent e)
+                    {
+                        // we can register a callback 
+                        // to be invoked after the event has been persisted in the log
+                        DurabilityListeners.Register(e, this);
+                        return true;
+                    }
+                }
+
+                return false; // only read or query events in this batch, cannot register a callback
+            }
+
+            public void ConfirmDurable(Event evt)
+            {
+                Task.Run(() => this.blobBatchReceiver.DeleteBlobAsync(this.blobClients));
+            }
+        }
+
+        public async Task<int> RemoveGarbageAsync(CancellationToken token)
+        {
+            async IAsyncEnumerable<Azure.Page<BlobItem>> GetExpiredBlobs()
+            {
+                // use a small first page since most of the time the query will 
+                // return blobs that have not expired yet, so we are wasting time and space if the
+                // page is large
+                var firstpage = await this.containerClient.GetBlobsAsync(
+                            prefix: BlobBatchSender.PathPrefix,
+                            cancellationToken: token)
+                            .AsPages(continuationToken: null, pageSizeHint: 5)
+                            .FirstAsync();
+
+                yield return firstpage;
+
+                if (firstpage.ContinuationToken != null)
+                {
+                    // for the remaining pages, use regular page size to reduce cost
+                    var remainingPages = this.containerClient.GetBlobsAsync(
+                            prefix: BlobBatchSender.PathPrefix,
+                            cancellationToken: token)
+                            .AsPages(continuationToken: firstpage.ContinuationToken, pageSizeHint: 100);
+
+                    await foreach (var page in remainingPages)
+                    {
+                        yield return page;
+                    }
+                }
+            }
+
+            int deletedCount = 0;
+            try
+            {
+                await foreach (Azure.Page<BlobItem> page in GetExpiredBlobs())
+                {
+                    List<BlockBlobClient> blobs = new List<BlockBlobClient>();
+                    bool completed = false;
+
+                    foreach (var blob in page.Values)
+                    {
+                        if (IsExpired(blob.Name))
+                        {
+                            blobs.Add(this.containerClient.GetBlockBlobClient(blob.Name));
+                        }
+                        else
+                        {
+                            // blobs are sorted in ascending time order, so once we found one that is not
+                            // expired yet we can stop enumerating
+                            completed = true;
+                        }
+
+                        deletedCount += await this.DeleteBlobAsync(blobs);
+
+                        if (completed)
+                        {
+                            return deletedCount;
+                        }
+
+                        bool IsExpired(string path)
+                        {
+                            // {PathPrefix}2023-06-13T23:28:55.5043743Z-2CA224EC
+                            var name = path.Substring(BlobBatchSender.PathPrefix.Length);
+                            // 2023-06-13T23:28:55.5043743Z-2CA224EC
+                            var date = name.Substring(0, name.Length - 9);
+                            // 2023-06-13T23:28:55.5043743Z
+
+                            if (DateTime.TryParse(date, out DateTime result))
+                            {
+                               return (DateTime.Now - result) > expirationTimeSpan;
+                            }
+                            else
+                            {
+                                this.traceHelper.LogError("{context} failed to parse blob name {blobName} : '{date}' is not a DateTime", this.traceContext, name, date);
+                                return false;
+                            }
+                        }
+                    }
+                }
+
+            }
+            catch(OperationCanceledException) when (token.IsCancellationRequested)
+            {
+                // normal during shutdown;
+            }
+            catch (Exception exception)
+            {
+                this.traceHelper.LogError("{context} encountered exception while removing expired blob batches : {exception}", this.traceContext, exception);
+            }
+
+            return deletedCount;
+        }
+    }
+}

--- a/src/DurableTask.Netherite/TransportLayer/EventHubs/BlobBatchReceiver.cs
+++ b/src/DurableTask.Netherite/TransportLayer/EventHubs/BlobBatchReceiver.cs
@@ -46,7 +46,7 @@ namespace DurableTask.Netherite.EventHubsTransport
         }
 
         public async IAsyncEnumerable<(EventData eventData, TEvent[] events, long)> ReceiveEventsAsync(
-            byte[] taskHubGuid, 
+            byte[] guid, 
             IEnumerable<EventData> hubMessages,
             [EnumeratorCancellation] CancellationToken token,
             long? nextPacketToReceive = null)
@@ -75,7 +75,7 @@ namespace DurableTask.Netherite.EventHubsTransport
 
                 try
                 {
-                    Packet.Deserialize(eventData.Body, out evt, out blobReference, taskHubGuid);
+                    Packet.Deserialize(eventData.Body, out evt, out blobReference, guid);
                 }
                 catch (Exception)
                 {
@@ -87,7 +87,7 @@ namespace DurableTask.Netherite.EventHubsTransport
                 {
                     if (evt == null)
                     {
-                        this.traceHelper.LogWarning("{context} ignored packet #{seqno} for different taskhub", this.traceContext, seqno);
+                        this.traceHelper.LogWarning("{context} ignored packet #{seqno} for different taskhub or client", this.traceContext, seqno);
                     }
                     else
                     {

--- a/src/DurableTask.Netherite/TransportLayer/EventHubs/BlobBatchSender.cs
+++ b/src/DurableTask.Netherite/TransportLayer/EventHubs/BlobBatchSender.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace DurableTask.Netherite.EventHubsTransport
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Runtime.CompilerServices;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Storage.Blobs;
+    using Azure.Storage.Blobs.Models;
+    using Azure.Storage.Blobs.Specialized;
+    using DurableTask.Netherite.Abstractions;
+    using DurableTask.Netherite.Faster;
+    using Microsoft.Azure.EventHubs;
+    using Microsoft.Extensions.Logging;
+
+    class BlobBatchSender
+    {
+        readonly string traceContext;
+        readonly EventHubsTraceHelper traceHelper;
+        readonly EventHubsTraceHelper lowestTraceLevel;
+        readonly BlobContainerClient containerClient;
+        readonly Random random = new Random();
+        readonly BlobUploadOptions options;
+
+        public const string PathPrefix = "eh-batches/";
+
+        public BlobBatchSender(string traceContext, EventHubsTraceHelper traceHelper, NetheriteOrchestrationServiceSettings settings)
+        {
+            this.traceContext = traceContext;
+            this.traceHelper = traceHelper;
+            this.lowestTraceLevel = traceHelper.IsEnabled(LogLevel.Trace) ? traceHelper : null;
+            var serviceClient = BlobUtilsV12.GetServiceClients(settings.BlobStorageConnection).WithRetries;
+            string containerName = BlobManager.GetContainerName(settings.HubName);
+            this.containerClient = serviceClient.GetBlobContainerClient(containerName);
+            this.options = new BlobUploadOptions() {  };
+        }
+
+        // these constants influence the max size of batches transmitted in EH and via blobs.
+        // note that these cannot be made arbitrarily large (EH batches cannot exceed max batch size on EH, and neither can the indexes of blob batches)
+        public int MaxEventHubsBatchBytes = 30 * 1024;
+        public int MaxEventHubsBatchEvents = 300;
+        public int MaxBlobBatchBytes = 500 * 1024;
+        public int MaxBlobBatchEvents = 5000;
+
+        string GetRandomBlobName()
+        {
+            uint random = (uint)this.random.Next();
+            return $"{DateTime.UtcNow:o}-{random:X8}";
+        }
+
+        public async Task<EventData> UploadEventsAsync(MemoryStream stream, List<int> packetOffsets, byte[] taskHubGuid, CancellationToken token)
+        {
+            string blobName = this.GetRandomBlobName();
+            string blobPath = $"{PathPrefix}{blobName}";
+            BlockBlobClient blobClient = this.containerClient.GetBlockBlobClient(blobPath);
+
+            long totalBytes = stream.Position;
+            stream.Seek(0, SeekOrigin.Begin);
+            stream.SetLength(totalBytes);
+
+            this.lowestTraceLevel?.LogTrace("{context} is writing blob {blobName} ({size} bytes)", this.traceContext, blobClient.Name, totalBytes);
+
+            await BlobManager.AsynchronousStorageWriteMaxConcurrency.WaitAsync();
+
+            try
+            {
+                await blobClient.UploadAsync(stream, this.options, token).ConfigureAwait(false);
+
+                this.lowestTraceLevel?.LogTrace("{context} wrote blob {blobName}", this.traceContext, blobClient.Name);
+
+                // create a message to send via event hubs
+                stream.SetLength(0);
+                Packet.Serialize(blobName, packetOffsets, stream, taskHubGuid);
+                var arraySegment = new ArraySegment<byte>(stream.GetBuffer(), 0, (int)stream.Position);
+                var eventData = new EventData(arraySegment);
+                return eventData;
+            }
+            catch (OperationCanceledException) when (token.IsCancellationRequested)
+            {
+                // normal during shutdown
+                throw;
+            }
+            catch (Exception exception)
+            {
+                this.traceHelper.LogError("{context} failed to write blob {blobName} : {exception}", this.traceContext, blobClient.Name, exception);
+                throw;
+            }
+            finally
+            {
+                BlobManager.AsynchronousStorageWriteMaxConcurrency.Release();
+            }
+        }
+    }
+}

--- a/src/DurableTask.Netherite/TransportLayer/EventHubs/BlobBatchSender.cs
+++ b/src/DurableTask.Netherite/TransportLayer/EventHubs/BlobBatchSender.cs
@@ -54,7 +54,7 @@ namespace DurableTask.Netherite.EventHubsTransport
             return $"{DateTime.UtcNow:o}-{random:X8}";
         }
 
-        public async Task<EventData> UploadEventsAsync(MemoryStream stream, List<int> packetOffsets, byte[] taskHubGuid, CancellationToken token)
+        public async Task<EventData> UploadEventsAsync(MemoryStream stream, List<int> packetOffsets, byte[] guid, CancellationToken token)
         {
             string blobName = this.GetRandomBlobName();
             string blobPath = $"{PathPrefix}{blobName}";
@@ -76,7 +76,7 @@ namespace DurableTask.Netherite.EventHubsTransport
 
                 // create a message to send via event hubs
                 stream.SetLength(0);
-                Packet.Serialize(blobName, packetOffsets, stream, taskHubGuid);
+                Packet.Serialize(blobName, packetOffsets, stream, guid);
                 var arraySegment = new ArraySegment<byte>(stream.GetBuffer(), 0, (int)stream.Position);
                 var eventData = new EventData(arraySegment);
                 return eventData;

--- a/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsClientSender.cs
+++ b/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsClientSender.cs
@@ -19,12 +19,12 @@ namespace DurableTask.Netherite.EventHubsTransport
         readonly EventHubsSender<ClientEvent>[] channels;
         int roundRobin;
 
-        public EventHubsClientSender(TransportAbstraction.IHost host, byte[] taskHubGuid, Guid clientId, PartitionSender[] senders, CancellationToken shutdownToken, EventHubsTraceHelper traceHelper, NetheriteOrchestrationServiceSettings settings)
+        public EventHubsClientSender(TransportAbstraction.IHost host, Guid clientId, PartitionSender[] senders, CancellationToken shutdownToken, EventHubsTraceHelper traceHelper, NetheriteOrchestrationServiceSettings settings)
         {
             this.channels = new Netherite.EventHubsTransport.EventHubsSender<ClientEvent>[senders.Length];
             for (int i = 0; i < senders.Length; i++)
             {
-                this.channels[i] = new EventHubsSender<ClientEvent>(host, taskHubGuid, senders[i], shutdownToken, traceHelper, settings);
+                this.channels[i] = new EventHubsSender<ClientEvent>(host, clientId.ToByteArray(), senders[i], shutdownToken, traceHelper, settings);
             }
         }
 

--- a/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsClientSender.cs
+++ b/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsClientSender.cs
@@ -19,12 +19,12 @@ namespace DurableTask.Netherite.EventHubsTransport
         readonly EventHubsSender<ClientEvent>[] channels;
         int roundRobin;
 
-        public EventHubsClientSender(TransportAbstraction.IHost host, byte[] taskHubGuid, Guid clientId, PartitionSender[] senders, CancellationToken shutdownToken, EventHubsTraceHelper traceHelper)
+        public EventHubsClientSender(TransportAbstraction.IHost host, byte[] taskHubGuid, Guid clientId, PartitionSender[] senders, CancellationToken shutdownToken, EventHubsTraceHelper traceHelper, NetheriteOrchestrationServiceSettings settings)
         {
             this.channels = new Netherite.EventHubsTransport.EventHubsSender<ClientEvent>[senders.Length];
             for (int i = 0; i < senders.Length; i++)
             {
-                this.channels[i] = new EventHubsSender<ClientEvent>(host, taskHubGuid, senders[i], shutdownToken, traceHelper);
+                this.channels[i] = new EventHubsSender<ClientEvent>(host, taskHubGuid, senders[i], shutdownToken, traceHelper, settings);
             }
         }
 

--- a/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsConnections.cs
+++ b/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsConnections.cs
@@ -274,7 +274,7 @@ namespace DurableTask.Netherite.EventHubsTransport
         }
 
 
-        public EventHubsSender<PartitionUpdateEvent> GetPartitionSender(int partitionId, byte[] taskHubGuid)
+        public EventHubsSender<PartitionUpdateEvent> GetPartitionSender(int partitionId, byte[] taskHubGuid, NetheriteOrchestrationServiceSettings settings)
         {
             return this._partitionSenders.GetOrAdd(partitionId, (key) => {
                 (EventHubClient client, string id) = this.partitionPartitions[partitionId];
@@ -284,13 +284,14 @@ namespace DurableTask.Netherite.EventHubsTransport
                     taskHubGuid,
                     partitionSender,
                     this.shutdownToken,
-                    this.TraceHelper);
+                    this.TraceHelper,
+                    settings);
                 this.TraceHelper.LogDebug("Created PartitionSender {sender} from {clientId}", partitionSender.ClientId, client.ClientId);
                 return sender;
             });
         }
 
-        public EventHubsClientSender GetClientSender(Guid clientId, byte[] taskHubGuid)
+        public EventHubsClientSender GetClientSender(Guid clientId, byte[] taskHubGuid, NetheriteOrchestrationServiceSettings settings)
         {
             return this._clientSenders.GetOrAdd(clientId, (key) =>
             {
@@ -308,7 +309,8 @@ namespace DurableTask.Netherite.EventHubsTransport
                         clientId,
                         partitionSenders,
                         this.shutdownToken,
-                        this.TraceHelper);
+                        this.TraceHelper,
+                        settings);
                 return sender;
             });
         }

--- a/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsConnections.cs
+++ b/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsConnections.cs
@@ -291,7 +291,7 @@ namespace DurableTask.Netherite.EventHubsTransport
             });
         }
 
-        public EventHubsClientSender GetClientSender(Guid clientId, byte[] taskHubGuid, NetheriteOrchestrationServiceSettings settings)
+        public EventHubsClientSender GetClientSender(Guid clientId, NetheriteOrchestrationServiceSettings settings)
         {
             return this._clientSenders.GetOrAdd(clientId, (key) =>
             {
@@ -305,7 +305,6 @@ namespace DurableTask.Netherite.EventHubsTransport
                 }
                 var sender = new EventHubsClientSender(
                         this.Host,
-                        taskHubGuid,
                         clientId,
                         partitionSenders,
                         this.shutdownToken,

--- a/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsSender.cs
+++ b/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsSender.cs
@@ -3,39 +3,42 @@
 
 namespace DurableTask.Netherite.EventHubsTransport
 {
-    using DurableTask.Core.Common;
-    using Microsoft.Azure.EventHubs;
-    using Microsoft.Extensions.Logging;
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.IO;
     using System.Threading;
     using System.Threading.Tasks;
+    using Azure.Messaging.EventHubs.Consumer;
+    using DurableTask.Core.Common;
+    using Microsoft.Azure.EventHubs;
+    using Microsoft.Extensions.Logging;
 
-    class EventHubsSender<T> : BatchWorker<Event> where T: Event
+    class EventHubsSender<T> : BatchWorker<Event> where T : Event
     {
         readonly PartitionSender sender;
         readonly TransportAbstraction.IHost host;
         readonly byte[] taskHubGuid;
         readonly EventHubsTraceHelper traceHelper;
+        readonly EventHubsTraceHelper lowestTraceLevel;
         readonly string eventHubName;
         readonly string eventHubPartition;
         readonly TimeSpan backoff = TimeSpan.FromSeconds(5);
-        int maxMessageSize = 900 * 1024; // we keep this slightly below the official limit since we have observed exceptions
-        int maxFragmentSize => this.maxMessageSize / 2; // we keep this lower than maxMessageSize because of serialization overhead
         readonly MemoryStream stream = new MemoryStream(); // reused for all packets
         readonly Stopwatch stopwatch = new Stopwatch();
+        readonly BlobBatchSender blobBatchSender;    
 
-        public EventHubsSender(TransportAbstraction.IHost host, byte[] taskHubGuid, PartitionSender sender, CancellationToken shutdownToken, EventHubsTraceHelper traceHelper)
-            : base($"EventHubsSender {sender.EventHubClient.EventHubName}/{sender.PartitionId}", false, 2000, shutdownToken, traceHelper)
+        public EventHubsSender(TransportAbstraction.IHost host, byte[] taskHubGuid, PartitionSender sender, CancellationToken shutdownToken, EventHubsTraceHelper traceHelper, NetheriteOrchestrationServiceSettings settings)
+           : base($"EventHubsSender {sender.EventHubClient.EventHubName}/{sender.PartitionId}", false, 2000, shutdownToken, traceHelper)
         {
             this.host = host;
             this.taskHubGuid = taskHubGuid;
             this.sender = sender;
             this.traceHelper = traceHelper;
+            this.lowestTraceLevel = traceHelper.IsEnabled(LogLevel.Trace) ? traceHelper : null;
             this.eventHubName = this.sender.EventHubClient.EventHubName;
             this.eventHubPartition = this.sender.PartitionId;
+            this.blobBatchSender = new BlobBatchSender($"EventHubsSender {this.eventHubName}/{this.eventHubPartition}", this.traceHelper, settings);
         }
 
         protected override async Task Process(IList<Event> toSend)
@@ -50,96 +53,109 @@ namespace DurableTask.Netherite.EventHubsTransport
             var maybeSent = -1;
             Exception senderException = null;
 
-            EventDataBatch CreateBatch() => this.sender.CreateBatch(new BatchOptions() { MaxMessageSize = maxMessageSize });
+            // track current position in toSend
+            int index = 0;
 
-            try
+            // track offsets of the packets in the stream
+            // since the first offset is always zero, there is one fewer than the number of packets
+            List<int> packetOffsets = new List<int>(Math.Min(toSend.Count, this.blobBatchSender.MaxBlobBatchEvents) - 1);
+
+            void CollectBatchContent(bool specificallyForBlob)
             {
-                var batch = CreateBatch();
+                int maxEvents = specificallyForBlob ? this.blobBatchSender.MaxBlobBatchEvents : this.blobBatchSender.MaxEventHubsBatchEvents;
+                int maxBytes = specificallyForBlob ? this.blobBatchSender.MaxBlobBatchBytes : this.blobBatchSender.MaxEventHubsBatchBytes;
 
-                async Task SendBatch(int lastPosition)
+                this.stream.Seek(0, SeekOrigin.Begin);
+                packetOffsets.Clear();
+                for (; index < toSend.Count && index < maxEvents && this.stream.Position < maxBytes; index++)
                 {
-                    maybeSent = lastPosition;
-                    this.cancellationToken.ThrowIfCancellationRequested();
-                    this.stopwatch.Restart();
-                    await this.sender.SendAsync(batch).ConfigureAwait(false);
-                    this.stopwatch.Stop();
-                    sentSuccessfully = lastPosition;
-                    this.traceHelper.LogDebug("EventHubsSender {eventHubName}/{eventHubPartitionId} sent batch of {numPackets} packets ({size} bytes) in {latencyMs:F2}ms, throughput={throughput:F2}MB/s", this.eventHubName, this.eventHubPartition, batch.Count, batch.Size, this.stopwatch.Elapsed.TotalMilliseconds, batch.Size/(1024*1024*this.stopwatch.Elapsed.TotalSeconds));
-                    batch.Dispose();
-                }
-
-                for (int i = 0; i < toSend.Count; i++)
-                {
-                    long startPos = this.stream.Position;
-                    var evt = toSend[i];
-
-                    this.traceHelper.LogTrace("EventHubsSender {eventHubName}/{eventHubPartitionId} is sending event {evt} id={eventId}", this.eventHubName, this.eventHubPartition, evt, evt.EventIdString);
-                    Packet.Serialize(evt, this.stream, this.taskHubGuid);
-                    int length = (int)(this.stream.Position - startPos);
-                    var arraySegment = new ArraySegment<byte>(this.stream.GetBuffer(), (int)startPos, length);
-                    var eventData = new EventData(arraySegment);
-                    bool tooBig = length > this.maxFragmentSize;
-
-                    if (!tooBig && batch.TryAdd(eventData))
+                    int currentOffset = (int) this.stream.Position;
+                    if (currentOffset > 0)
                     {
-                        this.traceHelper.LogTrace("EventHubsSender {eventHubName}/{eventHubPartitionId} added packet to batch ({size} bytes) {evt} id={eventId}", this.eventHubName, this.eventHubPartition, eventData.Body.Count, evt, evt.EventIdString);
-                        continue;
+                        packetOffsets.Add(currentOffset);
+                    }
+
+                    var evt = toSend[index];
+                    this.lowestTraceLevel?.LogTrace("EventHubsSender {eventHubName}/{eventHubPartitionId} is sending event {evt} id={eventId}", this.eventHubName, this.eventHubPartition, evt, evt.EventIdString);
+                    if (!specificallyForBlob)
+                    {
+                        Packet.Serialize(evt, this.stream, this.taskHubGuid);
                     }
                     else
                     {
-                        if (batch.Count > 0)
-                        {
-                            // send the batch we have so far
-                            await SendBatch(i - 1);
+                        // we don't need to include the task hub guid if the event is sent via blob
+                        Packet.Serialize(evt, this.stream);
+                    }                 
+                }
+            }
 
-                            // create a fresh batch
-                            batch = CreateBatch();
-                        }
+            try
+            {
+                // unless the total number of events is above the max already, we always check first if we can avoid using a blob
+                bool usingBlobBatches = toSend.Count > this.blobBatchSender.MaxEventHubsBatchEvents; 
 
-                        if (tooBig)
+                while (index < toSend.Count)
+                {
+                    CollectBatchContent(usingBlobBatches);
+
+                    if (!usingBlobBatches)
+                    {
+                        if (index == toSend.Count
+                            && index <= this.blobBatchSender.MaxEventHubsBatchEvents
+                            && this.stream.Position <= this.blobBatchSender.MaxEventHubsBatchBytes)
                         {
-                            // the message is too big. Break it into fragments, and send each individually.
-                            Guid groupId = Guid.NewGuid();
-                            this.traceHelper.LogDebug("EventHubsSender {eventHubName}/{eventHubPartitionId} fragmenting large event ({size} bytes) id={eventId} groupId={group:N}", this.eventHubName, this.eventHubPartition, length, evt.EventIdString, groupId);
-                            var fragments = FragmentationAndReassembly.Fragment(arraySegment, evt, groupId, this.maxFragmentSize);
-                            maybeSent = i;
-                            for (int k = 0; k < fragments.Count; k++)
+                            // we don't have a lot of bytes or messages to send
+                            // send them all in a single EH batch
+                            using var batch = this.sender.CreateBatch();
+                            long maxPosition = this.stream.Position;
+                            this.stream.Seek(0, SeekOrigin.Begin);
+                            var buffer = this.stream.GetBuffer();
+                            for (int j = 0; j < index; j++)
                             {
-                                //TODO send bytes directly instead of as events (which causes significant space overhead)
-                                this.stream.Seek(0, SeekOrigin.Begin);
-                                var fragment = fragments[k];
-                                Packet.Serialize((Event)fragment, this.stream, this.taskHubGuid);
-                                this.traceHelper.LogTrace("EventHubsSender {eventHubName}/{eventHubPartitionId} sending fragment {index}/{total} ({size} bytes) id={eventId}", this.eventHubName, this.eventHubPartition, k, fragments.Count, length, ((Event)fragment).EventIdString);
-                                length = (int)this.stream.Position;
-                                await this.sender.SendAsync(new EventData(new ArraySegment<byte>(this.stream.GetBuffer(), 0, length))).ConfigureAwait(false);
-                                this.traceHelper.LogDebug("EventHubsSender {eventHubName}/{eventHubPartitionId} sent fragment {index}/{total} ({size} bytes) id={eventId}", this.eventHubName, this.eventHubPartition, k, fragments.Count, length, ((Event)fragment).EventIdString);
+                                int offset = j == 0 ? 0 : packetOffsets[j - 1];
+                                int nextOffset = j < packetOffsets.Count ? packetOffsets[j] : (int) maxPosition;
+                                var length = nextOffset - offset;
+                                var arraySegment = new ArraySegment<byte>(buffer, offset, length);
+                                var eventData = new EventData(arraySegment);
+                                if (batch.TryAdd(eventData))
+                                {
+                                    Event evt = toSend[j];
+                                    this.lowestTraceLevel?.LogTrace("EventHubsSender {eventHubName}/{eventHubPartitionId} added packet to batch offset={offset} length={length} {evt} id={eventId}", this.eventHubName, this.eventHubPartition, offset, length, evt, evt.EventIdString);
+                                }
+                                else
+                                {
+                                    throw new InvalidOperationException("could not add event to batch"); // should never happen as max send size is very small
+                                }
                             }
-                            sentSuccessfully = i;
+                            maybeSent = index - 1;
+                            this.stopwatch.Restart();
+                            await this.sender.SendAsync(batch).ConfigureAwait(false);
+                            this.stopwatch.Stop();
+                            sentSuccessfully = index - 1;
+                            this.traceHelper.LogDebug("EventHubsSender {eventHubName}/{eventHubPartitionId} sent batch of {numPackets} packets ({size} bytes) in {latencyMs:F2}ms, throughput={throughput:F2}MB/s", this.eventHubName, this.eventHubPartition, batch.Count, batch.Size, this.stopwatch.Elapsed.TotalMilliseconds, batch.Size / (1024 * 1024 * this.stopwatch.Elapsed.TotalSeconds));
+                            break; // all messages were sent
                         }
                         else
                         {
-                            // back up one
-                            i--;
+                            usingBlobBatches = true;
                         }
-
-                        // the buffer can be reused now
-                        this.stream.Seek(0, SeekOrigin.Begin);
                     }
-                }
 
-                if (batch.Count > 0)
-                {
-                    await SendBatch(toSend.Count - 1);
-                    
-                    // the buffer can be reused now
-                    this.stream.Seek(0, SeekOrigin.Begin);
+                    // send the event(s) as a blob batch
+                    this.stopwatch.Restart();
+                    EventData blobMessage = await this.blobBatchSender.UploadEventsAsync(this.stream, packetOffsets, this.taskHubGuid, this.cancellationToken);
+                    maybeSent = index - 1;
+                    await this.sender.SendAsync(blobMessage);
+                    this.stopwatch.Stop();
+                    sentSuccessfully = index - 1;
+                    this.traceHelper.LogDebug("EventHubsSender {eventHubName}/{eventHubPartitionId} sent blob-batch of {numPackets} packets ({size} bytes) in {latencyMs:F2}ms, throughput={throughput:F2}MB/s", this.eventHubName, this.eventHubPartition, packetOffsets.Count + 1, this.stream.Position, this.stopwatch.Elapsed.TotalMilliseconds, this.stream.Position / (1024 * 1024 * this.stopwatch.Elapsed.TotalSeconds));
                 }
             }
-            catch(Microsoft.Azure.EventHubs.MessageSizeExceededException)
+            catch (OperationCanceledException) when (this.cancellationToken.IsCancellationRequested)
             {
-                this.maxMessageSize = 200 * 1024;
-                this.traceHelper.LogWarning("EventHubsSender {eventHubName}/{eventHubPartitionId} failed to send due to message size, reducing to {maxMessageSize}kB",
-                    this.eventHubName, this.eventHubPartition, this.maxMessageSize / 1024);
+                // normal during shutdown
+                this.traceHelper.LogDebug("EventHubsSender {eventHubName}/{eventHubPartitionId} was cancelled", this.eventHubName, this.eventHubPartition);
+                return;
             }
             catch (OperationCanceledException) when (this.cancellationToken.IsCancellationRequested)
             {
@@ -155,7 +171,7 @@ namespace DurableTask.Netherite.EventHubsTransport
             finally
             {
                 // we don't need the contents of the stream anymore.
-                this.stream.SetLength(0); 
+                this.stream.SetLength(0);
             }
 
             // Confirm all sent events, and retry or report maybe-sent ones

--- a/src/DurableTask.Netherite/TransportLayer/SingleHost/PartitionQueue.cs
+++ b/src/DurableTask.Netherite/TransportLayer/SingleHost/PartitionQueue.cs
@@ -87,7 +87,7 @@ namespace DurableTask.Netherite.SingleHostTransport
                     this.Notify();
                 };
                 
-                var nextInputQueuePosition = await this.Partition.CreateOrRestoreAsync(errorHandler, this.parameters, this.fingerPrint);
+                var (nextInputQueuePosition, _) = await this.Partition.CreateOrRestoreAsync(errorHandler, this.parameters, this.fingerPrint);
 
                 while(this.redeliverQueuePosition < nextInputQueuePosition)
                 {
@@ -144,7 +144,7 @@ namespace DurableTask.Netherite.SingleHostTransport
                 stream.Seek(0, SeekOrigin.Begin);
                 Packet.Serialize(evt, stream, this.taskhubGuid);
                 stream.Seek(0, SeekOrigin.Begin);
-                Packet.Deserialize(stream, out PartitionEvent freshEvent, null);
+                Packet.Deserialize(stream, out PartitionEvent freshEvent, out _,  null);
                 DurabilityListeners.Register(freshEvent, this);
                 freshEvent.NextInputQueuePosition = ++position;
                 list.Add(freshEvent);

--- a/src/DurableTask.Netherite/Util/FragmentationAndReassembly.cs
+++ b/src/DurableTask.Netherite/Util/FragmentationAndReassembly.cs
@@ -73,7 +73,7 @@ namespace DurableTask.Netherite
         {
             stream.Write(lastFragment.Bytes, 0, lastFragment.Bytes.Length);
             stream.Seek(0, SeekOrigin.Begin);
-            Packet.Deserialize(stream, out TEvent evt, null);
+            Packet.Deserialize(stream, out TEvent evt, out _, null);
             stream.Dispose();
             return evt;
         }
@@ -91,7 +91,7 @@ namespace DurableTask.Netherite
                 }
                 stream.Write(lastFragment.Bytes, 0, lastFragment.Bytes.Length);
                 stream.Seek(0, SeekOrigin.Begin);
-                Packet.Deserialize(stream, out TEvent evt, null);
+                Packet.Deserialize(stream, out TEvent evt, out _, null);
                 return evt;
             }
         }


### PR DESCRIPTION
This PR implements a new mechanism for optimizing the EH sender throughput.

Previously we observed in multiple cases that the limited throughput when sending data to a single partition caused bottlenecks in the application (#268, #240). 

With this new mechanism, anytime a partition sender needs to send large amounts of data (large messages, or many small messages), it does not send the messages directly via EH, but writes them to a blob batch, then sends a message containing the blob name. The receiver then loads the data from the blob batch. 

This may also resolve #272 since it replaces some of the code that was identified as the likely source of the error.