### PR TITLE
Instrument event-log serialization/deserialization

### DIFF
--- a/src/DurableTask.Netherite/StorageLayer/Faster/LogWorker.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/LogWorker.cs
@@ -11,6 +11,7 @@ namespace DurableTask.Netherite.Faster
     using System.Threading.Tasks;
     using System.Threading.Channels;
     using FASTER.core;
+    using System.IO.Hashing;
 
     class LogWorker : BatchWorker<PartitionUpdateEvent>
     {
@@ -19,6 +20,7 @@ namespace DurableTask.Netherite.Faster
         readonly Partition partition;
         readonly StoreWorker storeWorker;
         readonly FasterTraceHelper traceHelper;
+        readonly bool traceLogDetails;
         bool isShuttingDown;
 
         readonly IntakeWorker intakeWorker;
@@ -34,6 +36,7 @@ namespace DurableTask.Netherite.Faster
             this.storeWorker = storeWorker;
             this.traceHelper = traceHelper;
             this.intakeWorker = new IntakeWorker(cancellationToken, this, partition.TraceHelper);
+            this.traceLogDetails = traceHelper.IsTracingAtMostDetailedLevel;
 
             this.maxFragmentSize = (int) this.blobManager.GetEventLogSettings(partition.Settings.UseSeparatePageBlobStorage, partition.Settings.FasterTuningParameters).PageSize - 64; // faster needs some room for header, 64 bytes is conservative
         }
@@ -112,7 +115,7 @@ namespace DurableTask.Netherite.Faster
         {
             if (bytes.Length <= this.maxFragmentSize)
             {
-                this.log.Enqueue(bytes);
+                this.AppendToLog(bytes);
             }
             else
             {
@@ -123,10 +126,28 @@ namespace DurableTask.Netherite.Faster
                     bool isLastFragment = 1 + bytes.Length - pos <= this.maxFragmentSize;
                     int packetSize = isLastFragment ? 1 + bytes.Length - pos : this.maxFragmentSize;
                     bytes[pos - 1] = (byte)(((pos == 1) ? first : none) | (isLastFragment ? last : none));
-                    this.log.Enqueue(new ReadOnlySpan<byte>(bytes, pos - 1, packetSize));
+                    this.AppendToLog(new ReadOnlySpan<byte>(bytes, pos - 1, packetSize));
                     pos += packetSize - 1;
                 }
             }
+        }
+
+        void AppendToLog(ReadOnlySpan<byte> span)
+        {
+            this.log.Enqueue(span);
+            if (this.traceLogDetails)
+            {
+                this.TraceLogDetail("Appended", this.log.TailAddress, span);
+            }
+        }
+
+        void TraceLogDetail(string operation, long nextCommitLogPosition, ReadOnlySpan<byte> span)
+        {
+            byte firstByte = span[0];
+            char f = ((firstByte & first) != 0) ? 'F' : '.';
+            char l = ((firstByte & last) != 0) ? 'L' : '.';
+            byte[] crc = Crc32.Hash(span);
+            this.traceHelper.FasterStorageProgress($"CommitLogEntry {operation} {nextCommitLogPosition} {f}{l} length={span.Length} crc={crc[0]:X2}{crc[1]:X2}{crc[2]:X2}{crc[3]:X2}");
         }
 
         public async Task PersistAndShutdownAsync()
@@ -264,11 +285,17 @@ namespace DurableTask.Netherite.Faster
                         await iter.WaitAsync(this.cancellationToken);
                     }
 
+                    if (this.traceLogDetails)
+                    {
+                        this.TraceLogDetail("Read", iter.NextAddress, new ReadOnlySpan<byte>(result, 0, entryLength));
+                    }
+
                     if ((result[0] & first) != none)
                     {
                         if ((result[0] & last) != none)
                         {
-                            partitionEvent = (PartitionUpdateEvent)Serializer.DeserializeEvent(new ArraySegment<byte>(result, 1, entryLength - 1));
+                            partitionEvent = TryDeserializePartitionEvent(new MemoryStream(result, 1, entryLength - 1), reassembled:false);                 
+                            reassembly = null;
                         }
                         else
                         {
@@ -283,7 +310,7 @@ namespace DurableTask.Netherite.Faster
                         if ((result[0] & last) != none)
                         {
                             reassembly.Position = 0;
-                            partitionEvent = (PartitionUpdateEvent)Serializer.DeserializeEvent(reassembly);
+                            partitionEvent = TryDeserializePartitionEvent(reassembly, reassembled:true);
                             reassembly = null;
                         }
                     }
@@ -292,6 +319,20 @@ namespace DurableTask.Netherite.Faster
                     {
                         partitionEvent.NextCommitLogPosition = iter.NextAddress;
                         yield return partitionEvent;
+                    }
+                }
+
+                PartitionUpdateEvent TryDeserializePartitionEvent(MemoryStream from, bool reassembled)
+                {
+                    try
+                    {
+                        return (PartitionUpdateEvent)Serializer.DeserializeEvent(from);
+                    }
+                    catch (System.Runtime.Serialization.SerializationException serializationException)
+                    {
+                        string message = $"Could not deserialize partition event (nextCommitLogPosition={iter.NextAddress}, reassembled={reassembled}): {serializationException.Message}";
+                        this.blobManager.PartitionErrorHandler.HandleError("ReplayCommitLog", message, serializationException, false, false);
+                        return null; // continue even if it leads to incorrect state... as that is still better than no function (retries do not help here)
                     }
                 }
             }


### PR DESCRIPTION
Several changes, to deal with recently observed fatal deserialization errors that can make partitions permanently unusable.

1. Adds detailed tracing (enabled only at lowest Trace level) that collects detailed information about each portion of data written to and read from the log.
2. Collects more information about the thrown deserialization exceptions.
3. Catches the deserialization exceptions and tries to continue as best as possible, ignoring the particular event that threw the exception.

 