### PR TITLE
Always release partition lease when a partition shuts down

### DIFF
--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationServiceSettings.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationServiceSettings.cs
@@ -115,9 +115,10 @@ namespace DurableTask.Netherite
 
         /// <summary>
         /// Whether to checkpoint the current state of a partition when it is stopped. This improves recovery time but
-        /// lengthens shutdown time.
+        /// lengthens shutdown time and can cause memory pressure if many partitions are stopped at the same time,
+        /// for example if a host is shutting down.
         /// </summary>
-        public bool TakeStateCheckpointWhenStoppingPartition { get; set; } = true;
+        public bool TakeStateCheckpointWhenStoppingPartition { get; set; } = false;
 
         /// <summary>
         /// A limit on how many bytes to append to the log before initiating a state checkpoint. The default is 20MB.

--- a/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/BlobManager.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/BlobManager.cs
@@ -737,7 +737,10 @@ namespace DurableTask.Netherite.Faster
 
                     this.FaultInjector?.StorageAccess(this, "ReleaseLeaseAsync", "ReleaseLease", this.eventLogCommitBlob.Name);
 
-                    // we always release the lease here, whether the partition has already been terminated or not.
+                    // we must always release the lease here, whether the partition has already been terminated or not.
+                    // otherwise, the recovery of this partition (on this host or another host) has to wait for up
+                    // to 40s for the lease to expire. During this time, the partition is stalled (cannot process any work
+                    // items or client requests). In particular, client requests targeting this partition may be heavily delayed.
                     await this.leaseClient.ReleaseAsync(conditions: null, CancellationToken.None).ConfigureAwait(false);
 
                     this.TraceHelper.LeaseReleased(this.leaseTimer.Elapsed.TotalSeconds);

--- a/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/BlobManager.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/BlobManager.cs
@@ -677,6 +677,8 @@ namespace DurableTask.Netherite.Faster
 
         public async Task MaintenanceLoopAsync()
         {
+            bool releaseLeaseAtEnd = !this.UseLocalFiles;
+
             this.TraceHelper.LeaseProgress("Started lease maintenance loop");
             try
             {
@@ -711,6 +713,7 @@ namespace DurableTask.Netherite.Faster
             {
                 // We lost the lease to someone else. Terminate ownership immediately.
                 this.PartitionErrorHandler.HandleError(nameof(MaintenanceLoopAsync), "Lost partition lease", ex, true, true);
+                releaseLeaseAtEnd = false;
             }
             catch (Exception e)
             {
@@ -729,7 +732,7 @@ namespace DurableTask.Netherite.Faster
             this.TraceHelper.LeaseProgress("Waited for lease users to complete");
 
             // release the lease
-            if (!this.UseLocalFiles)
+            if (releaseLeaseAtEnd)
             {
                 try
                 {

--- a/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/BlobManager.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/BlobManager.cs
@@ -736,16 +736,11 @@ namespace DurableTask.Netherite.Faster
                     this.TraceHelper.LeaseProgress("Releasing lease");
 
                     this.FaultInjector?.StorageAccess(this, "ReleaseLeaseAsync", "ReleaseLease", this.eventLogCommitBlob.Name);
-                    await this.leaseClient.ReleaseAsync(null, this.PartitionErrorHandler.Token).ConfigureAwait(false);
+
+                    // we always release the lease here, whether the partition has already been terminated or not.
+                    await this.leaseClient.ReleaseAsync(conditions: null, CancellationToken.None).ConfigureAwait(false);
+
                     this.TraceHelper.LeaseReleased(this.leaseTimer.Elapsed.TotalSeconds);
-                }
-                catch (OperationCanceledException)
-                {
-                    // it's o.k. if termination is triggered while waiting
-                }
-                catch (Azure.RequestFailedException e) when (e.InnerException != null && e.InnerException is OperationCanceledException)
-                {
-                    // it's o.k. if termination is triggered while we are releasing the lease
                 }
                 catch (Exception e)
                 {

--- a/src/DurableTask.Netherite/Util/BlobUtils.cs
+++ b/src/DurableTask.Netherite/Util/BlobUtils.cs
@@ -100,6 +100,12 @@ namespace DurableTask.Netherite
                 return true; 
             }
 
+            // Empirically observed: transient DNS failures
+            if (exception is Azure.RequestFailedException && exception.InnerException is System.Net.Http.HttpRequestException e2 && e2.Message.Contains("No such host is known"))
+            {
+                return true;
+            }
+
             return false;
         }
 


### PR DESCRIPTION
While analyzing some of traces showing high client latencies (see https://github.com/Azure/azure-functions-durable-extension/issues/2603) we discovered a problem: in some cases the partition lease is not released when the partition is terminated, because the request is cancelled. This causes an excessive delay before the partitition recovery, since the lease has to expire first. Waiting for the lease to expire can take up to 40s and delays all pending client requests to that partition.

This PR fixes this problem by not passing the termination cancellation token to the lease renewal (which caused the lease release to not happen). 