### PR TITLE
Disambiguate NetheriteFactory constructor and rev version

### DIFF
--- a/src/DurableTask.Netherite.AzureFunctions/NetheriteProviderFactory.cs
+++ b/src/DurableTask.Netherite.AzureFunctions/NetheriteProviderFactory.cs
@@ -18,6 +18,33 @@ namespace DurableTask.Netherite.AzureFunctions
     using Microsoft.Extensions.Options;
     using Newtonsoft.Json;
 
+    /// <summary>
+    /// Utility class to disambiguate the right constructor to use for the NetheriteProviderFactory when using DI.
+    /// We need this class because there's two constructors of NetheriteProviderFactory, one of which is obsolete.
+    /// Starting in .NET8, this situation can lead to an ambiguous constructor resolution error even when the ActivatorUtilitiesConstructor attribute is used.
+    /// Therefore, this internal class help us narrow down the constructor selection.
+    /// </summary>
+    class UnambiguousNetheriteProviderFactory : NetheriteProviderFactory
+    {
+        /// <summary>
+        /// Constructors a NetheriteProviderFactory using the non-obsolete constructor from the parent class.
+        /// </summary>
+        [ActivatorUtilitiesConstructor]
+        internal UnambiguousNetheriteProviderFactory(
+            IOptions<DurableTaskOptions> extensionOptions,
+            ILoggerFactory loggerFactory,
+            IHostIdProvider hostIdProvider,
+            INameResolver nameResolver,
+            IServiceProvider serviceProvider,
+            DurableTask.Netherite.ConnectionResolver connectionResolver,
+#pragma warning disable CS0612 // Type or member is obsolete
+            IPlatformInformation platformInfo) : base(extensionOptions, loggerFactory, hostIdProvider, nameResolver, serviceProvider, connectionResolver, platformInfo)
+        {
+        }
+#pragma warning restore CS0612 // Type or member is obsolete
+
+    }
+
     public class NetheriteProviderFactory : IDurabilityProviderFactory
     {
         readonly static ConcurrentDictionary<(string taskhub, string storage, string transport), NetheriteProvider> CachedProviders

--- a/src/DurableTask.Netherite.AzureFunctions/NetheriteProviderStartup.cs
+++ b/src/DurableTask.Netherite.AzureFunctions/NetheriteProviderStartup.cs
@@ -16,7 +16,9 @@ namespace DurableTask.Netherite.AzureFunctions
         public void Configure(IWebJobsBuilder builder)
         {
 #if !NETCOREAPP2_2
-            builder.Services.AddSingleton<IDurabilityProviderFactory, NetheriteProviderFactory>();
+            // We use the UnambiguousNetheriteProviderFactory class instead of the base NetheriteProviderFactory class
+            // to avoid ambiguous constructor errors during DI. More details for this workaround can be found in the UnambiguousNetheriteProviderFactory class.
+            builder.Services.AddSingleton<IDurabilityProviderFactory, UnambiguousNetheriteProviderFactory>();
             builder.Services.TryAddSingleton<ConnectionResolver, NameResolverBasedConnectionNameResolver>();
 #else
             builder.Services.AddSingleton<IDurabilityProviderFactory, NetheriteProviderPseudoFactory>();

--- a/src/common.props
+++ b/src/common.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
 	<MajorVersion>1</MajorVersion>
 	<MinorVersion>5</MinorVersion>
-	<PatchVersion>1</PatchVersion>
+	<PatchVersion>2</PatchVersion>
 	<VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
 	<VersionSuffix></VersionSuffix>
 	<AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>


### PR DESCRIPTION
There are two `NetheriteProviderFactory` constructors: https://github.com/microsoft/durabletask-netherite/blob/f3e5f2621f05d615d52fd6005bf9c6d6d811ce99/src/DurableTask.Netherite.AzureFunctions/NetheriteProviderFactory.cs#L51-L109 . One is obsolete, and the other is not.

We used the `ActivatorUtilitiesConstructor` to tell DI which constructor to choose. However, it seems that annotation isn't honored in .NET8: https://github.com/dotnet/runtime/issues/95915.

Due to some combination of this .NET8 change, and the Host for Flex Consumption using a new DI library, DF apps in Flex Consumption using bundles are now failing with the following exception:

> System.InvalidOperationException : Unable to activate type 'DurableTask.Netherite.AzureFunctions.NetheriteProviderFactory'. The following constructors are ambiguous: 
Void .ctor(Microsoft.Extensions.Options.IOptions`1[Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions], Microsoft.Extensions.Logging.ILoggerFactory, Microsoft.Azure.WebJobs.Host.Executors.IHostIdProvider, Microsoft.Azure.WebJobs.INameResolver, System.IServiceProvider, DurableTask.Netherite.ConnectionResolver, Microsoft.Azure.WebJobs.Extensions.DurableTask.IPlatformInformation)
Void .ctor(Microsoft.Extensions.Options.IOptions`1[Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableTaskOptions], Microsoft.Extensions.Logging.ILoggerFactory, Microsoft.Azure.WebJobs.Extensions.DurableTask.IConnectionStringResolver, Microsoft.Azure.WebJobs.Host.Executors.IHostIdProvider, Microsoft.Azure.WebJobs.INameResolver, Microsoft.Azure.WebJobs.Extensions.DurableTask.IPlatformInformation)

This PR disambiguates the constructors by creating a new internal wrapper class, `UnambiguousNetheriteProviderFactory`, that re-exposes **only** the expected constructor, and registering it as the service provider for `IDurabilityProviderFactory`. This is a workaround suggested by Fabio from the Host team.