### PR TITLE
Revise handling of fatal exceptions

### DIFF
--- a/src/DurableTask.Netherite/Abstractions/TransportAbstraction.cs
+++ b/src/DurableTask.Netherite/Abstractions/TransportAbstraction.cs
@@ -62,6 +62,11 @@ namespace DurableTask.Netherite
             /// </summary>
             /// <param name="message"></param>
             void TraceWarning(string message);
+
+            /// <summary>
+            /// Called when some component observed a fatal exception. Host may take action to initiate a fast shutdown.
+            /// </summary>
+            void OnFatalExceptionObserved(Exception e);
         }
 
         /// <summary>

--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationServiceSettings.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationServiceSettings.cs
@@ -151,6 +151,12 @@ namespace DurableTask.Netherite
         public bool KeepInstanceIdsInMemory = true;
 
         /// <summary>
+        /// Whether to immediately shut down the transport layer and terminate the process when a fatal exception is observed.
+        /// This is true by default, to enable failing hosts to leave quickly which allows other hosts to recover the partitions more quickly.
+        /// </summary>
+        public bool EmergencyShutdownOnFatalExceptions = true;
+
+        /// <summary>
         /// Forces steps to pe persisted before applying their effects, disabling all pipelining.
         /// </summary>
         public bool PersistStepsFirst { get; set; } = false;

--- a/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/BlobManager.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/BlobManager.cs
@@ -640,7 +640,7 @@ namespace DurableTask.Netherite.Faster
                     }
                     continue;
                 }
-                catch (Exception e) when (!Utils.IsFatal(e))
+                catch (Exception e)
                 {
                     this.PartitionErrorHandler.HandleError(nameof(AcquireOwnership), "Could not acquire partition lease", e, true, false);
                     throw;
@@ -720,7 +720,7 @@ namespace DurableTask.Netherite.Faster
                 // We lost the lease to someone else. Terminate ownership immediately.
                 this.PartitionErrorHandler.HandleError(nameof(MaintenanceLoopAsync), "Lost partition lease", ex, true, true);
             }
-            catch (Exception e) when (!Utils.IsFatal(e))
+            catch (Exception e)
             {
                 this.PartitionErrorHandler.HandleError(nameof(MaintenanceLoopAsync), "Could not maintain partition lease", e, true, false);
             }

--- a/src/DurableTask.Netherite/StorageLayer/Faster/FasterAlt.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/FasterAlt.cs
@@ -472,7 +472,7 @@ namespace DurableTask.Netherite.Faster
                         await Task.Delay(nextRetryIn);
                         continue;
                     }
-                    catch (Exception exception) when (!Utils.IsFatal(exception))
+                    catch (Exception exception)
                     {
                         this.blobManager.PartitionErrorHandler.HandleError(nameof(LoadAsync), "Could not read object from storage", exception, true, this.blobManager.PartitionErrorHandler.IsTerminated);
                         throw;
@@ -562,7 +562,7 @@ namespace DurableTask.Netherite.Faster
                         await Task.Delay(nextRetryIn);
                         continue;
                     }
-                    catch (Exception exception) when (!Utils.IsFatal(exception))
+                    catch (Exception exception)
                     {
                         this.blobManager?.HandleStorageError(nameof(StoreAsync), "could not write object to storage", blob.Name, exception, true, this.blobManager.PartitionErrorHandler.IsTerminated);
                         throw;
@@ -592,7 +592,7 @@ namespace DurableTask.Netherite.Faster
             {
                 throw new OperationCanceledException("Partition was terminated.", this.terminationToken);
             }
-            catch (Exception e) when (!Utils.IsFatal(e))
+            catch (Exception e)
             {
                 this.blobManager.PartitionErrorHandler.HandleError(nameof(WriteCheckpointIntention), "Failed to write checkpoint intention to storage", e, true, this.blobManager.PartitionErrorHandler.IsTerminated);
                 throw;
@@ -616,7 +616,7 @@ namespace DurableTask.Netherite.Faster
             {
                 throw new OperationCanceledException("Partition was terminated.", this.terminationToken);
             }
-            catch (Exception e) when (!Utils.IsFatal(e))
+            catch (Exception e)
             {
                 this.blobManager.PartitionErrorHandler.HandleError(nameof(RemoveCheckpointIntention), "Failed to remove checkpoint intention from storage", e, true, false);
                 throw;
@@ -648,7 +648,7 @@ namespace DurableTask.Netherite.Faster
             {
                 throw new OperationCanceledException("Partition was terminated.", this.terminationToken);
             }
-            catch (Exception e) when (!Utils.IsFatal(e))
+            catch (Exception e)
             {
                 this.blobManager.PartitionErrorHandler.HandleError(nameof(ReadCheckpointIntentions), "Failed to read checkpoint intentions from storage", e, true, false);
                 throw;

--- a/src/DurableTask.Netherite/StorageLayer/Faster/FasterKV.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/FasterKV.cs
@@ -679,7 +679,7 @@ namespace DurableTask.Netherite.Faster
             {
                 // partition is terminating
             }
-            catch (Exception e) when (!Utils.IsFatal(e))
+            catch (Exception e)
             {
                 this.partition.ErrorHandler.HandleError(nameof(RunPrefetchSession), "PrefetchSession {sessionId} encountered exception", e, false, this.partition.ErrorHandler.IsTerminated);
             }

--- a/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsProcessor.cs
+++ b/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsProcessor.cs
@@ -97,7 +97,7 @@ namespace DurableTask.Netherite.EventHubsTransport
             this.blobBatchReceiver = new BlobBatchReceiver<PartitionEvent>(traceContext, this.traceHelper, this.settings, keepUntilConfirmed: true);
 
             var _ = shutdownToken.Register(
-              () => { var _ = Task.Run(() => this.IdempotentShutdown("shutdownToken", false)); },
+              () => { var _ = Task.Run(() => this.IdempotentShutdown("shutdownToken", eventHubsTransport.FatalExceptionObserved)); },
               useSynchronizationContext: false);
         }
 
@@ -253,7 +253,7 @@ namespace DurableTask.Netherite.EventHubsTransport
                 // the partition startup was canceled
                 this.traceHelper.LogDebug("EventHubsProcessor {eventHubName}/{eventHubPartition} canceled partition startup (incarnation {incarnation})", this.eventHubName, this.eventHubPartition, c.Incarnation);
             }
-            catch (Exception e) when (!Utils.IsFatal(e))
+            catch (Exception e)
             {
                 c.SuccessiveStartupFailures = 1 + (prior?.SuccessiveStartupFailures ?? 0);
                 c.ErrorHandler.HandleError("EventHubsProcessor.StartPartitionAsync", "failed to start partition", e, true, false);
@@ -338,11 +338,16 @@ namespace DurableTask.Netherite.EventHubsTransport
                     await context.CheckpointAsync(checkpoint);
                     this.lastCheckpointedOffset = long.Parse(checkpoint.Offset);
                 }
-                catch (Exception e) when (!Utils.IsFatal(e))
+                catch (Exception e)
                 {
                     // updating EventHubs checkpoints has been known to fail occasionally due to leases shifting around; since it is optional anyway
                     // we don't want this exception to cause havoc
                     this.traceHelper.LogWarning("EventHubsProcessor {eventHubName}/{eventHubPartition} failed to checkpoint receive position: {e}", this.eventHubName, this.eventHubPartition, e);
+
+                    if (Utils.IsFatal(e))
+                    {
+                        this.host.OnFatalExceptionObserved(e);
+                    }
                 }
             }
         }

