### PR TITLE
Fix hanging blob creation

### DIFF
--- a/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/AzureStorageDevice.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/AzureStorageDevice.cs
@@ -429,7 +429,7 @@ namespace DurableTask.Netherite.Faster
 
                     // If no blob exists for the segment, we must first create the segment asynchronouly. (Create call takes ~70 ms by measurement)
                     // After creation is done, we can call write.
-                    _ = entry.CreateAsync(size, pageBlob);
+                    _ = entry.CreateAsync(size, pageBlob, id);
                 }
                 // Otherwise, some other thread beat us to it. Okay to use their blobs.
                 blobEntry = this.blobs[segmentId];

--- a/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/BlobEntry.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/BlobEntry.cs
@@ -90,14 +90,8 @@ namespace DurableTask.Netherite.Faster
                 },
                 async () =>
                 {
-                    try
-                    {
-                        var response = await pageBlob.Default.GetPropertiesAsync();
-                        this.ETag = response.Value.ETag;
-                    }
-                    catch (Azure.RequestFailedException ex) when (BlobUtilsV12.BlobDoesNotExist(ex))
-                    {
-                    }
+                    var response = await pageBlob.Default.GetPropertiesAsync();
+                    this.ETag = response.Value.ETag;
                 });
 
             // At this point the blob is fully created. After this line all consequent writers will write immediately. We just

--- a/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/StorageOperations.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/StorageOperations.cs
@@ -101,7 +101,7 @@ namespace DurableTask.Netherite.Faster
                         }
                         continue;
                     }
-                    catch (Azure.RequestFailedException ex) when (BlobUtilsV12.PreconditionFailed(ex) && readETagAsync != null)
+                    catch (Azure.RequestFailedException ex) when (BlobUtilsV12.PreconditionFailed(ex) && readETagAsync != null && numAttempts < BlobManager.MaxRetries)
                     {
                         this.StorageTracer?.FasterStorageProgress($"storage operation {name} ({intent}) failed precondition on attempt {numAttempts}; target={target} latencyMs={stopwatch.Elapsed.TotalMilliseconds:F1} {details}");
                         mustReadETagFirst = true;


### PR DESCRIPTION
We observed an unnaturally large number of errors like "storage operation id=2438 has exceeded the time limit 00:01:30" that terminate the partition.

After analysis we found that this is caused by situations where a blob creation simultaneously succeeds (i.e. blob was created) and times out. Our retry path was not correctly detecting that the blob was already created.

This PR:
- fixes a missing check in the retry condition to avoid unlimited retries
- adds the id into the traces for the blob creation for easier diagnostics
- if the blob already exists, loads the e-tag, and skips the next attempt 
