### PR TITLE
Add source link reconstruction

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,37 @@
+<Project>
+  <!-- This is copied from:https://github.com/Azure/azure-functions-host/blob/dev/eng/build/RepositoryInfo.targets -->
+  <!-- The following build target allows us to reconstruct source-link information when building in 1ES -->
+
+  <!--
+    The convention for names of Azure DevOps repositories mirrored from GitHub is "{GitHub org name}.{GitHub repository name}".
+  -->
+  <PropertyGroup>
+    <!-- There are quite a few git repo forms:
+      https://azfunc@dev.azure.com/azfunc/internal/_git/azure.azure-functions-host
+      https://dev.azure.com/azfunc/internal/_git/azure.azure-functions-host
+      https://azfunc.visualstudio.com/internal/_git/azure.azure-functions-host
+      azfunc@vs-ssh.visualstudio.com:v3/azfunc/internal/azure.azure-functions-host
+      git@ssh.dev.azure.com:v3/azfunc/internal/azure.azure-functions-host
+    -->
+    <!-- Set DisableSourceLinkUrlTranslation to true when building a tool for internal use where sources only come from internal URIs -->
+    <DisableSourceLinkUrlTranslation Condition="'$(DisableSourceLinkUrlTranslation)' == ''">false</DisableSourceLinkUrlTranslation>
+    <_TranslateUrlPattern>(https://azfunc%40dev\.azure\.com/azfunc/internal/_git|https://dev\.azure\.com/azfunc/internal/_git|https://azfunc\.visualstudio\.com/internal/_git|azfunc%40vs-ssh\.visualstudio\.com:v3/azfunc/internal|git%40ssh\.dev\.azure\.com:v3/azfunc/internal)/([^/\.]+)\.(.+)</_TranslateUrlPattern>
+    <_TranslateUrlReplacement>https://github.com/$2/$3</_TranslateUrlReplacement>
+  </PropertyGroup>
+
+  <!-- When building from Azure Devops we update SourceLink to point back to the GitHub repo. -->
+  <Target Name="_TranslateAzureDevOpsUrlToGitHubUrl"
+    Condition="'$(DisableSourceLinkUrlTranslation)' == 'false'"
+    DependsOnTargets="$(SourceControlManagerUrlTranslationTargets)"
+    BeforeTargets="SourceControlManagerPublishTranslatedUrls">
+    <PropertyGroup>
+      <ScmRepositoryUrl>$([System.Text.RegularExpressions.Regex]::Replace($(ScmRepositoryUrl), $(_TranslateUrlPattern), $(_TranslateUrlReplacement)))</ScmRepositoryUrl>
+    </PropertyGroup>
+    <ItemGroup>
+      <SourceRoot Update="@(SourceRoot)">
+          <ScmRepositoryUrl>$([System.Text.RegularExpressions.Regex]::Replace(%(SourceRoot.ScmRepositoryUrl), $(_TranslateUrlPattern), $(_TranslateUrlReplacement)))</ScmRepositoryUrl>
+      </SourceRoot>
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/DurableTask.Netherite.sln
+++ b/DurableTask.Netherite.sln
@@ -26,6 +26,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{D33AB157-04B9-4BAD-B580-C3C87C17828C}"
 	ProjectSection(SolutionItems) = preProject
 		src\common.props = src\common.props
+		Directory.Build.targets = Directory.Build.targets
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{4A7226CF-57BF-4CA3-A4AC-91A398A1D84B}"


### PR DESCRIPTION
The Netherite version of this PR: https://github.com/Azure/durabletask/pull/1147
In short, since the code is now built from a _mirror_ of the GitHub code inside Azure DevOps, we're losing some source link information at built-time. This MSBuild file manually indicate that the code is coming from GitHub, despite building from ADO