### PR TITLE
Create unique scale monitor descriptors

### DIFF
--- a/src/DurableTask.Netherite.AzureFunctions/DurableTask.Netherite.AzureFunctions.csproj
+++ b/src/DurableTask.Netherite.AzureFunctions/DurableTask.Netherite.AzureFunctions.csproj
@@ -26,9 +26,9 @@
   <PropertyGroup>
 	<MajorVersion>1</MajorVersion>
 	<MinorVersion>4</MinorVersion>
-	<PatchVersion>0</PatchVersion>
+	<PatchVersion>1</PatchVersion>
 	<VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
+    <VersionSuffix>private</VersionSuffix>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <BuildSuffix Condition="'$(GITHUB_RUN_NUMBER)' != ''">.$(GITHUB_RUN_NUMBER)</BuildSuffix>
     <FileVersion>$(VersionPrefix)$(BuildSuffix)</FileVersion>

--- a/src/DurableTask.Netherite.AzureFunctions/NetheriteProvider.cs
+++ b/src/DurableTask.Netherite.AzureFunctions/NetheriteProvider.cs
@@ -145,7 +145,12 @@ namespace DurableTask.Netherite.AzureFunctions
             public ScaleMonitor(ScalingMonitor scalingMonitor)
             {
                 this.scalingMonitor = scalingMonitor;
-                this.descriptor = new ScaleMonitorDescriptor($"DurableTaskTrigger-Netherite-{this.scalingMonitor.TaskHubName}".ToLower());
+
+                // appending random GUID to end of descriptor to keep scale monitor keys unique
+                string guid = Guid.NewGuid().ToString("N");
+
+                var descriptorId = $"DurableTaskTrigger-Netherite-{this.scalingMonitor.TaskHubName}-{guid}".ToLower();
+                this.descriptor = new ScaleMonitorDescriptor(descriptorId);
             }
 
             public ScaleMonitorDescriptor Descriptor => this.descriptor;


### PR DESCRIPTION
This PR appends a GUID to the scale monitor descriptor to make it unique because customers have been seeing this exception - `System.ArgumentException : An item with the same key has already been added.`

This PR is used to create a private package for a customer to get this fix but it will get merged once the fix is validated.