--- a/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsSender.cs
+++ b/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsSender.cs
@@ -165,8 +165,13 @@ namespace DurableTask.Netherite.EventHubsTransport
             }
             catch (Exception e)
             {
-                this.traceHelper.LogWarning(e, "EventHubsSender {eventHubName}/{eventHubPartitionId} failed to send", this.eventHubName, this.eventHubPartition);
+                this.traceHelper.LogWarning("EventHubsSender {eventHubName}/{eventHubPartitionId} failed to send: {e}", this.eventHubName, this.eventHubPartition, e);
                 senderException = e;
+
+                if (Utils.IsFatal(e))
+                {
+                    this.host.OnFatalExceptionObserved(e);
+                }
             }
             finally
             {
@@ -221,9 +226,14 @@ namespace DurableTask.Netherite.EventHubsTransport
                 else
                     this.traceHelper.LogDebug("EventHubsSender {eventHubName}/{eventHubPartitionId} has confirmed {confirmed}, requeued {requeued}, dropped {dropped} outbound events", this.eventHubName, this.eventHubPartition, confirmed, requeued, dropped);
             }
-            catch (Exception exception) when (!Utils.IsFatal(exception))
+            catch (Exception exception)
             {
                 this.traceHelper.LogError("EventHubsSender {eventHubName}/{eventHubPartitionId} encountered an error while trying to confirm messages: {exception}", this.eventHubName, this.eventHubPartition, exception);
+
+                if (Utils.IsFatal(exception))
+                {
+                    this.host.OnFatalExceptionObserved(exception);
+                }
             }
         }
     }

--- a/src/DurableTask.Netherite/TransportLayer/ITransportLayer.cs
+++ b/src/DurableTask.Netherite/TransportLayer/ITransportLayer.cs
@@ -33,7 +33,8 @@ namespace DurableTask.Netherite
         /// <summary>
         /// Stops the transport backend.
         /// </summary>
+        /// <param name="fatalExceptionObserved">Whether this stop was initiated because we have observed a fatal exception.</param>
         /// <returns>After the transport backend has stopped.</returns>
-        Task StopAsync();
+        Task StopAsync(bool fatalExceptionObserved);
     }
 }

--- a/src/DurableTask.Netherite/TransportLayer/SingleHost/SingleHostTransportProvider.cs
+++ b/src/DurableTask.Netherite/TransportLayer/SingleHost/SingleHostTransportProvider.cs
@@ -95,7 +95,7 @@ namespace DurableTask.Netherite.SingleHostTransport
             return Task.CompletedTask;
         }
 
-        async Task ITransportLayer.StopAsync()
+        async Task ITransportLayer.StopAsync(bool fatalExceptionObserved)
         {
             var tasks = new List<Task>();
             tasks.Add(this.clientQueue.Client.StopAsync());


### PR DESCRIPTION
Currently, most of the code ignores fatal exceptions (such as OOM). The problem with that is that if a host crashes due to OOM it does not release the storage leases, which means no other host can pick up the partition until the lease expires (30s). 
 
To address this, this PR adds a new mechanism to deal with fatal exceptions on partitions. When experiencing a fatal exception within a partition, the partition error handler takes notice and *immediately* shuts the transport layer. This shutdown quickly tries to release all leases. This allows partitions to more quickly restart on other nodes. 