### PR TITLE
Fix compiler warnings about use of nullable features in non-nullable code

### DIFF
--- a/src/DurableTask.Netherite/OrchestrationService/PartitionErrorHandler.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/PartitionErrorHandler.cs
@@ -61,7 +61,7 @@ namespace DurableTask.Netherite
             this.host = host;
         }
      
-        public void HandleError(string context, string message, Exception? exception, bool terminatePartition, bool isWarning)
+        public void HandleError(string context, string message, Exception exception, bool terminatePartition, bool isWarning)
         {
             bool isFatal = exception != null && Utils.IsFatal(exception);
 
@@ -94,7 +94,7 @@ namespace DurableTask.Netherite
             }
         }
 
-        void TraceError(bool isWarning, string context, string message, Exception? exception, bool terminatePartition)
+        void TraceError(bool isWarning, string context, string message, Exception exception, bool terminatePartition)
         {
             var logLevel = isWarning ? LogLevel.Warning : LogLevel.Error;
             if (this.logLevelLimit <= logLevel)

--- a/src/DurableTask.Netherite/StorageLayer/Faster/StoreWorker.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/StoreWorker.cs
@@ -31,15 +31,15 @@ namespace DurableTask.Netherite.Faster
 
         // periodic index and store checkpointing
         CheckpointTrigger pendingCheckpointTrigger;
-        Task? pendingIndexCheckpoint;
-        Task<(long, (long,int))>? pendingStoreCheckpoint;
+        Task pendingIndexCheckpoint;
+        Task<(long, (long,int))> pendingStoreCheckpoint;
         (long,int) lastCheckpointedInputQueuePosition;
         long lastCheckpointedCommitLogPosition;
         long numberEventsSinceLastCheckpoint;
         DateTime timeOfNextIdleCheckpoint;
 
         // periodic compaction
-        Task<long?>? pendingCompaction;
+        Task<long?> pendingCompaction;
 
         // periodic load publishing
         PartitionLoadInfo loadInfo;
@@ -301,7 +301,7 @@ namespace DurableTask.Netherite.Faster
             long inputQueuePositionLag = this.GetInputQueuePositionLag();
             
             // since this is a pure function, we declare it as local static for improved performance
-            static string ReportNullableTaskStatus(Task? t)
+            static string ReportNullableTaskStatus(Task t)
             {
                 if (t == null)
                 {


### PR DESCRIPTION
Several compiler warnings were introduced by recent changes. 


This PR reverts the changes. 

