### PR TITLE
Fix blob batch persistence

### DIFF
--- a/src/DurableTask.Netherite/StorageLayer/Faster/StoreWorker.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/StoreWorker.cs
@@ -759,7 +759,7 @@ namespace DurableTask.Netherite.Faster
             // (note that it may not be the very next in the sequence since readonly events are not persisted in the log)
             if (partitionUpdateEvent.NextInputQueuePosition > 0 && partitionUpdateEvent.NextInputQueuePositionTuple.CompareTo(this.InputQueuePosition) <= 0)
             {
-                this.partition.ErrorHandler.HandleError(nameof(ProcessUpdate), "Duplicate event detected", null, false, false);
+                this.partition.ErrorHandler.HandleError(nameof(ProcessUpdate), $"Duplicate event detected: #{partitionUpdateEvent.NextInputQueuePositionTuple}", null, true, false);
                 return;
             }
 

--- a/src/DurableTask.Netherite/Tracing/EtwSource.cs
+++ b/src/DurableTask.Netherite/Tracing/EtwSource.cs
@@ -215,8 +215,8 @@ namespace DurableTask.Netherite
 
         // ----- general event processing and statistics
 
-        [Event(240, Level = EventLevel.Informational, Version = 3)]
-        public void PartitionEventProcessed(string Account, string TaskHub, int PartitionId, long CommitLogPosition, string Category, string PartitionEventId, string EventInfo, string InstanceId, long NextCommitLogPosition, long NextInputQueuePosition, double QueueElapsedMs, double FetchElapsedMs, double ElapsedMs, bool IsReplaying, string AppName, string ExtensionVersion)
+        [Event(240, Level = EventLevel.Informational, Version = 4)]
+        public void PartitionEventProcessed(string Account, string TaskHub, int PartitionId, long CommitLogPosition, string Category, string PartitionEventId, string EventInfo, string InstanceId, long NextCommitLogPosition, string NextInputQueuePosition, double QueueElapsedMs, double FetchElapsedMs, double ElapsedMs, bool IsReplaying, string AppName, string ExtensionVersion)
         {
             SetCurrentThreadActivityId(serviceInstanceId);
             this.WriteEvent(240, Account, TaskHub, PartitionId, CommitLogPosition, Category, PartitionEventId, EventInfo, InstanceId, NextCommitLogPosition, NextInputQueuePosition, QueueElapsedMs, FetchElapsedMs, ElapsedMs, IsReplaying, AppName, ExtensionVersion);

--- a/src/DurableTask.Netherite/Tracing/EventTraceHelper.cs
+++ b/src/DurableTask.Netherite/Tracing/EventTraceHelper.cs
@@ -50,14 +50,15 @@ namespace DurableTask.Netherite
                 double queueLatencyMs = evt.IssuedTimestamp - evt.ReceivedTimestamp;
                 double fetchLatencyMs = startedTimestamp - evt.IssuedTimestamp;
                 double latencyMs = finishedTimestamp - startedTimestamp;
+                string nextInputQueuePosition = evt.NextInputQueuePosition > 0 ? $"({evt.NextInputQueuePosition},{evt.NextInputQueueBatchPosition})" : string.Empty;
 
                 if (this.logger.IsEnabled(LogLevel.Information))
                 {
                     var details = string.Format($"{(replaying ? "Replayed" : "Processed")} {(evt.NextInputQueuePosition > 0 ? "external" : "internal")} {category}");
-                    this.logger.LogInformation("Part{partition:D2}.{commitLogPosition:D10} {details} {event} eventId={eventId} instanceId={instanceId} pos=({nextCommitLogPosition},{nextInputQueuePosition}) latency=({queueLatencyMs:F0}, {fetchLatencyMs:F0}, {latencyMs:F0})", this.partitionId, commitLogPosition, details, evt, evt.EventIdString, evt.TracedInstanceId, nextCommitLogPosition, evt.NextInputQueuePosition, queueLatencyMs, fetchLatencyMs, latencyMs);
+                    this.logger.LogInformation("Part{partition:D2}.{commitLogPosition:D10} {details} {event} eventId={eventId} instanceId={instanceId} nextCommitLogPosition={nextCommitLogPosition} nextInputQueuePosition={nextInputQueuePosition} latency=({queueLatencyMs:F0}, {fetchLatencyMs:F0}, {latencyMs:F0})", this.partitionId, commitLogPosition, details, evt, evt.EventIdString, evt.TracedInstanceId, nextCommitLogPosition, evt.NextInputQueuePosition, queueLatencyMs, fetchLatencyMs, latencyMs);
                 }
 
-                this.etw?.PartitionEventProcessed(this.account, this.taskHub, this.partitionId, commitLogPosition, category.ToString(), evt.EventIdString, evt.ToString(), evt.TracedInstanceId ?? string.Empty, nextCommitLogPosition, evt.NextInputQueuePosition, queueLatencyMs, fetchLatencyMs, latencyMs, replaying, TraceUtils.AppName, TraceUtils.ExtensionVersion) ;
+                this.etw?.PartitionEventProcessed(this.account, this.taskHub, this.partitionId, commitLogPosition, category.ToString(), evt.EventIdString, evt.ToString(), evt.TracedInstanceId ?? string.Empty, nextCommitLogPosition, nextInputQueuePosition, queueLatencyMs, fetchLatencyMs, latencyMs, replaying, TraceUtils.AppName, TraceUtils.ExtensionVersion) ;
             }
         }
 

