### PR TITLE
fix discard of packets so the next packet to expect is updated correctly

### DIFF
--- a/src/DurableTask.Netherite/TransportLayer/EventHubs/BlobBatchReceiver.cs
+++ b/src/DurableTask.Netherite/TransportLayer/EventHubs/BlobBatchReceiver.cs
@@ -51,7 +51,7 @@ namespace DurableTask.Netherite.EventHubsTransport
             byte[] guid, 
             IEnumerable<EventData> hubMessages,
             [EnumeratorCancellation] CancellationToken token,
-            long? nextPacketToReceive = null)
+            MutableLong nextPacketToReceive = null)
         {
             int ignoredPacketCount = 0;
 
@@ -59,7 +59,7 @@ namespace DurableTask.Netherite.EventHubsTransport
             {
                 var seqno = eventData.SystemProperties.SequenceNumber;
 
-                if (nextPacketToReceive.HasValue)
+                if (nextPacketToReceive != null)
                 {
                     if (seqno < nextPacketToReceive.Value)
                     {
@@ -182,9 +182,9 @@ namespace DurableTask.Netherite.EventHubsTransport
                     }
                 }
 
-                if (nextPacketToReceive.HasValue)
+                if (nextPacketToReceive != null)
                 {
-                    nextPacketToReceive = seqno + 1;
+                    nextPacketToReceive.Value = seqno + 1;
                 }
             }
 
@@ -361,5 +361,10 @@ namespace DurableTask.Netherite.EventHubsTransport
 
             return deletedCount;
         }
+    }
+
+    public class MutableLong
+    {
+        public long Value;
     }
 }

--- a/src/DurableTask.Netherite/TransportLayer/EventHubs/ScriptedEventProcessorHost.cs
+++ b/src/DurableTask.Netherite/TransportLayer/EventHubs/ScriptedEventProcessorHost.cs
@@ -348,7 +348,12 @@ namespace DurableTask.Netherite.EventHubsTransport
 
                             var receivedTimestamp = this.partition.CurrentTimeMs;
 
-                            await foreach ((EventData eventData, PartitionEvent[] events, long seqNo) in this.blobBatchReceiver.ReceiveEventsAsync(this.host.taskHubGuid, hubMessages, this.shutdownSource.Token, nextPacketToReceive.seqNo))
+
+                            // we need to update the next expected seqno even if the iterator returns no packets, since it may have discarded some
+                            // iterators do not support ref arguments, so we use a simple wrapper class to work around this limitation
+                            MutableLong nextPacket = new MutableLong() { Value = nextPacketToReceive.seqNo };
+
+                            await foreach ((EventData eventData, PartitionEvent[] events, long seqNo) in this.blobBatchReceiver.ReceiveEventsAsync(this.host.taskHubGuid, hubMessages, this.shutdownSource.Token, nextPacket))
                             {
                                 for (int i = 0; i < events.Length; i++)
                                 {
@@ -382,7 +387,7 @@ namespace DurableTask.Netherite.EventHubsTransport
                                     this.partition.SubmitEvents(events.Skip(nextPacketToReceive.batchPos).ToList());
                                 }
 
-                                nextPacketToReceive = (seqNo + 1, 0);
+                                nextPacketToReceive = (nextPacket.Value, 0);
                             }
 
                             this.host.logger.LogDebug("EventHubsProcessor {eventHubName}/{eventHubPartition}({incarnation}) received {totalEvents} events in {latencyMs:F2}ms, next expected packet is #{nextSeqno}", this.host.eventHubPath, this.partitionId, this.Incarnation, totalEvents, stopwatch.Elapsed.TotalMilliseconds, nextPacketToReceive.seqNo);


### PR DESCRIPTION
Fixes a bug where discarding events from other taskhubs causes the expected sequence number to be wrong (not updated to reflect the discarded packets) which then triggers spurious errors when receiving more events.

This code is not tested yet.