### PR TITLE
fix race condition on OrchestrationRuntimeState.NewEvents

### DIFF
--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
@@ -876,7 +876,7 @@ namespace DurableTask.Netherite
                 InstanceId = workItem.InstanceId,
                 BatchStartPosition = messageBatch.BatchStartPosition,
                 BatchLength = messageBatch.BatchLength,
-                NewEvents = (List<HistoryEvent>)newOrchestrationRuntimeState.NewEvents,
+                NewEvents = newOrchestrationRuntimeState.NewEvents.ToList(),
                 WorkItemForReuse = cacheWorkItemForReuse ? orchestrationWorkItem : null,
                 PackPartitionTaskMessages = partition.Settings.PackPartitionTaskMessages,
                 PersistFirst = partition.Settings.PersistStepsFirst ? BatchProcessed.PersistFirstStatus.Required : BatchProcessed.PersistFirstStatus.NotRequired,

--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
@@ -876,7 +876,7 @@ namespace DurableTask.Netherite
                 InstanceId = workItem.InstanceId,
                 BatchStartPosition = messageBatch.BatchStartPosition,
                 BatchLength = messageBatch.BatchLength,
-                NewEvents = newOrchestrationRuntimeState.NewEvents.ToList(),
+                NewEvents = newOrchestrationRuntimeState.NewEvents.ToList(), // `NewEvents` in `newOrchestrationRuntimeState` may be mutated, so we copy to avoid a surprise change.
                 WorkItemForReuse = cacheWorkItemForReuse ? orchestrationWorkItem : null,
                 PackPartitionTaskMessages = partition.Settings.PackPartitionTaskMessages,
                 PersistFirst = partition.Settings.PersistStepsFirst ? BatchProcessed.PersistFirstStatus.Required : BatchProcessed.PersistFirstStatus.NotRequired,


### PR DESCRIPTION
In the current code, the `BatchProcessed` event was copying the list `NewEvents` from `OrchestrationRuntimeState`. However, that list can be mutated when processing more batches. This violates the design principle that events should be immutable, and can lead to race conditions between code that is reading those events (e.g. for serialization) and code that is mutating it.

To fix this, we just make a copy of that list when constructing the `BatchProcessed` event.

 