--- a/src/DurableTask.Netherite/TransportLayer/EventHubs/BlobBatchReceiver.cs
+++ b/src/DurableTask.Netherite/TransportLayer/EventHubs/BlobBatchReceiver.cs
@@ -111,16 +111,17 @@ namespace DurableTask.Netherite.EventHubsTransport
 
                     try
                     {
-                        this.lowestTraceLevel?.LogTrace("{context} downloading blob {blobName}", this.traceContext, blobClient.Name);
+                        this.lowestTraceLevel?.LogTrace("{context} downloading blob {blobName} for #{seqno}", this.traceContext, blobClient.Name, seqno);
 
                         Azure.Response<BlobDownloadResult> downloadResult = await blobClient.DownloadContentAsync(token);
                         blobContent = downloadResult.Value.Content.ToArray();
 
-                        this.lowestTraceLevel?.LogTrace("{context} downloaded blob {blobName} ({size} bytes, {count} packets)", this.traceContext, blobClient.Name, blobContent.Length, blobReference.PacketOffsets.Count + 1);
+                        this.lowestTraceLevel?.LogTrace("{context} downloaded blob {blobName} for #{seqno} ({size} bytes, {count} packets)", this.traceContext, blobClient.Name, seqno, blobContent.Length, blobReference.PacketOffsets.Count + 1);
                     }
                     catch (OperationCanceledException) when (token.IsCancellationRequested)
                     {
                         // normal during shutdown
+                        this.lowestTraceLevel?.LogTrace("{context} cancelled downloading blob {blobName} for #{seqno}", this.traceContext, blobClient.Name, seqno);
                         throw;
                     }
                     catch (Azure.RequestFailedException exception) when (BlobUtilsV12.BlobDoesNotExist(exception) && errorHandler?.IsTerminated == true)

--- a/src/DurableTask.Netherite/TransportLayer/EventHubs/BlobBatchReceiver.cs
+++ b/src/DurableTask.Netherite/TransportLayer/EventHubs/BlobBatchReceiver.cs
@@ -144,6 +144,7 @@ namespace DurableTask.Netherite.EventHubsTransport
                     {
                         this.traceHelper.LogWarning("{context} blob {blobName} for batch #{seqno} was not found. Ignoring batch since it must have been already delivered.", this.traceContext, blobClient.Name, seqno);
 
+                        // return an empty batch, no events should be processed 
                         yield return (eventData, new TEvent[0], seqno, null);
                     }
                     else

