### PR TITLE
Enhance validation of deserialization and reporting of errors

### DIFF
--- a/src/DurableTask.Netherite/StorageLayer/Faster/FasterKV.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/FasterKV.cs
@@ -10,6 +10,7 @@ namespace DurableTask.Netherite.Faster
     using System.IO;
     using System.Linq;
     using System.Runtime.CompilerServices;
+    using System.Runtime.Serialization;
     using System.Text;
     using System.Threading;
     using System.Threading.Channels;
@@ -97,8 +98,8 @@ namespace DurableTask.Netherite.Faster
                 blobManager.StoreCheckpointSettings,
                 new SerializerSettings<Key, Value>
                 {
-                    keySerializer = () => new Key.Serializer(),
-                    valueSerializer = () => new Value.Serializer(this.StoreStats, partition.TraceHelper, this.cacheDebugger),
+                    keySerializer = () => new Key.Serializer(partition.ErrorHandler),
+                    valueSerializer = () => new Value.Serializer(this.StoreStats, partition.TraceHelper, this.cacheDebugger, partition.ErrorHandler),
                 });
 
             this.cacheTracker = memoryTracker.NewCacheTracker(this, (int) partition.PartitionId, this.cacheDebugger);
@@ -1594,13 +1595,48 @@ namespace DurableTask.Netherite.Faster
 
             public class Serializer : BinaryObjectSerializer<Key>
             {
-                public override void Deserialize(out Key obj)
+                readonly IPartitionErrorHandler errorHandler;
+
+                public Serializer(IPartitionErrorHandler errorHandler)
                 {
-                    obj = new Key();
-                    obj.Val.Deserialize(this.reader);
+                    this.errorHandler = errorHandler;
                 }
 
-                public override void Serialize(ref Key obj) => obj.Val.Serialize(this.writer);
+                public override void Deserialize(out Key obj)
+                {
+                    try
+                    {                      
+                        // first, determine the object type
+                        var objectType = (TrackedObjectKey.TrackedObjectType)this.reader.ReadByte();
+                        if (objectType != TrackedObjectKey.TrackedObjectType.History 
+                            && objectType != TrackedObjectKey.TrackedObjectType.Instance)
+                        {
+                            throw new SerializationException("invalid object type field");
+                        }
+                        var instanceId = this.reader.ReadString();
+                        obj = new TrackedObjectKey(objectType, instanceId);
+                        return;
+                    }
+                    catch (Exception ex)
+                    {
+                        this.errorHandler.HandleError("FasterKV.Key.Serializer", "could not deserialize key - possible data corruption", ex, true, this.errorHandler.IsTerminated);
+                    }
+
+                    obj = default;
+                }
+
+                public override void Serialize(ref Key obj)
+                {
+                    try
+                    {
+                        this.writer.Write((byte)obj.Val.ObjectType);
+                        this.writer.Write(obj.Val.InstanceId);
+                    }
+                    catch (Exception ex)
+                    {
+                        this.errorHandler.HandleError("FasterKV.Key.Serializer", "could not serialize key", ex, true, false);
+                    }
+                }
             }
         }
 
@@ -1624,49 +1660,77 @@ namespace DurableTask.Netherite.Faster
                 readonly StoreStatistics storeStats;
                 readonly PartitionTraceHelper traceHelper;
                 readonly CacheDebugger cacheDebugger;
+                readonly IPartitionErrorHandler errorHandler;
 
