### PR TITLE
fix cache size reporting

### DIFF
--- a/src/DurableTask.Netherite/StorageLayer/Faster/FasterKV.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/FasterKV.cs
@@ -1252,7 +1252,7 @@ namespace DurableTask.Netherite.Faster
         public override (double totalSizeMB, int fillPercentage) CacheSizeInfo {
             get
             {
-                double totalSize = (double)(Math.Min(0, this.cacheTracker.TrackedObjectSize) + this.MemoryUsedWithoutObjects);
+                double totalSize = (double)(Math.Max(0, this.cacheTracker.TrackedObjectSize) + this.MemoryUsedWithoutObjects);
                 double totalSizeMB = Math.Round(100 * totalSize / (1024 * 1024)) / 100;
                 if (this.cacheTracker.TargetSize == 0)
                 {


### PR DESCRIPTION
reported CacheMB size has apparently been broken due to a trivial math error since this PR: [fix corner case for cache size reporting by sebastianburckhardt · Pull Request #203 · microsoft/durabletask-netherite (github.com)](https://github.com/microsoft/durabletask-netherite/pull/203/files)

Easily fixed by this PR.