### PR TITLE
Increase FASTER.Core to 2.6.5

### DIFF
--- a/src/DurableTask.Netherite/DurableTask.Netherite.csproj
+++ b/src/DurableTask.Netherite/DurableTask.Netherite.csproj
@@ -57,7 +57,7 @@
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.2.3" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.16.0" />
     <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.16.2" />
-    <PackageReference Include="Microsoft.FASTER.Core" Version="2.6.4" />
+    <PackageReference Include="Microsoft.FASTER.Core" Version="2.6.5" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="System.Threading.Channels" Version="4.7.1" />


### PR DESCRIPTION
As in title - FASTER release made a hotfix for us here: https://github.com/microsoft/FASTER/pull/916