### PR TITLE
Migrate to 1ES pipelines

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -1,0 +1,34 @@
+
+trigger:
+    batch: true
+    branches:
+        include:
+            - vabachu/officialbuild
+
+# CI only, does not trigger on PRs.
+pr: none
+
+resources:
+    repositories:
+        - repository: 1es
+          type: git
+          name: 1ESPipelineTemplates/1ESPipelineTemplates
+          ref: refs/tags/release
+        - repository: eng
+          type: git
+          name: engineering
+          ref: refs/tags/release
+
+extends:
+    template: v1/1ES.Official.PipelineTemplate.yml@1es
+    parameters:
+        pool:
+            name: 1es-pool-azfunc
+            image: 1es-windows-2022
+            os: windows
+
+        stages:
+            - stage: BuildAndSign
+              dependsOn: []
+              jobs:
+                  - template: /eng/templates/build.yml@self

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -3,7 +3,7 @@ trigger:
     batch: true
     branches:
         include:
-            - vabachu/officialbuild
+            - main
 
 # CI only, does not trigger on PRs.
 pr: none

--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -1,0 +1,86 @@
+jobs:
+    - job: Build
+
+      templateContext:
+        outputs:
+            - output: pipelineArtifact
+              path: $(build.artifactStagingDirectory)
+              artifact: drop
+              sbomBuildDropPath: $(build.artifactStagingDirectory)
+              sbomPackageName: 'DurableTask Netherite SBOM'
+
+      steps:
+
+      # Install specific .NET sdk required by build or signing tasks
+      - task: UseDotNet@2
+        displayName: 'Use the .NET Core 2.1 SDK (required for build signing)'
+        inputs:
+            packageType: 'sdk'
+            version: '2.1.x'
+      - task: UseDotNet@2
+        displayName: 'Install .NET Core 2.2 SDK'
+        inputs:
+            packageType: 'sdk'
+            version: '2.2.x'
+      - task: UseDotNet@2
+        displayName: 'Install .NET Core 3.1 SDK'
+        inputs:
+            packageType: 'sdk'
+            version: '3.1.x'
+      - task: UseDotNet@2
+        displayName: 'Install .NET Core 5.0 SDK'
+        inputs:
+            packageType: 'sdk'
+            version: '5.0.x'
+      - task: UseDotNet@2
+        displayName: 'Install .NET Core 6.0 SDK (required for build signing)'
+        inputs:
+            packageType: 'sdk'
+            version: '6.0.x'
+      - task: UseDotNet@2
+        displayName: 'Install .NET Core 7.0 SDK'
+        inputs:
+            packageType: 'sdk'
+            version: '7.0.x'
+
+      # Start by restoring all the dependencies.
+      - task: DotNetCoreCLI@2
+        displayName: 'Restore nuget dependencies'
+        inputs:
+            command: restore
+            verbosityRestore: Minimal
+            projects: 'src/dirs.proj'
+
+      # Build the filtered solution in release mode, specifying the continuous integration flag.
+      - task: DotNetCoreCLI@2
+        displayName: 'Build'
+        inputs:
+            command: build
+            arguments: --no-restore -c release -p:GITHUB_RUN_NUMBER=$(Build.BuildId) -p:ContinuousIntegrationBuild=true
+            projects: 'src/dirs.proj'
+
+      - template: ci/sign-files.yml@eng
+        parameters:
+            displayName: Sign assemblies
+            folderPath: src
+            pattern: DurableTask.*.dll
+            signType: dll
+      
+      # Packaging needs to be a separate step from build.
+      # This will automatically pick up the signed DLLs.
+      - task: DotNetCoreCLI@2
+        displayName: Generate nuget packages
+        inputs:
+            command: pack
+            verbosityPack: Minimal
+            configuration: Release
+            nobuild: true
+            packDirectory: $(build.artifactStagingDirectory)
+            packagesToPack: 'src/dirs.proj'
+
+      - template: ci/sign-files.yml@eng
+        parameters:
+            displayName: Sign NugetPackages
+            folderPath: $(build.artifactStagingDirectory)
+            pattern: '*.nupkg'
+            signType: nuget


### PR DESCRIPTION
This PR migrates the pipelines to 1ES pipelines. It adds 2 files - official-build.yml and build.yml. official-build.yml references build.yml and runs on any changes pushed to the `main` branch.