### PR TITLE
fix EH batch load cancellation issue

### DIFF
--- a/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsProcessor.cs
+++ b/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsProcessor.cs
@@ -437,7 +437,7 @@ namespace DurableTask.Netherite.EventHubsTransport
                     // iterators do not support ref arguments, so we use a simple wrapper class to work around this limitation
                     MutableLong nextPacketToReceive = new MutableLong() { Value = current.NextPacketToReceive.seqNo };
 
-                    await foreach ((EventData eventData, PartitionEvent[] events, long seqNo) in this.blobBatchReceiver.ReceiveEventsAsync(this.taskHubGuid, packets, current.ErrorHandler.Token, nextPacketToReceive))
+                    await foreach ((EventData eventData, PartitionEvent[] events, long seqNo) in this.blobBatchReceiver.ReceiveEventsAsync(this.taskHubGuid, packets, this.shutdownToken, nextPacketToReceive))
                     {
                         for (int i = 0; i < events.Length; i++)
                         {
@@ -489,7 +489,7 @@ namespace DurableTask.Netherite.EventHubsTransport
 
                 await this.SaveEventHubsReceiverCheckpoint(context, 600000);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (this.shutdownToken.IsCancellationRequested)
             {
                 this.traceHelper.LogInformation("EventHubsProcessor {eventHubName}/{eventHubPartition}({incarnation}) was terminated", this.eventHubName, this.eventHubPartition, current.Incarnation);
             }

--- a/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsProcessor.cs
+++ b/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsProcessor.cs
@@ -489,7 +489,7 @@ namespace DurableTask.Netherite.EventHubsTransport
 
                 await this.SaveEventHubsReceiverCheckpoint(context, 600000);
             }
-            catch (OperationCanceledException) when (this.shutdownToken.IsCancellationRequested)
+            catch (OperationCanceledException) when (this.shutdownToken.IsCancellationRequested) // we should only ignore these exceptions during VM shutdowns. See :  https://github.com/microsoft/durabletask-netherite/pull/347
             {
                 this.traceHelper.LogInformation("EventHubsProcessor {eventHubName}/{eventHubPartition}({incarnation}) was terminated", this.eventHubName, this.eventHubPartition, current.Incarnation);
             }


### PR DESCRIPTION
Testing revealed issues where partitions continuously fail because of supposed "out-of-order" packets. What is actually happening is that the redelivery of previously delivered packets is sometimes not working correctly after a partition terminates.

I tracked this down to the fact that the event hubs transport may be inadvertently cancelling storage requests that retrieve the batch contents when the partition is terminated, which is incorrect (loading the batch content is not tied to the partition state and should be succeeding even if the partition is recycled). This means some packets are skipped and never delivered. 

This PR fixes the problem by using the correct cancellation token.

It also adds a condition to the message to check whether any cancellations are o.k. (so that inadvertent cancellations are reported as errors).