### PR TITLE
Revise how dispose tasks are organized 

### DIFF
--- a/src/DurableTask.Netherite/Abstractions/PartitionState/IPartitionErrorHandler.cs
+++ b/src/DurableTask.Netherite/Abstractions/PartitionState/IPartitionErrorHandler.cs
@@ -20,9 +20,9 @@ namespace DurableTask.Netherite
         CancellationToken Token { get; }
 
         /// <summary>
-        /// A place to subscribe (potentially non-instantaneous) cleanup actions that execute on a dedicated thread.
+        /// Adds a task to be executed after the partition has been terminated.
         /// </summary>
-        event Action OnShutdown;
+        void AddDisposeTask(string name, TimeSpan timeout, Action action);
 
         /// <summary>
         /// A boolean indicating whether the partition is terminated.
@@ -35,9 +35,11 @@ namespace DurableTask.Netherite
         bool NormalTermination { get; }
 
         /// <summary>
-        /// Wait for all termination operations to finish
+        /// Waits for the dispose tasks to complete, up to the specified time limit.
         /// </summary>
-        Task<bool> WaitForTermination(TimeSpan timeout);
+        /// <param name="timeout">The maximum time to wait for</param>
+        /// <returns>true if all tasks completed within the timeout, false otherwise.</returns>
+        bool WaitForDisposeTasks(TimeSpan timeout);
 
         /// <summary>
         /// Error handling for the partition.

--- a/src/DurableTask.Netherite/OrchestrationService/PartitionErrorHandler.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/PartitionErrorHandler.cs
@@ -4,6 +4,7 @@
 namespace DurableTask.Netherite
 {
     using System;
+    using System.Collections.Generic;
     using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
@@ -22,8 +23,7 @@ namespace DurableTask.Netherite
         readonly string taskHub;
         readonly TaskCompletionSource<object> shutdownComplete;
         readonly TransportAbstraction.IHost host;
-
-        public event Action OnShutdown;
+        readonly List<Task> disposeTasks;
 
         public CancellationToken Token
         {
@@ -44,6 +44,11 @@ namespace DurableTask.Netherite
 
         public bool NormalTermination =>  this.terminationStatus == TerminatedNormally;
 
+        public bool WaitForDisposeTasks(TimeSpan timeout)
+        {
+            return Task.WhenAll(this.disposeTasks).Wait(timeout);
+        }
+
         volatile int terminationStatus = NotTerminated;
         const int NotTerminated = 0;
         const int TerminatedWithError = 1;
@@ -59,6 +64,7 @@ namespace DurableTask.Netherite
             this.taskHub = taskHubName;
             this.shutdownComplete = new TaskCompletionSource<object>();
             this.host = host;
+            this.disposeTasks = new List<Task>();
         }
      
         public void HandleError(string context, string message, Exception exception, bool terminatePartition, bool isWarning)
@@ -119,9 +125,8 @@ namespace DurableTask.Netherite
         {
             try
             {
-                this.logger?.LogDebug("Part{partition:D2} Started PartitionCancellation", this.partitionId);
+                // this immediately cancels all activities depending on the error handler token
                 this.cts.Cancel();
-                this.logger?.LogDebug("Part{partition:D2} Completed PartitionCancellation", this.partitionId);
             }
             catch (AggregateException aggregate)
             {
@@ -134,47 +139,45 @@ namespace DurableTask.Netherite
             {
                 this.HandleError("PartitionErrorHandler.Terminate", "Exception in PartitionCancellation", e, false, true);
             }
-
-            // we use a dedicated shutdown thread to help debugging and to contain damage if there are hangs
-            Thread shutdownThread = TrackedThreads.MakeTrackedThread(Shutdown, "PartitionShutdown");
-            shutdownThread.Start();
-
-            void Shutdown()
+            finally
             {
-                try
-                {
-                    this.logger?.LogDebug("Part{partition:D2} Started PartitionShutdown", this.partitionId);
-
-                    if (this.OnShutdown != null)
-                    {
-                        this.OnShutdown();
-                    }
-
-                    this.cts.Dispose();
-
-                    this.logger?.LogDebug("Part{partition:D2} Completed PartitionShutdown", this.partitionId);
-                }
-                catch (AggregateException aggregate)
-                {
-                    foreach (var e in aggregate.InnerExceptions)
-                    {
-                        this.HandleError("PartitionErrorHandler.Shutdown", "Exception in PartitionShutdown", e, false, true);
-                    }
-                }
-                catch (Exception e)
-                {
-                    this.HandleError("PartitionErrorHandler.Shutdown", "Exception in PartitionShutdown", e, false, true);
-                }
-
-                this.shutdownComplete.TrySetResult(null);
+                // now that the partition is dead, run all the dispose tasks
+                Task.Run(this.DisposeAsync);
             }
         }
 
-        public async Task<bool> WaitForTermination(TimeSpan timeout)
+        public void AddDisposeTask(string name, TimeSpan timeout, Action action)
         {
-            Task timeoutTask = Task.Delay(timeout);
-            var first = await Task.WhenAny(timeoutTask, this.shutdownComplete.Task);
-            return first == this.shutdownComplete.Task;
+            this.disposeTasks.Add(new Task(() =>
+            {
+                Task disposeTask = Task.Run(action);
+                try
+                {
+                    bool completedInTime = disposeTask.Wait(timeout);
+                    if (!completedInTime)
+                    {
+                        this.HandleError("PartitionErrorHandler.DisposeAsync", $"Dispose Task {name} timed out after {timeout}", null, false, false);
+                    }
+                }
+                catch(Exception exception)
+                {
+                    this.HandleError("PartitionErrorHandler.DisposeAsync", $"Dispose Task {name} threw exception {exception}", null, false, false);
+                }
+            }));
+        }
+
+        async Task DisposeAsync()
+        {
+            // execute all the dispose tasks in parallel
+            var tasks = this.disposeTasks;
+            foreach (var task in tasks)
+            {
+                task.Start();
+            }
+            await Task.WhenAll(tasks);
+
+            // we can now dispose the cancellation token source itself
+            this.cts.Dispose();
         }
     }
 }

