### PR TITLE
Upgrade FASTER dependency to v2.6.1

### DIFF
--- a/src/DurableTask.Netherite/DurableTask.Netherite.csproj
+++ b/src/DurableTask.Netherite/DurableTask.Netherite.csproj
@@ -24,11 +24,11 @@
 
   <!-- Version settings: https://andrewlock.net/version-vs-versionsuffix-vs-packageversion-what-do-they-all-mean/ -->
   <PropertyGroup>
-    <MajorVersion>1</MajorVersion>
-	<MinorVersion>4</MinorVersion>
-	<PatchVersion>1</PatchVersion>
+    <MajorVersion>2</MajorVersion>
+	<MinorVersion>0</MinorVersion>
+	<PatchVersion>0</PatchVersion>
 	<VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
+    <VersionSuffix>preview</VersionSuffix>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <BuildSuffix Condition="'$(GITHUB_RUN_NUMBER)' != ''">.$(GITHUB_RUN_NUMBER)</BuildSuffix>
     <FileVersion>$(VersionPrefix)$(BuildSuffix)</FileVersion>
@@ -56,7 +56,7 @@
     <PackageReference Include="Microsoft.Azure.EventHubs.Processor" Version="4.3.2" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.2.3" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.16.0" />
-	<PackageReference Include="Microsoft.FASTER.Core" Version="2.0.23" />
+	<PackageReference Include="Microsoft.FASTER.Core" Version="2.6.1" />
     <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.15.1" />
 	<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />

--- a/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/BlobManager.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/BlobManager.cs
@@ -121,7 +121,6 @@ namespace DurableTask.Netherite.Faster
                 MutableFraction = tuningParameters?.StoreLogMutableFraction ?? 0.9,
                 SegmentSizeBits = segmentSizeBits,
                 PreallocateLog = false,
-                ReadFlags = ReadFlags.None,
                 ReadCacheSettings = null, // no read cache
                 MemorySizeBits = memorySizeBits,
             };
@@ -873,7 +872,7 @@ namespace DurableTask.Netherite.Faster
 
         #region ILogCommitManager
 
-        void ILogCommitManager.Commit(long beginAddress, long untilAddress, byte[] commitMetadata, long commitNum)
+        void ILogCommitManager.Commit(long beginAddress, long untilAddress, byte[] commitMetadata, long commitNum, bool forceWriteMetadata)
         {
             try
             {
@@ -1458,6 +1457,11 @@ namespace DurableTask.Netherite.Faster
                         this.CheckpointInfoETag = response.Value.ETag;
                     });
             }
+        }
+
+        public void CheckpointVersionShift(long oldVersion, long newVersion)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/LocalFileCheckpointManager.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/LocalFileCheckpointManager.cs
@@ -91,5 +91,10 @@ namespace DurableTask.Netherite.Faster
 
         void IDisposable.Dispose()
             => this.localCheckpointManager.Dispose();
+
+        public void CheckpointVersionShift(long oldVersion, long newVersion)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/DurableTask.Netherite/StorageLayer/Faster/FasterKV.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/FasterKV.cs
@@ -186,7 +186,7 @@ namespace DurableTask.Netherite.Faster
         ClientSession<Key, Value, EffectTracker, Output, object, IFunctions<Key, Value, EffectTracker, Output, object>> CreateASession(string id, bool isScan)
         {
             var functions = new Functions(this.partition, this, this.cacheTracker, isScan);
-            return this.fht.NewSession(functions, id, readFlags: (isScan ? ReadFlags.None : ReadFlags.CopyReadsToTail));
+            return this.fht.NewSession(functions, id);
         }
 
         public IDisposable TrackTemporarySession(ClientSession<Key, Value, EffectTracker, Output, object, IFunctions<Key, Value, EffectTracker, Output, object>> session)

--- a/test/DurableTask.Netherite.Tests/DurableTask.Netherite.Tests.csproj
+++ b/test/DurableTask.Netherite.Tests/DurableTask.Netherite.Tests.csproj
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">


### PR DESCRIPTION
This PR includes the following changes:

- [ ] Upgrade FASTER dependency to v2.6.1
- [ ] Upgrade Netherite version to 2.0.0-preview
- [ ] Add validation that customers are not using Netherite V2 with a task hub from Netherite V1 and vice versa
- [ ] Add validation when serializing/deserializing so we can more easily pinpoint data corruption issues