### PR TITLE
Revise compaction state machine

### DIFF
--- a/src/DurableTask.Netherite/StorageLayer/Faster/TrackedObjectStore.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/TrackedObjectStore.cs
@@ -37,7 +37,7 @@ namespace DurableTask.Netherite.Faster
 
         public abstract Task FinalizeCheckpointCompletedAsync(Guid guid);
 
-        public abstract long? GetCompactionTarget();
+        public abstract bool CompactionIsDue(out long target);
 
         public abstract Task<long> RunCompactionAsync(long target);
 


### PR DESCRIPTION
This PR addresses several issues and makes some fixes related to the following issues we observed:

**Issue 1.** The partition load table does not show activity that originates from compactions or checkpoints being performed. This is not ideal because it can mean that (a) issues such as infinite checkpointing or compaction loops easily are not immediately visible (e.g. see https://github.com/microsoft/durabletask-netherite/pull/409), and (b) the scale controller is not aware of the true amount of work being performed by partitions.

To fix this we add activity level (L) to the partition load monitor whenever a checkpoint or compaction is in progress. Also, if compactions take particularly long, we add (M) or (H) indicators.

**Issue 2**. Compactions were only triggered during idle periods, and only after some time delay. This is a problem if there are no idle periods, or if compactions need to run more frequently, such as when we have a continuous influx of requests.

To fix this we check whether a compaction should be performed independently of whether the partition is idle, and how much time has passed.

**Issue 3.** the new, more efficient compaction algorithm inhttps://github.com/microsoft/durabletask-netherite/pull/408 warrants different parameter tuning - compaction is now much less expensive compared to the checkpointing that is triggered along with it, so we should do fewer and larger compactions

We adjust the values for the max compaction area size (50000 -> 200000) and the minimum expected reduction at which we start compacting (5000 -> 10000) 