### PR TITLE
fix build break by suppressing tfm build warnings

### DIFF
--- a/src/DurableTask.Netherite.AzureFunctions/DurableTask.Netherite.AzureFunctions.csproj
+++ b/src/DurableTask.Netherite.AzureFunctions/DurableTask.Netherite.AzureFunctions.csproj
@@ -25,11 +25,13 @@
   <!-- Version can be edited in common.props -->
   <Import Project=".\..\common.props" />
 
-
-  <!-- Our netcoreapp2.2 target is a non-functional dummy target, so we don't need the warning -->
+	<!-- Our netcoreapp2.2 target is a non-functional dummy target. It does not contain any runnable code
+	     but we needed to have it at some point to keep the functions environment happy. Since the generated
+			 dll does not contain runnable code we can ignore deprecation warnings. -->
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.2' ">
-	<NoWarn>NETSDK1138</NoWarn>
-  </PropertyGroup>
+		<NoWarn>NETSDK1138</NoWarn>
+		<SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+	</PropertyGroup>
   
   <ItemGroup>
     <None Include="icon.png" Pack="true" PackagePath="\" />


### PR DESCRIPTION
Fixes broken build in some environments where TFM build warnings were treated as errors.

The fix is simply suppressing those warnings, specifically for the 2.2 target which is a dummy target. I also updated the comments.