### PR TITLE
Add readme and official build codeql

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -8,6 +8,17 @@ trigger:
 # CI only, does not trigger on PRs.
 pr: none
 
+schedules:
+# Build nightly to catch any new CVEs and report SDL often.
+# We are also required to generated CodeQL reports weekly, so this
+# helps us meet that.
+- cron: "0 0 * * *"
+  displayName: Nightly Build
+  branches:
+    include:
+    - main
+  always: true
+
 resources:
     repositories:
         - repository: 1es

--- a/src/DurableTask.Netherite.AzureFunctions/DurableTask.Netherite.AzureFunctions.csproj
+++ b/src/DurableTask.Netherite.AzureFunctions/DurableTask.Netherite.AzureFunctions.csproj
@@ -20,7 +20,16 @@
     <PackageTags>Azure Task Durable Orchestration Workflow Activity Reliable EventHubs</PackageTags>
     <PackageId>Microsoft.Azure.DurableTask.Netherite.AzureFunctions</PackageId>
     <PackageIcon>icon.png</PackageIcon>
+	<PackageReadmeFile>.\README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <!-- Include the README.md at the root of the repo into the nupkg-->
+  <ItemGroup>
+    <None Include="..\..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 
   <!-- Version can be edited in common.props -->
   <Import Project=".\..\common.props" />

--- a/src/DurableTask.Netherite/DurableTask.Netherite.csproj
+++ b/src/DurableTask.Netherite/DurableTask.Netherite.csproj
@@ -20,8 +20,17 @@
     <PackageId>Microsoft.Azure.DurableTask.Netherite</PackageId>
     <PackageIcon>icon.png</PackageIcon>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+	<PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
+  <!-- Include the README.md at the root of the repo into the nupkg-->
+  <ItemGroup>
+    <None Include="..\..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
+	
   <!-- Version can be edited in common.props -->
   <Import Project=".\..\common.props" />
   <ItemGroup>

--- a/src/Functions.Worker.Extensions.DurableTask.Netherite/Functions.Worker.Extensions.DurableTask.Netherite.csproj
+++ b/src/Functions.Worker.Extensions.DurableTask.Netherite/Functions.Worker.Extensions.DurableTask.Netherite.csproj
@@ -20,7 +20,16 @@
     <PackageTags>Azure Task Durable Orchestration Workflow Activity Reliable EventHubs</PackageTags>
     <PackageId>$(AssemblyName)</PackageId>
     <PackageIcon>icon.png</PackageIcon>
+	<PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <!-- Include the README.md at the root of the repo into the nupkg-->
+  <ItemGroup>
+    <None Include="..\..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 
   <!-- Version can be edited in common.props -->
   <Import Project=".\..\common.props" />


### PR DESCRIPTION
As in title, add README to packages, to remove warning when uploading to NuGet
And add partial CodeQL support by making official builds run weekly