### PR TITLE
Revise partition startup

### DIFF
--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationServiceSettings.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationServiceSettings.cs
@@ -169,6 +169,11 @@ namespace DurableTask.Netherite
         public int PackPartitionTaskMessages { get; set; } = 100;
 
         /// <summary>
+        /// Time limit for partition startup, in minutes.
+        /// </summary>
+        public int PartitionStartupTimeoutMinutes { get; set; } = 15;
+
+        /// <summary>
         /// Allows attaching additional checkers and debuggers during testing.
         /// </summary>
         [JsonIgnore]

--- a/src/DurableTask.Netherite/OrchestrationService/Partition.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/Partition.cs
@@ -55,7 +55,10 @@ namespace DurableTask.Netherite
         // A little helper property that allows us to conventiently check the condition for low-level event tracing
         public EventTraceHelper EventDetailTracer => this.EventTraceHelper.IsTracingAtMostDetailedLevel ? this.EventTraceHelper : null;
 
-        static readonly SemaphoreSlim MaxConcurrentStarts = new SemaphoreSlim(5);
+        // We use this semaphore to limit how many partitions can be starting up at the same time on the same host
+        // because starting up a partition may temporarily consume a lot of CPU, I/O, and memory
+        const int ConcurrentStartsLimit = 5;
+        static readonly SemaphoreSlim MaxConcurrentStarts = new SemaphoreSlim(ConcurrentStartsLimit);
 
         public Partition(
             NetheriteOrchestrationService host,
@@ -108,7 +111,7 @@ namespace DurableTask.Netherite
 
             // before we start the partition, we have to acquire the MaxConcurrentStarts semaphore
             // (to prevent a host from being overwhelmed by the simultaneous start of too many partitions)
-            this.TraceHelper.TracePartitionProgress("Waiting", ref this.LastTransition, this.CurrentTimeMs, "");
+            this.TraceHelper.TracePartitionProgress("Waiting", ref this.LastTransition, this.CurrentTimeMs, $"max={ConcurrentStartsLimit} available={MaxConcurrentStarts.CurrentCount}");
             await MaxConcurrentStarts.WaitAsync();
 
             try
@@ -117,9 +120,8 @@ namespace DurableTask.Netherite
 
                 (long, int) inputQueuePosition;
 
-                using (new PartitionTimeout(errorHandler, "partition startup", TimeSpan.FromMinutes(this.Settings.PartitionStartupTimeoutMinutes)))
+                await using (new PartitionTimeout(errorHandler, "partition startup", TimeSpan.FromMinutes(this.Settings.PartitionStartupTimeoutMinutes)))
                 {
-
                     // create or restore partition state from last snapshot
                     // create the state
                     this.State = ((TransportAbstraction.IHost)this.host).StorageLayer.CreatePartitionState(parameters);

--- a/src/DurableTask.Netherite/Util/PartitionTimeout.cs
+++ b/src/DurableTask.Netherite/Util/PartitionTimeout.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace DurableTask.Netherite
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// A utility class for terminating the partition if some task takes too long.
+    /// Implemented as a disposable, with <see cref="IDisposable.Dispose"> used to cancel the timeout.
+    /// </summary>
+    class PartitionTimeout : IDisposable
+    {
+        readonly CancellationTokenSource tokenSource;
+        readonly Task timeoutTask;
+
+        public PartitionTimeout(IPartitionErrorHandler errorHandler, string task, TimeSpan timeout)
+        {
+            this.tokenSource = new CancellationTokenSource();
+            this.timeoutTask = Task.Delay(timeout, this.tokenSource.Token);
+
+            // if the timeout tasks runs to completion without being cancelled, terminate the partition
+            this.timeoutTask.ContinueWith(
+                 _ => errorHandler.HandleError(
+                     $"{nameof(PartitionTimeout)}",
+                     $"{task} timed out after {timeout}",
+                     e: null,
+                     terminatePartition: true,
+                     reportAsWarning: false),
+                 TaskContinuationOptions.OnlyOnRanToCompletion);
+        }
+
+        public void Dispose()
+        {      
+            // cancel the timeout task (if it has not already completed)
+            this.tokenSource.Cancel();
+
+            // dispose the token source after the timeout task has completed
+            this.timeoutTask.ContinueWith(_ => this.tokenSource.Dispose());
+        }
+    }
+}


### PR DESCRIPTION
While analyzing https://github.com/Azure/azure-functions-durable-extension/issues/2603 we noticed that in some cases, partition startup takes an extraordinary amount of time. This may be caused by hangs or other reasons.

To better diagnose this type of issue, and to make it can recover from indefinite hangs, this PR makes the following changes:

1. It adds a "waiting" transition prior to the "starting" transition. This allows us to differentiate between time spent waiting for the MaxConcurrentStarts semaphore, and the actual time spent starting up the partition.
2. I adds a timeout to the partition startup. This timeout is configurable in the settings. The default is 15 minutes for now.