--- a/src/DurableTask.Netherite/TransportLayer/EventHubs/BlobBatchReceiver.cs
+++ b/src/DurableTask.Netherite/TransportLayer/EventHubs/BlobBatchReceiver.cs
@@ -124,7 +124,7 @@ namespace DurableTask.Netherite.EventHubsTransport
                     catch (Azure.RequestFailedException exception) when (BlobUtilsV12.BlobDoesNotExist(exception) && errorHandler?.IsTerminated == true)
                     {
                         // a download can fail if the lease is lost and the next owner processes and then deletes it first
-                        throw new OperationCanceledException("blob already deleted", exception, token);
+                        throw new OperationCanceledException("blob not found, likely already deleted", exception, token);
                     }
                     catch (Exception exception)
                     {

--- a/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsProcessor.cs
+++ b/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsProcessor.cs
@@ -147,7 +147,7 @@ namespace DurableTask.Netherite.EventHubsTransport
                 {
                     if (this.traceHelper.IsEnabled(LogLevel.Trace))
                     {
-                        this.traceHelper.LogTrace("EventHubsProcessor {eventHubName}/{eventHubPartition} discarding buffered event nextInputQueuePosition={nextInputQueuePosition} lastInBatch={lastInBatch} seqno={seqNo} offset={offset} batchBlob={batchBlob}", this.eventHubName, this.eventHubPartition, front.Event.NextInputQueuePositionTuple, evt.EventIdString, confirmed.LastInBatch, confirmed.SeqNo, confirmed.Offset, confirmed.BatchBlob);
+                        this.traceHelper.LogTrace("EventHubsProcessor {eventHubName}/{eventHubPartition} discarding buffered event nextInputQueuePosition={nextInputQueuePosition} lastInBatch={lastInBatch} seqno={seqNo} offset={offset} batchBlob={batchBlob}", this.eventHubName, this.eventHubPartition, front.Event.NextInputQueuePositionTuple, confirmed.LastInBatch, confirmed.SeqNo, confirmed.Offset, confirmed.BatchBlob);
                     }
 
                     if (confirmed.LastInBatch)

--- a/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsProcessor.cs
+++ b/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsProcessor.cs
@@ -11,6 +11,7 @@ namespace DurableTask.Netherite.EventHubsTransport
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using Azure.Storage.Blobs.Specialized;
     using DurableTask.Core.Common;
     using DurableTask.Netherite.Abstractions;
     using Microsoft.Azure.EventHubs;
@@ -47,8 +48,15 @@ namespace DurableTask.Netherite.EventHubsTransport
         // since EventProcessorHost does not redeliver packets, we need to keep them around until we are sure
         // they are processed durably, so we can redeliver them when recycling/recovering a partition
         // we make this a concurrent queue so we can remove confirmed events concurrently with receiving new ones
-        readonly ConcurrentQueue<(PartitionEvent[] events, long offset, long seqno)> pendingDelivery;
+        readonly ConcurrentQueue<EventEntry> pendingDelivery;
         AsyncLock deliveryLock;
+
+        record struct EventEntry(long SeqNo, long BatchPos, PartitionEvent Event, bool LastInBatch, long Offset, BlockBlobClient BatchBlob)
+        {
+            public EventEntry(long seqNo, long batchPos, PartitionEvent evt) : this(seqNo, batchPos, evt, false, 0, null) { }
+
+            public EventEntry(long seqNo, long batchPos, PartitionEvent evt, long offset, BlockBlobClient blob) : this(seqNo, batchPos, evt, true, 0, blob) { }
+        }
 
         // this points to the latest incarnation of this partition; it gets
         // updated as we recycle partitions (create new incarnations after failures)
@@ -83,7 +91,7 @@ namespace DurableTask.Netherite.EventHubsTransport
             this.host = host;
             this.sender = sender;
             this.parameters = parameters;
-            this.pendingDelivery = new ConcurrentQueue<(PartitionEvent[] events, long offset, long seqno)>();
+            this.pendingDelivery = new();
             this.partitionContext = partitionContext;
             this.settings = settings;
             this.eventHubsTransport = eventHubsTransport;
@@ -94,7 +102,7 @@ namespace DurableTask.Netherite.EventHubsTransport
             this.traceHelper = new EventHubsTraceHelper(traceHelper, this.partitionId);
             this.shutdownToken = shutdownToken;
             string traceContext = $"EventHubsProcessor {this.eventHubName}/{this.eventHubPartition}";
-            this.blobBatchReceiver = new BlobBatchReceiver<PartitionEvent>(traceContext, this.traceHelper, this.settings, keepUntilConfirmed: true);
+            this.blobBatchReceiver = new BlobBatchReceiver<PartitionEvent>(traceContext, this.traceHelper, this.settings);
 
             var _ = shutdownToken.Register(
               () => { var _ = Task.Run(() => this.IdempotentShutdown("shutdownToken", eventHubsTransport.FatalExceptionObserved)); },
@@ -122,16 +130,33 @@ namespace DurableTask.Netherite.EventHubsTransport
 
         public void ConfirmDurable(Event evt)
         {
+            List<BlockBlobClient> obsoleteBatches = null;
+
             // this is called after an event has committed (i.e. has been durably persisted in the recovery log).
-            // so we know we will never need to deliver it again. We remove it from the local buffer, and also checkpoint
-            // with EventHubs occasionally.
-            while (this.pendingDelivery.TryPeek(out var front) && front.events[front.events.Length - 1].NextInputQueuePosition <= ((PartitionEvent)evt).NextInputQueuePosition)
+            // so we know we will never need to deliver it again. We remove it from the local buffer, update the fields that
+            // track the last persisted position, and delete the blob batch if this was the last event in the batch.
+            while (this.pendingDelivery.TryPeek(out var front) 
+                && front.Event.NextInputQueuePositionTuple.CompareTo(((PartitionEvent) evt).NextInputQueuePositionTuple) <= 0)
             {
-                if (this.pendingDelivery.TryDequeue(out var candidate))
+                if (this.pendingDelivery.TryDequeue(out var confirmed))
                 {
-                    this.persistedOffset = Math.Max(this.persistedOffset, candidate.offset);
-                    this.persistedSequenceNumber = Math.Max(this.persistedSequenceNumber, candidate.seqno);
+                    Debug.Assert(front == confirmed);
+                    if (confirmed.LastInBatch)
+                    {
+                        this.persistedOffset = Math.Max(this.persistedOffset, confirmed.Offset);
+                        this.persistedSequenceNumber = Math.Max(this.persistedSequenceNumber, confirmed.SeqNo);
+
+                        if (confirmed.BatchBlob != null)
+                        {
+                            (obsoleteBatches ??= new()).Add(confirmed.BatchBlob);
+                        }
+                    }
                 }
+            }
+
+            if (obsoleteBatches != null)
+            {
+                Task backgroundTask = Task.Run(() => this.blobBatchReceiver.DeleteBlobBatchesAsync(obsoleteBatches));
             }
         }
 
@@ -225,7 +250,7 @@ namespace DurableTask.Netherite.EventHubsTransport
                 {
                     this.traceHelper.LogDebug("EventHubsProcessor {eventHubName}/{eventHubPartition} checking for packets requiring redelivery (incarnation {incarnation})", this.eventHubName, this.eventHubPartition, c.Incarnation);
                     var batch = this.pendingDelivery
-                        .SelectMany(x => x.Item1)
+                        .Select(x => x.Event)
                         .Where(evt => (evt.NextInputQueuePosition, evt.NextInputQueueBatchPosition).CompareTo(c.NextPacketToReceive) > 0)
                         .ToList();
                     if (batch.Count > 0)
@@ -432,38 +457,36 @@ namespace DurableTask.Netherite.EventHubsTransport
                     // iterators do not support ref arguments, so we use a simple wrapper class to work around this limitation
                     MutableLong nextPacketToReceive = new MutableLong() { Value = current.NextPacketToReceive.seqNo };
 
-                    await foreach ((EventData eventData, PartitionEvent[] events, long seqNo) in this.blobBatchReceiver.ReceiveEventsAsync(this.taskHubGuid, packets, this.shutdownToken, nextPacketToReceive))
+                    await foreach ((EventData eventData, PartitionEvent[] events, long seqNo, BlockBlobClient blob) in this.blobBatchReceiver.ReceiveEventsAsync(this.taskHubGuid, packets, this.shutdownToken, nextPacketToReceive))
                     {
                         for (int i = 0; i < events.Length; i++)
                         {
                             PartitionEvent evt = events[i];
-
+                            
                             if (i < events.Length - 1)
                             {
                                 evt.NextInputQueuePosition = seqNo;
                                 evt.NextInputQueueBatchPosition = i + 1;
+                                this.pendingDelivery.Enqueue(new EventEntry(seqNo, i, evt));
                             }
                             else
                             {
                                 evt.NextInputQueuePosition = seqNo + 1;
+                                evt.NextInputQueueBatchPosition = 0;
+                                this.pendingDelivery.Enqueue(new EventEntry(seqNo, i, evt, long.Parse(eventData.SystemProperties.Offset), blob));
                             }
 
                             if (this.traceHelper.IsEnabled(LogLevel.Trace))
                             {
-                                this.traceHelper.LogTrace("EventHubsProcessor {eventHubName}/{eventHubPartition}({incarnation}) received packet #{seqno}.{subSeqNo} {event} id={eventId}", this.eventHubName, this.eventHubPartition, current.Incarnation, seqNo, i, evt, evt.EventIdString);
+                                this.traceHelper.LogTrace("EventHubsProcessor {eventHubName}/{eventHubPartition}({incarnation}) received packet #({seqno},{subSeqNo}) {event} id={eventId}", this.eventHubName, this.eventHubPartition, current.Incarnation, seqNo, i, evt, evt.EventIdString);
+                            }
+
+                            if (evt is PartitionUpdateEvent partitionUpdateEvent)
+                            {
+                                DurabilityListeners.Register(evt, this);
                             }
 
                             totalEvents++;
-                        }
- 
-                        // add events to redelivery queue, and attach durability listener to last update event in the batch
-                        this.pendingDelivery.Enqueue((events, long.Parse(eventData.SystemProperties.Offset), eventData.SystemProperties.SequenceNumber));
-                        for (int i = events.Length - 1; i >= 0; i--)
-                        {
-                            if (events[i] is PartitionUpdateEvent partitionUpdateEvent)
-                            {
-                                DurabilityListeners.Register(partitionUpdateEvent, this);
-                            }
                         }
 
                         if (current.NextPacketToReceive.batchPos == 0)

--- a/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsProcessor.cs
+++ b/src/DurableTask.Netherite/TransportLayer/EventHubs/EventHubsProcessor.cs
@@ -422,6 +422,12 @@ namespace DurableTask.Netherite.EventHubsTransport
             
             this.traceHelper.LogDebug("EventHubsProcessor {eventHubName}/{eventHubPartition} is receiving events starting with #{seqno}", this.eventHubName, this.eventHubPartition, firstSequenceNumber);
 
+            if (this.shutdownToken.IsCancellationRequested)
+            {
+                this.traceHelper.LogDebug("EventHubsProcessor {eventHubName}/{eventHubPartition} already shut down", this.eventHubName, this.eventHubPartition);
+                return;
+            }
+
             PartitionIncarnation current = await this.currentIncarnation;
 
             while (current != null && current.ErrorHandler.IsTerminated)


### PR DESCRIPTION
Fixes #363.

Previously, the code determined whether it was safe to delete a blob batch by checking the last update event for persistence. However, since there could still be read events after the update event, it meant that the blob may be deleted too early (and then hit a missing blob exception when trying to fetch the blob). This was observed in #363.

A similar mechanism was also used to determine whether a batch needed to be kept around for redelivery when reincarnating a partition. This has the same problems: a batch could be removed from the redelivery queue too early.

This PR fixes and simplifies this problem by
a) precisely tracking the persistence state of a batch by using the full position tuple (seqno, batchpos) in the redelivery queue, as opposed to only using the seqno. Read events can thus stay in the queue until later write events commit.
b) delete the blobs from storage at the same time we remove the batch from the redelivery queue.