### PR TITLE
Use OrchestrationAlreadyExistsException instead of InvalidOperationException

### DIFF
--- a/src/DurableTask.Netherite/OrchestrationService/Client.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/Client.cs
@@ -13,6 +13,7 @@ namespace DurableTask.Netherite
     using System.Threading.Tasks;
     using Azure.Core;
     using DurableTask.Core;
+    using DurableTask.Core.Exceptions;
     using DurableTask.Core.History;
     using Microsoft.Azure.Storage;
     using Newtonsoft.Json;
@@ -473,7 +474,7 @@ namespace DurableTask.Netherite
                 // An instance in this state already exists.
                 if (this.host.Settings.ThrowExceptionOnInvalidDedupeStatus)
                 {
-                    throw new InvalidOperationException($"An Orchestration instance with the status {creationResponseReceived.ExistingInstanceOrchestrationStatus} already exists.");
+                    throw new OrchestrationAlreadyExistsException($"An Orchestration instance with the status {creationResponseReceived.ExistingInstanceOrchestrationStatus} already exists.");
                 }
             }
         }


### PR DESCRIPTION
Similar change as https://github.com/Azure/durabletask/pull/1060.

This is a coordinated change relating to this Durable Functions PR: https://github.com/Azure/azure-functions-durable-extension/pull/2779

Should be non-breaking because `OrchestrationAlreadyExistsException` already derives from `InvalidOperationException`.