### PR TITLE
go back to version 1.4.3 to do a quick patch release

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For some other considerations about how to choose the engine, see [the documenta
 
 ## Status
 
-The current version of Netherite is *1.5.0*. Netherite supports almost all of the DT and DF APIs. 
+The current version of Netherite is *1.4.3*. Netherite supports almost all of the DT and DF APIs. 
 
 Some notable differences to the default Azure Table storage provider include:
 - Instance queries and purge requests are not issued directly against Azure Storage, but are processed by the function app. Thus, the performance (latency and throughput) of queries heavily depends on 

--- a/src/DurableTask.Netherite.AzureFunctions/DurableTask.Netherite.AzureFunctions.csproj
+++ b/src/DurableTask.Netherite.AzureFunctions/DurableTask.Netherite.AzureFunctions.csproj
@@ -25,8 +25,8 @@
   <!-- Version settings: https://andrewlock.net/version-vs-versionsuffix-vs-packageversion-what-do-they-all-mean/ -->
   <PropertyGroup>
 	<MajorVersion>1</MajorVersion>
-	<MinorVersion>5</MinorVersion>
-	<PatchVersion>0</PatchVersion>
+	<MinorVersion>4</MinorVersion>
+	<PatchVersion>3</PatchVersion>
 	<VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>

--- a/src/DurableTask.Netherite/DurableTask.Netherite.csproj
+++ b/src/DurableTask.Netherite/DurableTask.Netherite.csproj
@@ -25,8 +25,8 @@
   <!-- Version settings: https://andrewlock.net/version-vs-versionsuffix-vs-packageversion-what-do-they-all-mean/ -->
   <PropertyGroup>
     <MajorVersion>1</MajorVersion>
-	<MinorVersion>5</MinorVersion>
-	<PatchVersion>0</PatchVersion>
+	<MinorVersion>4</MinorVersion>
+	<PatchVersion>3</PatchVersion>
 	<VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>

--- a/src/Functions.Worker.Extensions.DurableTask.Netherite/Functions.Worker.Extensions.DurableTask.Netherite.csproj
+++ b/src/Functions.Worker.Extensions.DurableTask.Netherite/Functions.Worker.Extensions.DurableTask.Netherite.csproj
@@ -26,8 +26,8 @@
   <!-- This version MUST be kept constant with DurableTask.Netherite.AzureFunctions -->
   <PropertyGroup>
     <MajorVersion>1</MajorVersion>
-    <MinorVersion>5</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <MinorVersion>4</MinorVersion>
+    <PatchVersion>3</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
       <VersionSuffix></VersionSuffix>
       <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>

--- a/src/Functions.Worker.Extensions.DurableTask.Netherite/Properties/AssemblyInfo.cs
+++ b/src/Functions.Worker.Extensions.DurableTask.Netherite/Properties/AssemblyInfo.cs
@@ -4,4 +4,4 @@
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
 // This must be updated when updating the version of the package
-[assembly: ExtensionInformation("Microsoft.Azure.DurableTask.Netherite.AzureFunctions", "1.5.0", true)]
+[assembly: ExtensionInformation("Microsoft.Azure.DurableTask.Netherite.AzureFunctions", "1.4.3", true)]


### PR DESCRIPTION
Since 1.5.0 is currently delayed by issues in the FASTER release pipeline, we are releasing a 1.4.3 patch release containing the many other fixes since 1.4.2