--- a/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/BlobManager.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/BlobManager.cs
@@ -754,9 +754,11 @@ namespace DurableTask.Netherite.Faster
                 }
             }
 
+            this.TraceHelper.FasterProgress("Blob manager is terminating partition normally");
+
             this.PartitionErrorHandler.TerminateNormally();
 
-            this.TraceHelper.LeaseProgress("Blob manager stopped");
+            this.TraceHelper.FasterProgress("Blob manager stopped");
         }
 
         public async Task RemoveObsoleteCheckpoints()

--- a/src/DurableTask.Netherite/StorageLayer/Faster/FasterKV.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/FasterKV.cs
@@ -112,7 +112,7 @@ namespace DurableTask.Netherite.Faster
             partition.Assert(this.fht.ReadCache == null, "Unexpected read cache");
 
             this.terminationToken = partition.ErrorHandler.Token;
-            partition.ErrorHandler.OnShutdown += this.Shutdown;
+            partition.ErrorHandler.AddDisposeTask($"{nameof(FasterKV)}.{nameof(this.Dispose)}", TimeSpan.FromMinutes(2), this.Dispose);
 
             this.compactionStopwatch = new Stopwatch();
             this.compactionStopwatch.Start();
@@ -122,58 +122,53 @@ namespace DurableTask.Netherite.Faster
             this.blobManager.TraceHelper.FasterProgress("Constructed FasterKV");
         }
 
-        void Shutdown()
+        void Dispose()
         {
+            this.TraceHelper.FasterProgress("Disposing CacheTracker");
+            this.cacheTracker?.Dispose();
+
+            foreach (var s in this.sessionsToDisposeOnShutdown)
+            {
+                this.TraceHelper.FasterStorageProgress($"Disposing Temporary Session");
+                s.Dispose();
+            }
+
+            this.TraceHelper.FasterProgress("Disposing Main Session");
             try
             {
-                this.TraceHelper.FasterProgress("Disposing CacheTracker");
-                this.cacheTracker?.Dispose();
+                this.mainSession?.Dispose();
+            }
+            catch (OperationCanceledException)
+            {
+                // can happen during shutdown
+            }
 
-                foreach (var s in this.sessionsToDisposeOnShutdown)
-                {
-                    this.TraceHelper.FasterStorageProgress($"Disposing Temporary Session");
-                    s.Dispose();
-                }
-
-                this.TraceHelper.FasterProgress("Disposing Main Session");
+            this.TraceHelper.FasterProgress("Disposing Query Sessions");
+            foreach (var s in this.querySessions)
+            {
                 try
                 {
-                    this.mainSession?.Dispose();
+                    s?.Dispose();
                 }
-                catch(OperationCanceledException)
+                catch (OperationCanceledException)
                 {
                     // can happen during shutdown
                 }
-
-                this.TraceHelper.FasterProgress("Disposing Query Sessions");
-                foreach (var s in this.querySessions)
-                {
-                    try
-                    {
-                        s?.Dispose();
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        // can happen during shutdown
-                    }
-                }
-
-                this.TraceHelper.FasterProgress("Disposing FasterKV");
-                this.fht.Dispose();
-
-                this.TraceHelper.FasterProgress($"Disposing Devices");
-                this.blobManager.DisposeDevices();
-
-                if (this.blobManager.FaultInjector != null)
-                {
-                    this.TraceHelper.FasterProgress($"Unregistering from FaultInjector");
-                    this.blobManager.FaultInjector.Disposed(this.blobManager);
-                }
             }
-            catch (Exception e)
+
+            this.TraceHelper.FasterProgress("Disposing FasterKV");
+            this.fht.Dispose();
+
+            this.TraceHelper.FasterProgress($"Disposing Devices");
+            this.blobManager.DisposeDevices();
+
+            if (this.blobManager.FaultInjector != null)
             {
-                this.blobManager.TraceHelper.FasterStorageError("Disposing FasterKV", e);
+                this.TraceHelper.FasterProgress($"Unregistering from FaultInjector");
+                this.blobManager.FaultInjector.Disposed(this.blobManager);
             }
+
+            this.TraceHelper.FasterProgress("Disposed FasterKV");
         }
 
         double GetElapsedCompactionMilliseconds()