-                public Serializer(StoreStatistics storeStats, PartitionTraceHelper traceHelper, CacheDebugger cacheDebugger)
+                public Serializer(StoreStatistics storeStats, PartitionTraceHelper traceHelper, CacheDebugger cacheDebugger, IPartitionErrorHandler errorHandler)
                 {
                     this.storeStats = storeStats;
                     this.traceHelper = traceHelper;
                     this.cacheDebugger = cacheDebugger;
+                    this.errorHandler = errorHandler;   
                 }
 
                 public override void Deserialize(out Value obj)
                 {
-                    int version = this.reader.ReadInt32();
-                    int count = this.reader.ReadInt32();
-                    byte[] bytes = this.reader.ReadBytes(count); // lazy deserialization - keep as byte array until used
-                    obj = new Value { Val = bytes, Version = version};
-                    if (this.cacheDebugger != null)
+                    try
                     {
-                        var trackedObject = DurableTask.Netherite.Serializer.DeserializeTrackedObject(bytes);
-                        this.cacheDebugger?.Record(trackedObject.Key, CacheDebugger.CacheEvent.DeserializeBytes, version, null, 0);
+                        if (!this.errorHandler.IsTerminated) // skip deserialization if the partition is already terminated - to speed up cancellation and to avoid repeated errors
+                        {
+                            int version = this.reader.ReadInt32();
+                            int count = this.reader.ReadInt32();
+                            byte[] bytes = this.reader.ReadBytes(count); // lazy deserialization - keep as byte array until used
+
+                            if (bytes.Length != count)
+                            {
+                                throw new EndOfStreamException($"trying to read {count} bytes but only found {bytes.Length}");
+                            }
+
+                            obj = new Value { Val = bytes, Version = version};
+                            if (this.cacheDebugger != null)
+                            {
+                                var trackedObject = DurableTask.Netherite.Serializer.DeserializeTrackedObject(bytes);
+                                this.cacheDebugger?.Record(trackedObject.Key, CacheDebugger.CacheEvent.DeserializeBytes, version, null, 0);
+                            }
+
+                            return;
+                        }
                     }
+                    catch (Exception ex)
+                    {
+                        this.errorHandler.HandleError("FasterKV.Key.Serializer", "could not deserialize value - possible data corruption", ex, true, this.errorHandler.IsTerminated);
+                    }
+                    obj = default;
                 }
 
                 public override void Serialize(ref Value obj)
                 {
-                    this.writer.Write(obj.Version);
-                    if (obj.Val is byte[] serialized)
+                    try
                     {
-                        // We did already serialize this object on the last CopyUpdate. So we can just use the byte array.
-                        this.writer.Write(serialized.Length);
-                        this.writer.Write(serialized);
-                        if (this.cacheDebugger != null)
+                        this.writer.Write(obj.Version);
+                        if (obj.Val is byte[] serialized)
                         {
-                            var trackedObject = DurableTask.Netherite.Serializer.DeserializeTrackedObject(serialized);
-                            this.cacheDebugger?.Record(trackedObject.Key, CacheDebugger.CacheEvent.SerializeBytes, obj.Version, null, 0);
+                            // We did already serialize this object on the last CopyUpdate. So we can just use the byte array.
+                            this.writer.Write(serialized.Length);
+                            this.writer.Write(serialized);
+                            if (this.cacheDebugger != null)
+                            {
+                                var trackedObject = DurableTask.Netherite.Serializer.DeserializeTrackedObject(serialized);
+                                this.cacheDebugger?.Record(trackedObject.Key, CacheDebugger.CacheEvent.SerializeBytes, obj.Version, null, 0);
+                            }
+                        }
+                        else
+                        {
+                            TrackedObject trackedObject = (TrackedObject) obj.Val;
+                            var bytes = DurableTask.Netherite.Serializer.SerializeTrackedObject(trackedObject);
+                            this.storeStats.Serialize++;
+                            this.writer.Write(bytes.Length);
+                            this.writer.Write(bytes);
+                            this.cacheDebugger?.Record(trackedObject.Key, CacheDebugger.CacheEvent.SerializeObject, obj.Version, null, 0);
                         }
                     }
-                    else
+                    catch (Exception ex)
                     {
-                        TrackedObject trackedObject = (TrackedObject) obj.Val;
-                        var bytes = DurableTask.Netherite.Serializer.SerializeTrackedObject(trackedObject);
-                        this.storeStats.Serialize++;
-                        this.writer.Write(bytes.Length);
-                        this.writer.Write(bytes);
-                        this.cacheDebugger?.Record(trackedObject.Key, CacheDebugger.CacheEvent.SerializeObject, obj.Version, null, 0);
+                        this.errorHandler.HandleError("FasterKV.Key.Serializer", "could not serialize value", ex, true, false);
                     }
                 }
             }


### PR DESCRIPTION
To help us better diagnose and debug data corruption issues:

1) when deserializing data from storage, do more validation to better detect and report typical manifestations of data corruption (e.g. enumerations outside of range, streams not containing enough bytes).

2) if observing errors in deserialization or serialization, terminate the partition with a corresponding error message that is easily visible in the logs.

3) Skip deserialization when a partition is already terminated (this also provides a quick workaround for https://github.com/microsoft/FASTER/issues/883).