### PR TITLE
Ignore duplicate client requests

### DIFF
--- a/src/DurableTask.Netherite/PartitionState/PrefetchState.cs
+++ b/src/DurableTask.Netherite/PartitionState/PrefetchState.cs
@@ -87,7 +87,9 @@ namespace DurableTask.Netherite
                 }
                 else
                 {
-                    return; // this is a duplicate. Ignore it.
+                    // this is a duplicate. Ignore it.
+                    effects.EventTraceHelper?.TraceEventProcessingWarning($"Dropped duplicate client request {clientRequestEvent} id={clientRequestEvent.EventIdString}");
+                    return; 
                 }
             }
             else 

--- a/src/DurableTask.Netherite/PartitionState/PrefetchState.cs
+++ b/src/DurableTask.Netherite/PartitionState/PrefetchState.cs
@@ -75,6 +75,8 @@ namespace DurableTask.Netherite
         {
             if (clientRequestEvent.Phase == ClientRequestEventWithPrefetch.ProcessingPhase.Read)
             {
+                // It's possible for EventHubs to duplicate client-to-partition events. Therefore, we perform a best-effort
+                // de-duplication of EH messages. For more details, see: https://github.com/microsoft/durabletask-netherite/pull/379
                 if (!this.PendingPrefetches.ContainsKey(clientRequestEvent.EventIdString))
                         {
                     // Issue a read request that fetches the instance state.

--- a/src/DurableTask.Netherite/PartitionState/PrefetchState.cs
+++ b/src/DurableTask.Netherite/PartitionState/PrefetchState.cs
@@ -78,7 +78,7 @@ namespace DurableTask.Netherite
                 // It's possible for EventHubs to duplicate client-to-partition events. Therefore, we perform a best-effort
                 // de-duplication of EH messages. For more details, see: https://github.com/microsoft/durabletask-netherite/pull/379
                 if (!this.PendingPrefetches.ContainsKey(clientRequestEvent.EventIdString))
-                        {
+                {
                     // Issue a read request that fetches the instance state.
                     // We buffer this request in the pending list so we can recover it, and can filter duplicates
                     // (as long as the duplicates appear soon after the original)


### PR DESCRIPTION
During stress testing we observed to our surprise that event hubs sometimes duplicates events internally. Specifically, it is possible for an event to be successfully sent by a partition client only once, but then this event appears twice in the delivery sequence to the partition, with two different sequence numbers. Specifically we saw the same event being delivered at positions 2115 and 2121. The events in between (positions 2116 to 2120) corresponded to events that were sent from a different source.


Thankfully the practical impact of this discovery is relatively minor since we are already deduplicating almost all events. The only events not being duplicated are client requests that are sent from a client to a partition.

Netherite was designed assuming this would not happen, so we detected this because an assertion violation triggered.
In this PR we modify the code so that if a duplicate is detected, we ignore it instead of creating an assertion violation error. 

Note that this is not a reliable client request deduplication, because if the duplicate arrives much later than the original, the duplicate will be processed a second time. However I think this is an o.k. approximation since any clients that are sensitive to duplication problems should already use idempotent versions of the API calls (such as including deduplication status when creating an orchestration) which would not be affected by internal event duplication.