### PR TITLE
Tune semaphore settings for Azure Storage accesses

### DIFF
--- a/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/BlobManager.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/BlobManager.cs
@@ -72,8 +72,8 @@ namespace DurableTask.Netherite.Faster
 
         public IPartitionErrorHandler PartitionErrorHandler { get; private set; }
 
-        internal static SemaphoreSlim AsynchronousStorageReadMaxConcurrency = new SemaphoreSlim(Math.Min(100, Environment.ProcessorCount * 10));
-        internal static SemaphoreSlim AsynchronousStorageWriteMaxConcurrency = new SemaphoreSlim(Math.Min(50, Environment.ProcessorCount * 7));
+        internal static SemaphoreSlim AsynchronousStorageReadMaxConcurrency = new SemaphoreSlim(Math.Min(100, Environment.ProcessorCount * 20));
+        internal static SemaphoreSlim AsynchronousStorageWriteMaxConcurrency = new SemaphoreSlim(Math.Min(50, Environment.ProcessorCount * 10));
 
         internal volatile int LeaseUsers;
 


### PR DESCRIPTION
Revises the semaphore settings so that workers with very few cores can still reasonably make progress. 
This is based on observing issues in test runs on EP1. 