--- a/src/DurableTask.Netherite/StorageLayer/Faster/FasterLog.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/FasterLog.cs
@@ -20,24 +20,19 @@ namespace DurableTask.Netherite.Faster
             this.blobManager = blobManager;
             var eventlogsettings = blobManager.GetEventLogSettings(settings.UseSeparatePageBlobStorage, settings.FasterTuningParameters);
             this.log = new FASTER.core.FasterLog(eventlogsettings);
-            blobManager.PartitionErrorHandler.OnShutdown += this.Shutdown;
+            blobManager.PartitionErrorHandler.AddDisposeTask($"{nameof(FasterLog)}.{nameof(this.Dispose)}", TimeSpan.FromMinutes(2), this.Dispose);
             this.terminationToken = blobManager.PartitionErrorHandler.Token;
         }
-        
-        void Shutdown()
-        {
-            try
-            {
-                this.blobManager.TraceHelper.FasterProgress("Disposing FasterLog");
-                this.log.Dispose();
 
-                this.blobManager.TraceHelper.FasterProgress("Disposing FasterLog Device");
-                this.blobManager.EventLogDevice.Dispose();
-            }
-            catch (Exception e)
-            {
-                this.blobManager.TraceHelper.FasterStorageError("Disposing FasterLog", e);
-            }
+        void Dispose()
+        {
+            this.blobManager.TraceHelper.FasterProgress("Disposing FasterLog");
+            this.log.Dispose();
+
+            this.blobManager.TraceHelper.FasterProgress("Disposing FasterLog Device");
+            this.blobManager.EventLogDevice.Dispose();
+
+            this.blobManager.TraceHelper.FasterProgress("Disposed FasterLog");
         }
 
         public long BeginAddress => this.log.BeginAddress;

--- a/src/DurableTask.Netherite/StorageLayer/Faster/PartitionStorage.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/PartitionStorage.cs
@@ -115,7 +115,7 @@ namespace DurableTask.Netherite.Faster
             if (this.partition.Settings.TestHooks?.ReplayChecker == null)
             {
                 this.hangCheckTimer = new Timer(this.CheckForStuckWorkers, null, 0, 20000);
-                errorHandler.OnShutdown += () => this.hangCheckTimer.Dispose();
+                errorHandler.AddDisposeTask("DisposeHangTimer", TimeSpan.FromSeconds(10), () => this.hangCheckTimer.Dispose());
             }
 
             bool hasCheckpoint = false;

--- a/src/DurableTask.Netherite/TransportLayer/SingleHost/PartitionQueue.cs
+++ b/src/DurableTask.Netherite/TransportLayer/SingleHost/PartitionQueue.cs
@@ -78,14 +78,14 @@ namespace DurableTask.Netherite.SingleHostTransport
             {
                 this.Partition = this.host.AddPartition(this.partitionId, this.sender);
                 var errorHandler = this.host.CreateErrorHandler(this.partitionId);
-                errorHandler.OnShutdown += () =>
+                errorHandler.AddDisposeTask("PartitionQueue.Termination", TimeSpan.FromSeconds(10), () =>
                 {
                     if (!this.isShuttingDown && this.testHooks?.FaultInjectionActive != true)
                     {
                         this.testHooks?.Error("MemoryTransport", "Unexpected partition termination");
                     }
                     this.Notify();
-                };
+                });
                 
                 var (nextInputQueuePosition, _) = await this.Partition.CreateOrRestoreAsync(errorHandler, this.parameters, this.fingerPrint);
 


### PR DESCRIPTION
There are a number of tasks that need to execute after a partition has shut down.

These dispose tasks were previously registered as events. 

For more uniform handling of timeouts and error reporting, this PR now allows disposal tasks to be registered with timeouts, and generates consistent partition error messages when any of the tasks throw or do not complete in time.

 