### PR TITLE
Make adjustments and add tracing

### DIFF
--- a/src/DurableTask.Netherite/StorageLayer/Faster/FasterKV.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/FasterKV.cs
@@ -742,6 +742,7 @@ namespace DurableTask.Netherite.Faster
             catch (OperationCanceledException) when (this.terminationToken.IsCancellationRequested)
             {
                 // partition is terminating
+                this.blobManager.TraceHelper.FasterProgress($"PrefetchSession {sessionId} cancelled");
             }
             catch (Exception e)
             {

--- a/src/DurableTask.Netherite/StorageLayer/Faster/PartitionStorage.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/PartitionStorage.cs
@@ -115,7 +115,7 @@ namespace DurableTask.Netherite.Faster
             if (this.partition.Settings.TestHooks?.ReplayChecker == null)
             {
                 this.hangCheckTimer = new Timer(this.CheckForStuckWorkers, null, 0, 20000);
-                errorHandler.AddDisposeTask("DisposeHangTimer", TimeSpan.FromSeconds(10), () => this.hangCheckTimer.Dispose());
+                errorHandler.AddDisposeTask("DisposeHangTimer", TimeSpan.FromSeconds(120), () => this.hangCheckTimer.Dispose());
             }
 
             bool hasCheckpoint = false;
@@ -235,6 +235,7 @@ namespace DurableTask.Netherite.Faster
 
             if (this.blobManager.PartitionErrorHandler.IsTerminated)
             {
+                this.hangCheckTimer.Dispose();
                 return; // partition is already terminated, no point in checking for hangs
             }
 

--- a/src/DurableTask.Netherite/Util/BlobUtils.cs
+++ b/src/DurableTask.Netherite/Util/BlobUtils.cs
@@ -106,6 +106,16 @@ namespace DurableTask.Netherite
                 return true;
             }
 
+            // Empirically observed: socket exceptions under heavy stress, such as
+            // - "Only one usage of each socket address (protocol/network address/port) is normally permitted"
+            // - "An operation on a socket could not be performed because the system lacked sufficient buffer space or because a queue was full"
+            if (exception is Azure.RequestFailedException 
+                && (exception.InnerException is System.Net.Http.HttpRequestException e3)
+                && e3.InnerException is System.Net.Sockets.SocketException)
+            {
+                return true;
+            }
+
             return false;
         }
 


### PR DESCRIPTION
Based on observations in recent stress testing runs, this PR makes the following adjustments:

1. add tracing when making cancellation callbacks to FASTER, since we are suspecting hangs
2. adjust timeout parameter
3. recognize a couple more transient socket exceptions