### PR TITLE
Add timeouts to test and fix race condition in device startup

### DIFF
--- a/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/AzureStorageDevice.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/AzureStorageDevice.cs
@@ -82,12 +82,12 @@ namespace DurableTask.Netherite.Faster
             this.pageBlobDirectory = pageBlobDirectory;
             this.blobName = blobName;
             this.PartitionErrorHandler = blobManager.PartitionErrorHandler;
-            this.PartitionErrorHandler.Token.Register(this.CancelAllRequests);
             this.BlobManager = blobManager;
             this.underLease = underLease;
             this.hangCheckTimer = new Timer(this.DetectHangs, null, 0, 20000);
             this.singleWriterSemaphore = underLease ? new SemaphoreSlim(1) : null;
             this.limit = TimeSpan.FromSeconds(90);
+            this.PartitionErrorHandler.Token.Register(this.CancelAllRequests);
         }
 
         /// <inheritdoc/>

--- a/test/DurableTask.Netherite.AzureFunctions.Tests/IntegrationTestBase.cs
+++ b/test/DurableTask.Netherite.AzureFunctions.Tests/IntegrationTestBase.cs
@@ -10,6 +10,7 @@ namespace DurableTask.Netherite.AzureFunctions.Tests
     using System.Threading;
     using System.Threading.Tasks;
     using DurableTask.Netherite.AzureFunctions.Tests.Logging;
+    using DurableTask.Netherite.Tests;
     using Microsoft.Azure.WebJobs;
     using Microsoft.Azure.WebJobs.Extensions.DurableTask;
     using Microsoft.Extensions.DependencyInjection;
@@ -74,21 +75,23 @@ namespace DurableTask.Netherite.AzureFunctions.Tests
             this.AddFunctions(typeof(ClientFunctions));
         }
 
-        async Task IAsyncLifetime.InitializeAsync()
+        Task IAsyncLifetime.InitializeAsync()
         {
-           await this.functionsHost.StartAsync();
+             return Common.WithTimeoutAsync(TimeSpan.FromMinutes(1), () => this.functionsHost.StartAsync());
         }
 
-        async Task IAsyncLifetime.DisposeAsync() 
+        Task IAsyncLifetime.DisposeAsync() 
         {
-            try
+            return Common.WithTimeoutAsync(TimeSpan.FromMinutes(1), async () =>
             {
-                await this.functionsHost.StopAsync();
-            }
-            catch(OperationCanceledException)
-            {
-
-            }
+                try
+                {
+                    await this.functionsHost.StopAsync();
+                }
+                catch (OperationCanceledException)
+                {
+                }
+            });
         }
 
         protected void AddFunctions(Type functionType) => this.typeLocator.AddFunctionType(functionType);

--- a/test/DurableTask.Netherite.Tests/FasterPartitionTests.cs
+++ b/test/DurableTask.Netherite.Tests/FasterPartitionTests.cs
@@ -34,6 +34,8 @@ namespace DurableTask.Netherite.Tests
         ITestOutputHelper outputHelper;
         string errorInTestHooks;
 
+        static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(5);
+
         const int extraLogEntrySize = 96; // since v2 Faster puts extra stuff in the log. Empirically determined.
 
         public FasterPartitionTests(ITestOutputHelper outputHelper)
@@ -125,174 +127,59 @@ namespace DurableTask.Netherite.Tests
         /// Create a partition and then restore it.
         /// </summary>
         [Fact]
-        public async Task CreateThenRestore()
+        public Task CreateThenRestore()
         {
-            this.settings.PartitionCount = 1;
-            var orchestrationType = typeof(ScenarioTests.Orchestrations.SayHelloInline);
+            return Common.WithTimeoutAsync(DefaultTimeout, async () =>
             {
-                // start the service 
-                var (service, client) = await this.StartService(recover: false, orchestrationType);
+                this.settings.PartitionCount = 1;
+                var orchestrationType = typeof(ScenarioTests.Orchestrations.SayHelloInline);
+                {
+                    // start the service 
+                    var (service, client) = await this.StartService(recover: false, orchestrationType);
 
-                // do orchestration
-                var instance = await client.CreateOrchestrationInstanceAsync(orchestrationType, "0", "0");
-                await client.WaitForOrchestrationAsync(instance, TimeSpan.FromSeconds(20));
+                    // do orchestration
+                    var instance = await client.CreateOrchestrationInstanceAsync(orchestrationType, "0", "0");
+                    await client.WaitForOrchestrationAsync(instance, TimeSpan.FromSeconds(20));
 
-                // stop the service
-                await service.StopAsync();
-            }
-            {
-                // start the service 
-                var (service, client) = await this.StartService(recover: true, orchestrationType);
-                var orchestrationState = await client.GetOrchestrationStateAsync("0");
-                Assert.Equal(OrchestrationStatus.Completed, orchestrationState?.OrchestrationStatus);
+                    // stop the service
+                    await service.StopAsync();
+                }
+                {
+                    // start the service 
+                    var (service, client) = await this.StartService(recover: true, orchestrationType);
+                    var orchestrationState = await client.GetOrchestrationStateAsync("0");
+                    Assert.Equal(OrchestrationStatus.Completed, orchestrationState?.OrchestrationStatus);
 
-                // stop the service
-                await service.StopAsync();
-            }
+                    // stop the service
+                    await service.StopAsync();
+                }
+            });
         }
 
         /// <summary>
         /// Run a number of orchestrations that requires more memory than available for FASTER
         /// </summary>
         [Fact()]
-        public async Task LimitedMemory()
+        public Task LimitedMemory()
         {
-            this.settings.PartitionCount = 1;
-            this.SetCheckpointFrequency(CheckpointFrequency.None);
-
-            // set the memory size very small so we can force evictions
-            this.settings.FasterTuningParameters = new Faster.BlobManager.FasterTuningParameters()
+            return Common.WithTimeoutAsync(DefaultTimeout, async () =>
             {
-                StoreLogPageSizeBits = 10,       // 1 KB
-                StoreLogMemorySizeBits = 12,     // 4 KB, which means only about 166 entries fit into memory
-            };
+                this.settings.PartitionCount = 1;
+                this.SetCheckpointFrequency(CheckpointFrequency.None);
 
-            // we use the standard hello orchestration from the samples, which calls 5 activities in sequence
-            var orchestrationType = typeof(ScenarioTests.Orchestrations.Hello5);
-            var activityType = typeof(ScenarioTests.Activities.Hello);
-            string InstanceId(int i) => $"Orch{i:D5}";
-            int OrchestrationCount = 100; // requires 200 FASTER key-value pairs so it does not fit into memory
-
-            // start the service 
-            var (service, client) = await this.StartService(recover: false, orchestrationType, activityType);
-
-            // start all orchestrations
-            {
-                var tasks = new Task[OrchestrationCount];
-                for (int i = 0; i < OrchestrationCount; i++)
-                    tasks[i] = client.CreateOrchestrationInstanceAsync(orchestrationType, InstanceId(i), null);
-
-                var timeout = TimeSpan.FromMinutes(3);
-                var terminationTask = Task.Delay(timeout, this.cts.Token);
-                var completionTask = Task.WhenAll(tasks);
-                var firstTask = await Task.WhenAny(terminationTask, completionTask);
-                Assert.True(this.errorInTestHooks == null, $"while starting orchestrations: {this.errorInTestHooks}");
-                Assert.True(firstTask != terminationTask, $"timed out after {timeout} while starting orchestrations");
-            }
-
-            // wait for all orchestrations to finish executing
-            this.output?.Invoke("waiting for orchestrations to finish executing...");
-            try
-            {
-                async Task WaitFor(int i)
+                // set the memory size very small so we can force evictions
+                this.settings.FasterTuningParameters = new Faster.BlobManager.FasterTuningParameters()
                 {
-                    try
-                    {
-                        await client.WaitForOrchestrationAsync(new OrchestrationInstance { InstanceId = InstanceId(i) }, TimeSpan.FromMinutes(10));
-                    }
-                    catch (Exception e)
-                    {
-                        this.output?.Invoke($"Orchestration {InstanceId(i)} failed with {e.GetType()}: {e.Message}");
-                    }
-                }
+                    StoreLogPageSizeBits = 10,       // 1 KB
+                    StoreLogMemorySizeBits = 12,     // 4 KB, which means only about 166 entries fit into memory
+                };
 
-                var tasks = new Task[OrchestrationCount];
-                var timeout = Debugger.IsAttached ? TimeSpan.FromMinutes(15) : TimeSpan.FromMinutes(3);
-                for (int i = 0; i < OrchestrationCount; i++)
-                    tasks[i] = WaitFor(i);
+                // we use the standard hello orchestration from the samples, which calls 5 activities in sequence
+                var orchestrationType = typeof(ScenarioTests.Orchestrations.Hello5);
+                var activityType = typeof(ScenarioTests.Activities.Hello);
+                string InstanceId(int i) => $"Orch{i:D5}";
+                int OrchestrationCount = 100; // requires 200 FASTER key-value pairs so it does not fit into memory
 
-                void PrintUnfinished()
-                {
-                    var sb = new StringBuilder();
-                    sb.Append("Waiting for orchestrations:");
-                    for (int i = 0; i < OrchestrationCount; i++)
-                    {
-                        if (!tasks[i].IsCompleted)
-                        {
-                            sb.Append(' ');
-                            sb.Append(InstanceId(i));
-                        }
-                    }
-                    this.output?.Invoke(sb.ToString());
-                }
-
-                void ProgressReportThread()
-                {
-                    Stopwatch elapsed = new Stopwatch();
-                    elapsed.Start();
-
-                    while (elapsed.Elapsed < timeout)
-                    {
-                        Thread.Sleep(10000);
-                        PrintUnfinished();
-                    }
-
-                    this.cts.Cancel();
-                }
-                var thread = TrackedThreads.MakeTrackedThread(ProgressReportThread, "ProgressReportThread");
-                thread.Start();
-
-                var terminationTask = Task.Delay(timeout, this.cts.Token);
-                var completionTask = Task.WhenAll(tasks);
-                var firstTask = await Task.WhenAny(terminationTask, completionTask);
-                Assert.True(this.errorInTestHooks == null, $"while executing orchestrations: {this.errorInTestHooks}");
-
-                PrintUnfinished();
-
-                Assert.True(firstTask != terminationTask, $"timed out after {timeout} while executing orchestrations");
-
-                foreach (var line in this.cacheDebugger.Dump())
-                {
-                    this.output?.Invoke(line);
-                }
-            }
-            catch (Exception e)
-            {
-                this.output?.Invoke($"exception thrown while executing orchestrations: {e}");
-                foreach (var line in this.cacheDebugger.Dump())
-                {
-                    this.output?.Invoke(line);
-                }
-                throw;
-            }
-
-            // shut down the service
-            await service.StopAsync();
-        }
-
-        /// <summary>
-        /// Create a partition and then restore it, and use the size tracker again.
-        /// </summary>
-        [Fact]
-        public async Task CheckSizeTrackerOnRecovery()
-        {
-            this.settings.PartitionCount = 1;
-            this.SetCheckpointFrequency(CheckpointFrequency.None);
-
-            // set the memory size very small so we can force evictions
-            this.settings.FasterTuningParameters = new Faster.BlobManager.FasterTuningParameters()
-            {
-                StoreLogPageSizeBits = 10,       // 1 KB
-                StoreLogMemorySizeBits = 12,     // 4 KB, which means only about 166 entries fit into memory
-            };
-
-            // we use the standard hello orchestration from the samples, which calls 5 activities in sequence
-            var orchestrationType = typeof(ScenarioTests.Orchestrations.Hello5);
-            var activityType = typeof(ScenarioTests.Activities.Hello);
-            string InstanceId(int i) => $"Orch{i:D5}";
-            int OrchestrationCount = 100; // requires 200 FASTER key-value pairs so it does not fit into memory
-
-            {
                 // start the service 
                 var (service, client) = await this.StartService(recover: false, orchestrationType, activityType);
 
@@ -302,11 +189,17 @@ namespace DurableTask.Netherite.Tests
                     for (int i = 0; i < OrchestrationCount; i++)
                         tasks[i] = client.CreateOrchestrationInstanceAsync(orchestrationType, InstanceId(i), null);
 
-                    await Task.WhenAll(tasks);
-                    Assert.True(this.errorInTestHooks == null, $"TestHooks detected problem while starting orchestrations: {this.errorInTestHooks}");
+                    var timeout = TimeSpan.FromMinutes(3);
+                    var terminationTask = Task.Delay(timeout, this.cts.Token);
+                    var completionTask = Task.WhenAll(tasks);
+                    var firstTask = await Task.WhenAny(terminationTask, completionTask);
+                    Assert.True(this.errorInTestHooks == null, $"while starting orchestrations: {this.errorInTestHooks}");
+                    Assert.True(firstTask != terminationTask, $"timed out after {timeout} while starting orchestrations");
                 }
 
                 // wait for all orchestrations to finish executing
+                this.output?.Invoke("waiting for orchestrations to finish executing...");
+                try
                 {
                     async Task WaitFor(int i)
                     {
@@ -321,122 +214,246 @@ namespace DurableTask.Netherite.Tests
                     }
 
                     var tasks = new Task[OrchestrationCount];
+                    var timeout = Debugger.IsAttached ? TimeSpan.FromMinutes(15) : TimeSpan.FromMinutes(3);
                     for (int i = 0; i < OrchestrationCount; i++)
                         tasks[i] = WaitFor(i);
-                    await Task.WhenAll(tasks);
-                    Assert.True(this.errorInTestHooks == null, $"TestHooks detected problem while executing orchestrations: {this.errorInTestHooks}");
-                }
 
-                this.output?.Invoke("--- test progress: BEFORE SHUTDOWN ------------------------------------");
-                foreach (var line in this.cacheDebugger.Dump())
+                    void PrintUnfinished()
+                    {
+                        var sb = new StringBuilder();
+                        sb.Append("Waiting for orchestrations:");
+                        for (int i = 0; i < OrchestrationCount; i++)
+                        {
+                            if (!tasks[i].IsCompleted)
+                            {
+                                sb.Append(' ');
+                                sb.Append(InstanceId(i));
+                            }
+                        }
+                        this.output?.Invoke(sb.ToString());
+                    }
+
+                    void ProgressReportThread()
+                    {
+                        Stopwatch elapsed = new Stopwatch();
+                        elapsed.Start();
+
+                        while (elapsed.Elapsed < timeout)
+                        {
+                            Thread.Sleep(10000);
+                            PrintUnfinished();
+                        }
+
+                        this.cts.Cancel();
+                    }
+                    var thread = TrackedThreads.MakeTrackedThread(ProgressReportThread, "ProgressReportThread");
+                    thread.Start();
+
+                    var terminationTask = Task.Delay(timeout, this.cts.Token);
+                    var completionTask = Task.WhenAll(tasks);
+                    var firstTask = await Task.WhenAny(terminationTask, completionTask);
+                    Assert.True(this.errorInTestHooks == null, $"while executing orchestrations: {this.errorInTestHooks}");
+
+                    PrintUnfinished();
+
+                    Assert.True(firstTask != terminationTask, $"timed out after {timeout} while executing orchestrations");
+
+                    foreach (var line in this.cacheDebugger.Dump())
+                    {
+                        this.output?.Invoke(line);
+                    }
+                }
+                catch (Exception e)
                 {
-                    this.output?.Invoke(line);
+                    this.output?.Invoke($"exception thrown while executing orchestrations: {e}");
+                    foreach (var line in this.cacheDebugger.Dump())
+                    {
+                        this.output?.Invoke(line);
+                    }
+                    throw;
                 }
 
                 // shut down the service
                 await service.StopAsync();
-            }
+            });
+        }
 
+        /// <summary>
+        /// Create a partition and then restore it, and use the size tracker again.
+        /// </summary>
+        [Fact]
+        public Task CheckSizeTrackerOnRecovery()
+        {
+            return Common.WithTimeoutAsync(DefaultTimeout, async () =>
             {
-                this.output?.Invoke("--- test progress: BEFORE RECOVERY ------------------------------------");
+                this.settings.PartitionCount = 1;
+                this.SetCheckpointFrequency(CheckpointFrequency.None);
 
-                // recover the service 
-                var (service, client) = await this.StartService(recover: true, orchestrationType, activityType);
-
-                this.output?.Invoke("--- test progress: AFTER RECOVERY ------------------------------------");
-
-
-                // query the status of all orchestrations
+                // set the memory size very small so we can force evictions
+                this.settings.FasterTuningParameters = new Faster.BlobManager.FasterTuningParameters()
                 {
-                    var tasks = new Task[OrchestrationCount];
-                    for (int i = 0; i < OrchestrationCount; i++)
-                        tasks[i] = client.WaitForOrchestrationAsync(new OrchestrationInstance { InstanceId = InstanceId(i) }, TimeSpan.FromMinutes(10));
-                    await Task.WhenAll(tasks);
-                    Assert.True(this.errorInTestHooks == null, $"TestHooks detected problem while querying orchestration states: {this.errorInTestHooks}");
+                    StoreLogPageSizeBits = 10,       // 1 KB
+                    StoreLogMemorySizeBits = 12,     // 4 KB, which means only about 166 entries fit into memory
+                };
+
+                // we use the standard hello orchestration from the samples, which calls 5 activities in sequence
+                var orchestrationType = typeof(ScenarioTests.Orchestrations.Hello5);
+                var activityType = typeof(ScenarioTests.Activities.Hello);
+                string InstanceId(int i) => $"Orch{i:D5}";
+                int OrchestrationCount = 100; // requires 200 FASTER key-value pairs so it does not fit into memory
+
+                {
+                    // start the service 
+                    var (service, client) = await this.StartService(recover: false, orchestrationType, activityType);
+
+                    // start all orchestrations
+                    {
+                        var tasks = new Task[OrchestrationCount];
+                        for (int i = 0; i < OrchestrationCount; i++)
+                            tasks[i] = client.CreateOrchestrationInstanceAsync(orchestrationType, InstanceId(i), null);
+
+                        await Task.WhenAll(tasks);
+                        Assert.True(this.errorInTestHooks == null, $"TestHooks detected problem while starting orchestrations: {this.errorInTestHooks}");
+                    }
+
+                    // wait for all orchestrations to finish executing
+                    {
+                        async Task WaitFor(int i)
+                        {
+                            try
+                            {
+                                await client.WaitForOrchestrationAsync(new OrchestrationInstance { InstanceId = InstanceId(i) }, TimeSpan.FromMinutes(10));
+                            }
+                            catch (Exception e)
+                            {
+                                this.output?.Invoke($"Orchestration {InstanceId(i)} failed with {e.GetType()}: {e.Message}");
+                            }
+                        }
+
+                        var tasks = new Task[OrchestrationCount];
+                        for (int i = 0; i < OrchestrationCount; i++)
+                            tasks[i] = WaitFor(i);
+                        await Task.WhenAll(tasks);
+                        Assert.True(this.errorInTestHooks == null, $"TestHooks detected problem while executing orchestrations: {this.errorInTestHooks}");
+                    }
+
+                    this.output?.Invoke("--- test progress: BEFORE SHUTDOWN ------------------------------------");
+                    foreach (var line in this.cacheDebugger.Dump())
+                    {
+                        this.output?.Invoke(line);
+                    }
+
+                    // shut down the service
+                    await service.StopAsync();
                 }
 
-                this.output?.Invoke("--- test progress: AFTER QUERIES ------------------------------------");
-                foreach (var line in this.cacheDebugger.Dump())
                 {
-                    this.output?.Invoke(line);
-                }
+                    this.output?.Invoke("--- test progress: BEFORE RECOVERY ------------------------------------");
 
-                // shut down the service
-                await service.StopAsync();
-            }
+                    // recover the service 
+                    var (service, client) = await this.StartService(recover: true, orchestrationType, activityType);
+
+                    this.output?.Invoke("--- test progress: AFTER RECOVERY ------------------------------------");
+
+
+                    // query the status of all orchestrations
+                    {
+                        var tasks = new Task[OrchestrationCount];
+                        for (int i = 0; i < OrchestrationCount; i++)
+                            tasks[i] = client.WaitForOrchestrationAsync(new OrchestrationInstance { InstanceId = InstanceId(i) }, TimeSpan.FromMinutes(10));
+                        await Task.WhenAll(tasks);
+                        Assert.True(this.errorInTestHooks == null, $"TestHooks detected problem while querying orchestration states: {this.errorInTestHooks}");
+                    }
+
+                    this.output?.Invoke("--- test progress: AFTER QUERIES ------------------------------------");
+                    foreach (var line in this.cacheDebugger.Dump())
+                    {
+                        this.output?.Invoke(line);
+                    }
+
+                    // shut down the service
+                    await service.StopAsync();
+                }
+            });
         }
 
         /// <summary>
         /// Fill memory, then compute size, then reduce page count, and measure size again
         /// </summary>
         [Fact]
-        public async Task PipelinedStart()
+        public Task PipelinedStart()
         {
-            this.settings.PartitionCount = 1;
-            this.settings.InstanceCacheSizeMB = 2;
-            this.SetCheckpointFrequency(CheckpointFrequency.Frequent);
-
-            var orchestrationType = typeof(ScenarioTests.Orchestrations.Hello5);
-            var activityType = typeof(ScenarioTests.Activities.Hello);
-            string InstanceId(int i) => $"Orch{i:D5}";
-            int numOrchestrations = 500;
-
-            // start the service 
-            var (service, client) = await this.StartService(recover: false, orchestrationType, activityType);
-
-            // start all orchestrations and then get the status of each one
+            return Common.WithTimeoutAsync(DefaultTimeout, async () =>
             {
-                var orchestrations = await Enumerable.Range(0, numOrchestrations).ParallelForEachAsync(200, true, (iteration) =>
-                {
-                    var orchestrationInstanceId = InstanceId(iteration);
-                    return client.CreateOrchestrationInstanceAsync(orchestrationType, orchestrationInstanceId, null);
-                });
-                Assert.True(this.errorInTestHooks == null, $"TestHooks detected problem while starting orchestrations: {this.errorInTestHooks}");
-                await Enumerable.Range(0, numOrchestrations).ParallelForEachAsync(200, true, (iteration) =>
-                {
-                    return client.GetOrchestrationStateAsync(orchestrations[iteration]);
-                });  
-                Assert.True(this.errorInTestHooks == null, $"TestHooks detected problem while checking progress of orchestrations: {this.errorInTestHooks}");
-            }
+                this.settings.PartitionCount = 1;
+                this.settings.InstanceCacheSizeMB = 2;
+                this.SetCheckpointFrequency(CheckpointFrequency.Frequent);
 
-            await service.StopAsync();
+                var orchestrationType = typeof(ScenarioTests.Orchestrations.Hello5);
+                var activityType = typeof(ScenarioTests.Activities.Hello);
+                string InstanceId(int i) => $"Orch{i:D5}";
+                int numOrchestrations = 500;
+
+                // start the service 
+                var (service, client) = await this.StartService(recover: false, orchestrationType, activityType);
+
+                // start all orchestrations and then get the status of each one
+                {
+                    var orchestrations = await Enumerable.Range(0, numOrchestrations).ParallelForEachAsync(200, true, (iteration) =>
+                    {
+                        var orchestrationInstanceId = InstanceId(iteration);
+                        return client.CreateOrchestrationInstanceAsync(orchestrationType, orchestrationInstanceId, null);
+                    });
+                    Assert.True(this.errorInTestHooks == null, $"TestHooks detected problem while starting orchestrations: {this.errorInTestHooks}");
+                    await Enumerable.Range(0, numOrchestrations).ParallelForEachAsync(200, true, (iteration) =>
+                    {
+                        return client.GetOrchestrationStateAsync(orchestrations[iteration]);
+                    });
+                    Assert.True(this.errorInTestHooks == null, $"TestHooks detected problem while checking progress of orchestrations: {this.errorInTestHooks}");
+                }
+
+                await service.StopAsync();
+            });
         }
 
         /// <summary>
         /// Repro fail on basic 1000 * hello
         /// </summary>
         [Fact]
-        public async Task CheckMemorySize()
+        public Task CheckMemorySize()
         {
-            this.settings.PartitionCount = 1;
-            this.SetCheckpointFrequency(CheckpointFrequency.None);
-
-            var orchestrationType = typeof(ScenarioTests.Orchestrations.SemiLargePayloadFanOutFanIn);
-            var activityType = typeof(ScenarioTests.Activities.Echo);
-            string InstanceId(int i) => $"Orch{i:D5}";
-            int OrchestrationCount = 30;
-            int FanOut = 7;
-            long historyAndStatusSize = OrchestrationCount * (FanOut * 50000 /* in history */ + 2 * 16000 /* in status */);
-
-            // start the service 
-            var (service, client) = await this.StartService(recover: false, orchestrationType, activityType);
-
-            // run all orchestrations
+            return Common.WithTimeoutAsync(DefaultTimeout, async () =>
             {
-                var tasks = new Task[OrchestrationCount];
-                for (int i = 0; i < OrchestrationCount; i++)
-                    tasks[i] = client.CreateOrchestrationInstanceAsync(orchestrationType, InstanceId(i), FanOut);
-                await Task.WhenAll(tasks);
-                for (int i = 0; i < OrchestrationCount; i++)
-                    tasks[i] = client.WaitForOrchestrationAsync(new OrchestrationInstance { InstanceId = InstanceId(i) }, TimeSpan.FromMinutes(3));
-                await Task.WhenAll(tasks);
-                Assert.True(this.errorInTestHooks == null, $"TestHooks detected problem while starting orchestrations: {this.errorInTestHooks}");
-            }
+                this.settings.PartitionCount = 1;
+                this.SetCheckpointFrequency(CheckpointFrequency.None);
 
-            (int numPages, long memorySize) = this.cacheDebugger.MemoryTracker.GetMemorySize();
+                var orchestrationType = typeof(ScenarioTests.Orchestrations.SemiLargePayloadFanOutFanIn);
+                var activityType = typeof(ScenarioTests.Activities.Echo);
+                string InstanceId(int i) => $"Orch{i:D5}";
+                int OrchestrationCount = 30;
+                int FanOut = 7;
+                long historyAndStatusSize = OrchestrationCount * (FanOut * 50000 /* in history */ + 2 * 16000 /* in status */);
 
-            Assert.InRange(memorySize, historyAndStatusSize, 1.05 * historyAndStatusSize);
-            await service.StopAsync();
+                // start the service 
+                var (service, client) = await this.StartService(recover: false, orchestrationType, activityType);
+
+                // run all orchestrations
+                {
+                    var tasks = new Task[OrchestrationCount];
+                    for (int i = 0; i < OrchestrationCount; i++)
+                        tasks[i] = client.CreateOrchestrationInstanceAsync(orchestrationType, InstanceId(i), FanOut);
+                    await Task.WhenAll(tasks);
+                    for (int i = 0; i < OrchestrationCount; i++)
+                        tasks[i] = client.WaitForOrchestrationAsync(new OrchestrationInstance { InstanceId = InstanceId(i) }, TimeSpan.FromMinutes(3));
+                    await Task.WhenAll(tasks);
+                    Assert.True(this.errorInTestHooks == null, $"TestHooks detected problem while starting orchestrations: {this.errorInTestHooks}");
+                }
+
+                (int numPages, long memorySize) = this.cacheDebugger.MemoryTracker.GetMemorySize();
+
+                Assert.InRange(memorySize, historyAndStatusSize, 1.05 * historyAndStatusSize);
+                await service.StopAsync();
+            });
         }
 
 
@@ -444,64 +461,67 @@ namespace DurableTask.Netherite.Tests
         /// Fill up memory, then compute size, then reduce page count, and measure size again
         /// </summary>
         [Fact]
-        public async Task CheckMemoryReduction()
+        public Task CheckMemoryReduction()
         {
-            this.settings.PartitionCount = 1;
-            this.SetCheckpointFrequency(CheckpointFrequency.None);
-
-            int pageCountBits = 3;
-            int pageCount = 1 << pageCountBits;
-
-            // set the memory size very small so we can force evictions
-            this.settings.FasterTuningParameters = new Faster.BlobManager.FasterTuningParameters()
+            return Common.WithTimeoutAsync(DefaultTimeout, async () =>
             {
-                StoreLogPageSizeBits = 9,       // 512 B
-                StoreLogMemorySizeBits = 9 + pageCountBits,  
-            };
+                this.settings.PartitionCount = 1;
+                this.SetCheckpointFrequency(CheckpointFrequency.None);
 
-            var orchestrationType = typeof(ScenarioTests.Orchestrations.SemiLargePayloadFanOutFanIn);
-            var activityType = typeof(ScenarioTests.Activities.Echo);
-            string InstanceId(int i) => $"Orch{i:D5}";
-            int OrchestrationCount = 50;
-            int FanOut = 3;
-            long historyAndStatusSize = OrchestrationCount * (FanOut * 50000 /* in history */ + 2*16000 /* in status */);
+                int pageCountBits = 3;
+                int pageCount = 1 << pageCountBits;
 
-            // start the service 
-            var (service, client) = await this.StartService(recover: false, orchestrationType, activityType);
+                // set the memory size very small so we can force evictions
+                this.settings.FasterTuningParameters = new Faster.BlobManager.FasterTuningParameters()
+                {
+                    StoreLogPageSizeBits = 9,       // 512 B
+                    StoreLogMemorySizeBits = 9 + pageCountBits,
+                };
 
-            // run all orchestrations
-            {
-                var tasks = new Task[OrchestrationCount];
-                for (int i = 0; i < OrchestrationCount; i++)
-                    tasks[i] = client.CreateOrchestrationInstanceAsync(orchestrationType, InstanceId(i), FanOut);
-                await Task.WhenAll(tasks);
-                for (int i = 0; i < OrchestrationCount; i++)
-                    tasks[i] = client.WaitForOrchestrationAsync(new OrchestrationInstance { InstanceId = InstanceId(i) }, TimeSpan.FromMinutes(3));
-                await Task.WhenAll(tasks);
-                Assert.True(this.errorInTestHooks == null, $"TestHooks detected problem while starting orchestrations: {this.errorInTestHooks}");
-            }
+                var orchestrationType = typeof(ScenarioTests.Orchestrations.SemiLargePayloadFanOutFanIn);
+                var activityType = typeof(ScenarioTests.Activities.Echo);
+                string InstanceId(int i) => $"Orch{i:D5}";
+                int OrchestrationCount = 50;
+                int FanOut = 3;
+                long historyAndStatusSize = OrchestrationCount * (FanOut * 50000 /* in history */ + 2 * 16000 /* in status */);
+
+                // start the service 
+                var (service, client) = await this.StartService(recover: false, orchestrationType, activityType);
+
+                // run all orchestrations
+                {
+                    var tasks = new Task[OrchestrationCount];
+                    for (int i = 0; i < OrchestrationCount; i++)
+                        tasks[i] = client.CreateOrchestrationInstanceAsync(orchestrationType, InstanceId(i), FanOut);
+                    await Task.WhenAll(tasks);
+                    for (int i = 0; i < OrchestrationCount; i++)
+                        tasks[i] = client.WaitForOrchestrationAsync(new OrchestrationInstance { InstanceId = InstanceId(i) }, TimeSpan.FromMinutes(3));
+                    await Task.WhenAll(tasks);
+                    Assert.True(this.errorInTestHooks == null, $"TestHooks detected problem while starting orchestrations: {this.errorInTestHooks}");
+                }
 
 
-            {
-                (int numPages, long memorySize) = this.cacheDebugger.MemoryTracker.GetMemorySize();
-                Assert.InRange(numPages, 1, pageCount);
-                Assert.InRange(memorySize, 0, historyAndStatusSize * 1.1);
-            }
+                {
+                    (int numPages, long memorySize) = this.cacheDebugger.MemoryTracker.GetMemorySize();
+                    Assert.InRange(numPages, 1, pageCount);
+                    Assert.InRange(memorySize, 0, historyAndStatusSize * 1.1);
+                }
 
-            int emptyPageCount = 0;
-            int tolerance = 1; 
+                int emptyPageCount = 0;
+                int tolerance = 1;
 
-            for (int i = 0; i < 4; i++)
-            {
-                emptyPageCount++;
-                this.cacheDebugger.MemoryTracker.SetEmptyPageCount(emptyPageCount);
-                await Task.Delay(TimeSpan.FromSeconds(20));
-                (int numPages, long memorySize) = this.cacheDebugger.MemoryTracker.GetMemorySize();
-                Assert.InRange(numPages, 1, pageCount - emptyPageCount + tolerance);
-                Assert.InRange(memorySize, 0, historyAndStatusSize * 1.1);
-            }
+                for (int i = 0; i < 4; i++)
+                {
+                    emptyPageCount++;
+                    this.cacheDebugger.MemoryTracker.SetEmptyPageCount(emptyPageCount);
+                    await Task.Delay(TimeSpan.FromSeconds(20));
+                    (int numPages, long memorySize) = this.cacheDebugger.MemoryTracker.GetMemorySize();
+                    Assert.InRange(numPages, 1, pageCount - emptyPageCount + tolerance);
+                    Assert.InRange(memorySize, 0, historyAndStatusSize * 1.1);
+                }
 
-            await service.StopAsync();
+                await service.StopAsync();
+            });
         }
 
         /// <summary>
@@ -510,182 +530,188 @@ namespace DurableTask.Netherite.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public async Task CheckMemoryControl(bool useSpaceConsumingOrchestrations)
+        public Task CheckMemoryControl(bool useSpaceConsumingOrchestrations)
         {
-            this.settings.PartitionCount = 1;
-            this.settings.FasterTuningParameters = new BlobManager.FasterTuningParameters()
+            return Common.WithTimeoutAsync(DefaultTimeout, async () =>
             {
-                StoreLogPageSizeBits = 10
-            };
-            this.SetCheckpointFrequency(CheckpointFrequency.None);
-            this.settings.TestHooks.CacheDebugger.EnableSizeChecking = false; // our size checker is not entirely accurate in low-memory situationss
-
-            Type orchestrationType, activityType;
-            long SizePerInstance;
-            object input;
-            int portionSize;
-            double uppertolerance;
-            double lowertolerance;
-
-            if (useSpaceConsumingOrchestrations)
-            {
-                this.settings.InstanceCacheSizeMB = 4;
-                orchestrationType = typeof(ScenarioTests.Orchestrations.SemiLargePayloadFanOutFanIn);
-                activityType = typeof(ScenarioTests.Activities.Echo);
-                int FanOut = 1;
-                input = FanOut;
-                SizePerInstance = FanOut * 50000 /* in history */ + 16000 /* in status */;
-                portionSize = 50;
-                uppertolerance = 1.1;
-                lowertolerance = 0;
-
-            }
-            else
-            {
-                this.settings.InstanceCacheSizeMB = 2;
-                orchestrationType = typeof(ScenarioTests.Orchestrations.Hello5);
-                activityType = typeof(ScenarioTests.Activities.Hello);
-                SizePerInstance = 3610 /* empiric */;
-                input = null;
-                portionSize = 300;
-                uppertolerance = 1.1;
-                lowertolerance = 0.5;
-            }
-
-            // start the service 
-            var (service, client) = await this.StartService(recover: false, orchestrationType, activityType);
-
-            int logBytesPerInstance = 2 * 40;
-            long memoryPerPage = ((1 << this.settings.FasterTuningParameters.StoreLogPageSizeBits.Value) / logBytesPerInstance) * SizePerInstance;
-            double memoryRangeTo = (this.settings.InstanceCacheSizeMB.Value - 1) * 1024 * 1024;
-            double memoryRangeFrom = (memoryRangeTo - memoryPerPage);
-            memoryRangeTo = Math.Max(memoryRangeTo, MemoryTracker.MinimumMemoryPages * memoryPerPage);
-            memoryRangeTo = uppertolerance * memoryRangeTo;
-            memoryRangeFrom = lowertolerance * memoryRangeFrom;
-            double pageRangeFrom = Math.Max(MemoryTracker.MinimumMemoryPages, Math.Floor(memoryRangeFrom / memoryPerPage));
-            double pageRangeTo = Math.Ceiling(memoryRangeTo / memoryPerPage);
-
-            async Task AddOrchestrationsAsync(int numOrchestrations)
-            { 
-                var tasks = new Task<OrchestrationInstance>[numOrchestrations];
-                for (int i = 0; i < numOrchestrations; i++)
-                    tasks[i] = client.CreateOrchestrationInstanceAsync(orchestrationType, Guid.NewGuid().ToString(), input);
-                await Task.WhenAll(tasks);
-                Assert.True(this.errorInTestHooks == null, $"TestHooks detected problem while starting orchestrations: {this.errorInTestHooks}");
-                var tasks2 = new Task<OrchestrationState>[numOrchestrations];
-                for (int i = 0; i < numOrchestrations; i++)
-                    tasks2[i] = client.WaitForOrchestrationAsync(tasks[i].Result, TimeSpan.FromMinutes(3));
-                await Task.WhenAll(tasks2);
-                Assert.True(this.errorInTestHooks == null, $"TestHooks detected problem while waiting for orchestrations: {this.errorInTestHooks}");
-            }
-
-            for (int i = 0; i < 4; i++)
-            {
-                this.output("memory control ------------------- Add orchestrations");
+                this.settings.PartitionCount = 1;
+                this.settings.FasterTuningParameters = new BlobManager.FasterTuningParameters()
                 {
-                    await AddOrchestrationsAsync(portionSize);
+                    StoreLogPageSizeBits = 10
+                };
+                this.SetCheckpointFrequency(CheckpointFrequency.None);
+                this.settings.TestHooks.CacheDebugger.EnableSizeChecking = false; // our size checker is not entirely accurate in low-memory situationss
 
-                    this.output("memory control -------- wait for effect");
-                    await Task.Delay(TimeSpan.FromSeconds(10));
+                Type orchestrationType, activityType;
+                long SizePerInstance;
+                object input;
+                int portionSize;
+                double uppertolerance;
+                double lowertolerance;
 
-                    this.output("memory control -------- check memory size");
-                    (int numPages, long memorySize) = this.cacheDebugger.MemoryTracker.GetMemorySize();
+                if (useSpaceConsumingOrchestrations)
+                {
+                    this.settings.InstanceCacheSizeMB = 4;
+                    orchestrationType = typeof(ScenarioTests.Orchestrations.SemiLargePayloadFanOutFanIn);
+                    activityType = typeof(ScenarioTests.Activities.Echo);
+                    int FanOut = 1;
+                    input = FanOut;
+                    SizePerInstance = FanOut * 50000 /* in history */ + 16000 /* in status */;
+                    portionSize = 50;
+                    uppertolerance = 1.1;
+                    lowertolerance = 0;
 
-                    Assert.InRange(numPages, pageRangeFrom, pageRangeTo);
-                    Assert.InRange(memorySize, memoryRangeFrom, memoryRangeTo);
                 }
-            }       
+                else
+                {
+                    this.settings.InstanceCacheSizeMB = 2;
+                    orchestrationType = typeof(ScenarioTests.Orchestrations.Hello5);
+                    activityType = typeof(ScenarioTests.Activities.Hello);
+                    SizePerInstance = 3610 /* empiric */;
+                    input = null;
+                    portionSize = 300;
+                    uppertolerance = 1.1;
+                    lowertolerance = 0.5;
+                }
 
-            await service.StopAsync();
+                // start the service 
+                var (service, client) = await this.StartService(recover: false, orchestrationType, activityType);
+
+                int logBytesPerInstance = 2 * 40;
+                long memoryPerPage = ((1 << this.settings.FasterTuningParameters.StoreLogPageSizeBits.Value) / logBytesPerInstance) * SizePerInstance;
+                double memoryRangeTo = (this.settings.InstanceCacheSizeMB.Value - 1) * 1024 * 1024;
+                double memoryRangeFrom = (memoryRangeTo - memoryPerPage);
+                memoryRangeTo = Math.Max(memoryRangeTo, MemoryTracker.MinimumMemoryPages * memoryPerPage);
+                memoryRangeTo = uppertolerance * memoryRangeTo;
+                memoryRangeFrom = lowertolerance * memoryRangeFrom;
+                double pageRangeFrom = Math.Max(MemoryTracker.MinimumMemoryPages, Math.Floor(memoryRangeFrom / memoryPerPage));
+                double pageRangeTo = Math.Ceiling(memoryRangeTo / memoryPerPage);
+
+                async Task AddOrchestrationsAsync(int numOrchestrations)
+                {
+                    var tasks = new Task<OrchestrationInstance>[numOrchestrations];
+                    for (int i = 0; i < numOrchestrations; i++)
+                        tasks[i] = client.CreateOrchestrationInstanceAsync(orchestrationType, Guid.NewGuid().ToString(), input);
+                    await Task.WhenAll(tasks);
+                    Assert.True(this.errorInTestHooks == null, $"TestHooks detected problem while starting orchestrations: {this.errorInTestHooks}");
+                    var tasks2 = new Task<OrchestrationState>[numOrchestrations];
+                    for (int i = 0; i < numOrchestrations; i++)
+                        tasks2[i] = client.WaitForOrchestrationAsync(tasks[i].Result, TimeSpan.FromMinutes(3));
+                    await Task.WhenAll(tasks2);
+                    Assert.True(this.errorInTestHooks == null, $"TestHooks detected problem while waiting for orchestrations: {this.errorInTestHooks}");
+                }
+
+                for (int i = 0; i < 4; i++)
+                {
+                    this.output("memory control ------------------- Add orchestrations");
+                    {
+                        await AddOrchestrationsAsync(portionSize);
+
+                        this.output("memory control -------- wait for effect");
+                        await Task.Delay(TimeSpan.FromSeconds(10));
+
+                        this.output("memory control -------- check memory size");
+                        (int numPages, long memorySize) = this.cacheDebugger.MemoryTracker.GetMemorySize();
+
+                        Assert.InRange(numPages, pageRangeFrom, pageRangeTo);
+                        Assert.InRange(memorySize, memoryRangeFrom, memoryRangeTo);
+                    }
+                }
+
+                await service.StopAsync();
+            });
         }
 
         /// <summary>
         /// Test behavior of queries and point queries
         /// </summary>
         [Fact]
-        public async Task QueriesCopyToTail()
+        public Task QueriesCopyToTail()
         {
-            this.settings.PartitionCount = 1;
-            this.SetCheckpointFrequency(CheckpointFrequency.None);
-
-            var checkpointInjector = this.settings.TestHooks.CheckpointInjector = new Faster.CheckpointInjector(this.settings.TestHooks);
-
-            var orchestrationType = typeof(ScenarioTests.Orchestrations.SayHelloFanOutFanIn);
-            var orchestrationType2 = typeof(ScenarioTests.Orchestrations.SayHelloInline);
-
+            return Common.WithTimeoutAsync(DefaultTimeout, async () =>
             {
-                // start the service 
-                var service = new NetheriteOrchestrationService(this.settings, this.loggerFactory);
-                var orchestrationService = (IOrchestrationService)service;
-                var orchestrationServiceClient = (IOrchestrationServiceClient)service;
-                var orchestrationServiceQueryClient = (IOrchestrationServiceQueryClient)service;
-                await orchestrationService.CreateAsync();
-                await orchestrationService.StartAsync();
-                var host = (TransportAbstraction.IHost)service;
-                Assert.Equal(1u, service.NumberPartitions);
-                var worker = new TaskHubWorker(service);
-                var client = new TaskHubClient(service);
-                worker.AddTaskOrchestrations(orchestrationType);
-                worker.AddTaskOrchestrations(orchestrationType2);
-                await worker.StartAsync();
+                this.settings.PartitionCount = 1;
+                this.SetCheckpointFrequency(CheckpointFrequency.None);
 
-                int numExtraEntries = 0;
+                var checkpointInjector = this.settings.TestHooks.CheckpointInjector = new Faster.CheckpointInjector(this.settings.TestHooks);
 
-                // check that log contains no records
-                var log = await checkpointInjector.InjectAsync(log => (Faster.StoreWorker.CheckpointTrigger.None, null));
-                Assert.Equal(0 * log.FixedRecordSize + numExtraEntries * extraLogEntrySize, log.TailAddress - log.BeginAddress);
+                var orchestrationType = typeof(ScenarioTests.Orchestrations.SayHelloFanOutFanIn);
+                var orchestrationType2 = typeof(ScenarioTests.Orchestrations.SayHelloInline);
 
-                // create 100 instances
-                var instance = await client.CreateOrchestrationInstanceAsync(orchestrationType, "parent", 99);
-                await client.WaitForOrchestrationAsync(instance, TimeSpan.FromSeconds(40));
-                var instances = await orchestrationServiceQueryClient.GetAllOrchestrationStatesAsync(CancellationToken.None);
-                numExtraEntries += 2;
-                Assert.Equal(100, instances.Count);
+                {
+                    // start the service 
+                    var service = new NetheriteOrchestrationService(this.settings, this.loggerFactory);
+                    var orchestrationService = (IOrchestrationService)service;
+                    var orchestrationServiceClient = (IOrchestrationServiceClient)service;
+                    var orchestrationServiceQueryClient = (IOrchestrationServiceQueryClient)service;
+                    await orchestrationService.CreateAsync();
+                    await orchestrationService.StartAsync();
+                    var host = (TransportAbstraction.IHost)service;
+                    Assert.Equal(1u, service.NumberPartitions);
+                    var worker = new TaskHubWorker(service);
+                    var client = new TaskHubClient(service);
+                    worker.AddTaskOrchestrations(orchestrationType);
+                    worker.AddTaskOrchestrations(orchestrationType2);
+                    await worker.StartAsync();
 
-                // check that log contains 200 records
-                log = await checkpointInjector.InjectAsync(log => (Faster.StoreWorker.CheckpointTrigger.None, null));
-                Assert.Equal(200 * log.FixedRecordSize + numExtraEntries * extraLogEntrySize, log.TailAddress - log.BeginAddress);
-                Assert.Equal(log.ReadOnlyAddress, log.BeginAddress);
+                    int numExtraEntries = 0;
 
-                // take a foldover checkpoint
-                log = await checkpointInjector.InjectAsync(log => (Faster.StoreWorker.CheckpointTrigger.Idle, null));
-                Assert.Equal(200 * log.FixedRecordSize + numExtraEntries * extraLogEntrySize, log.TailAddress - log.BeginAddress);
-                Assert.Equal(log.ReadOnlyAddress, log.TailAddress);
+                    // check that log contains no records
+                    var log = await checkpointInjector.InjectAsync(log => (Faster.StoreWorker.CheckpointTrigger.None, null));
+                    Assert.Equal(0 * log.FixedRecordSize + numExtraEntries * extraLogEntrySize, log.TailAddress - log.BeginAddress);
 
-                // read all instances using a query and check that the log did not grow
-                // (because queries do not copy to tail)
-                instances = await orchestrationServiceQueryClient.GetAllOrchestrationStatesAsync(CancellationToken.None);
-                Assert.Equal(100, instances.Count);
-                log = await checkpointInjector.InjectAsync(log => (Faster.StoreWorker.CheckpointTrigger.None, null));
-                Assert.Equal(200 * log.FixedRecordSize + numExtraEntries * extraLogEntrySize, log.TailAddress - log.BeginAddress);
-                Assert.Equal(log.ReadOnlyAddress, log.TailAddress);
+                    // create 100 instances
+                    var instance = await client.CreateOrchestrationInstanceAsync(orchestrationType, "parent", 99);
+                    await client.WaitForOrchestrationAsync(instance, TimeSpan.FromSeconds(40));
+                    var instances = await orchestrationServiceQueryClient.GetAllOrchestrationStatesAsync(CancellationToken.None);
+                    numExtraEntries += 2;
+                    Assert.Equal(100, instances.Count);
 
-                // read all instances using point queries and check that the log grew by one record per instance
-                // (because point queries read the InstanceState on the main session, which copies it to the tail)
-                var tasks = instances.Select(instance => orchestrationServiceClient.GetOrchestrationStateAsync(instance.OrchestrationInstance.InstanceId, false));
-                await Task.WhenAll(tasks);
-                log = await checkpointInjector.InjectAsync(log => (Faster.StoreWorker.CheckpointTrigger.None, null));
-                numExtraEntries += 1;
-                Assert.Equal(300 * log.FixedRecordSize + numExtraEntries * extraLogEntrySize, log.TailAddress - log.BeginAddress);
-                Assert.Equal(log.ReadOnlyAddress, log.TailAddress - 100 * log.FixedRecordSize - 1 * extraLogEntrySize);
+                    // check that log contains 200 records
+                    log = await checkpointInjector.InjectAsync(log => (Faster.StoreWorker.CheckpointTrigger.None, null));
+                    Assert.Equal(200 * log.FixedRecordSize + numExtraEntries * extraLogEntrySize, log.TailAddress - log.BeginAddress);
+                    Assert.Equal(log.ReadOnlyAddress, log.BeginAddress);
 
-                // doing the same again has no effect
-                // (because all instances are already in the mutable section)
-                tasks = instances.Select(instance => orchestrationServiceClient.GetOrchestrationStateAsync(instance.OrchestrationInstance.InstanceId, false));
-                await Task.WhenAll(tasks);
-                log = await checkpointInjector.InjectAsync(log => (Faster.StoreWorker.CheckpointTrigger.None, null));
-                Assert.Equal(300 * log.FixedRecordSize + numExtraEntries * extraLogEntrySize, log.TailAddress - log.BeginAddress);
-                Assert.Equal(log.ReadOnlyAddress, log.TailAddress - 100 * log.FixedRecordSize - 1 * extraLogEntrySize);
+                    // take a foldover checkpoint
+                    log = await checkpointInjector.InjectAsync(log => (Faster.StoreWorker.CheckpointTrigger.Idle, null));
+                    Assert.Equal(200 * log.FixedRecordSize + numExtraEntries * extraLogEntrySize, log.TailAddress - log.BeginAddress);
+                    Assert.Equal(log.ReadOnlyAddress, log.TailAddress);
 
-                // take a foldover checkpoint
-                // this moves the readonly section back to the end
-                log = await checkpointInjector.InjectAsync(log => (Faster.StoreWorker.CheckpointTrigger.Idle, null));
-                Assert.Equal(300 * log.FixedRecordSize + numExtraEntries * extraLogEntrySize, log.TailAddress - log.BeginAddress);
-                Assert.Equal(log.ReadOnlyAddress, log.TailAddress);
+                    // read all instances using a query and check that the log did not grow
+                    // (because queries do not copy to tail)
+                    instances = await orchestrationServiceQueryClient.GetAllOrchestrationStatesAsync(CancellationToken.None);
+                    Assert.Equal(100, instances.Count);
+                    log = await checkpointInjector.InjectAsync(log => (Faster.StoreWorker.CheckpointTrigger.None, null));
+                    Assert.Equal(200 * log.FixedRecordSize + numExtraEntries * extraLogEntrySize, log.TailAddress - log.BeginAddress);
+                    Assert.Equal(log.ReadOnlyAddress, log.TailAddress);
 
-                // stop the service
-                await orchestrationService.StopAsync();
-            }
+                    // read all instances using point queries and check that the log grew by one record per instance
+                    // (because point queries read the InstanceState on the main session, which copies it to the tail)
+                    var tasks = instances.Select(instance => orchestrationServiceClient.GetOrchestrationStateAsync(instance.OrchestrationInstance.InstanceId, false));
+                    await Task.WhenAll(tasks);
+                    log = await checkpointInjector.InjectAsync(log => (Faster.StoreWorker.CheckpointTrigger.None, null));
+                    numExtraEntries += 1;
+                    Assert.Equal(300 * log.FixedRecordSize + numExtraEntries * extraLogEntrySize, log.TailAddress - log.BeginAddress);
+                    Assert.Equal(log.ReadOnlyAddress, log.TailAddress - 100 * log.FixedRecordSize - 1 * extraLogEntrySize);
+
+                    // doing the same again has no effect
+                    // (because all instances are already in the mutable section)
+                    tasks = instances.Select(instance => orchestrationServiceClient.GetOrchestrationStateAsync(instance.OrchestrationInstance.InstanceId, false));
+                    await Task.WhenAll(tasks);
+                    log = await checkpointInjector.InjectAsync(log => (Faster.StoreWorker.CheckpointTrigger.None, null));
+                    Assert.Equal(300 * log.FixedRecordSize + numExtraEntries * extraLogEntrySize, log.TailAddress - log.BeginAddress);
+                    Assert.Equal(log.ReadOnlyAddress, log.TailAddress - 100 * log.FixedRecordSize - 1 * extraLogEntrySize);
+
+                    // take a foldover checkpoint
+                    // this moves the readonly section back to the end
+                    log = await checkpointInjector.InjectAsync(log => (Faster.StoreWorker.CheckpointTrigger.Idle, null));
+                    Assert.Equal(300 * log.FixedRecordSize + numExtraEntries * extraLogEntrySize, log.TailAddress - log.BeginAddress);
+                    Assert.Equal(log.ReadOnlyAddress, log.TailAddress);
+
+                    // stop the service
+                    await orchestrationService.StopAsync();
+                }
+            });
         }
 
 
@@ -693,187 +719,193 @@ namespace DurableTask.Netherite.Tests
         /// Test log compaction
         /// </summary>
         [Fact]
-        public async Task Compaction()
+        public Task Compaction()
         {
-            this.settings.PartitionCount = 1;
-            this.SetCheckpointFrequency(CheckpointFrequency.None);
-            
-            var checkpointInjector = this.settings.TestHooks.CheckpointInjector = new Faster.CheckpointInjector(this.settings.TestHooks);
-
-            var orchestrationType = typeof(ScenarioTests.Orchestrations.SayHelloFanOutFanIn);
-            var orchestrationType2 = typeof(ScenarioTests.Orchestrations.SayHelloInline);
-
-            long compactUntil = 0;
+            return Common.WithTimeoutAsync(DefaultTimeout, async () =>
             {
-                // start the service 
-                var service = new NetheriteOrchestrationService(this.settings, this.loggerFactory);
-                var orchestrationService = (IOrchestrationService)service;
-                var orchestrationServiceClient = (IOrchestrationServiceClient)service;
-                var orchestrationServiceQueryClient = (IOrchestrationServiceQueryClient)service;
-                await orchestrationService.CreateAsync();
-                await orchestrationService.StartAsync();
-                var host = (TransportAbstraction.IHost)service;
-                Assert.Equal(1u, service.NumberPartitions);
-                var worker = new TaskHubWorker(service);
-                var client = new TaskHubClient(service);
-                worker.AddTaskOrchestrations(orchestrationType);
-                worker.AddTaskOrchestrations(orchestrationType2);
-                await worker.StartAsync();
+                this.settings.PartitionCount = 1;
+                this.SetCheckpointFrequency(CheckpointFrequency.None);
 
-                // create 100 instances
-                var instance = await client.CreateOrchestrationInstanceAsync(orchestrationType, "parent", 99);
-                await client.WaitForOrchestrationAsync(instance, TimeSpan.FromSeconds(40));
-                var instances = await orchestrationServiceQueryClient.GetAllOrchestrationStatesAsync(CancellationToken.None);
-                Assert.Equal(100, instances.Count);
+                var checkpointInjector = this.settings.TestHooks.CheckpointInjector = new Faster.CheckpointInjector(this.settings.TestHooks);
 
-                int numExtraEntries = 1;
+                var orchestrationType = typeof(ScenarioTests.Orchestrations.SayHelloFanOutFanIn);
+                var orchestrationType2 = typeof(ScenarioTests.Orchestrations.SayHelloInline);
 
-                // repeat foldover and copy to tail to inflate the log
-                for (int i = 0; i < 4; i++)
+                long compactUntil = 0;
                 {
-                    // take a foldover checkpoint
-                    var log2 = await checkpointInjector.InjectAsync(log => (Faster.StoreWorker.CheckpointTrigger.Idle, null));
-                    numExtraEntries += 1;
-                    Assert.Equal((200 + (100 * i)) * log2.FixedRecordSize + numExtraEntries * extraLogEntrySize, log2.TailAddress - log2.BeginAddress);
-                    Assert.Equal(log2.ReadOnlyAddress, log2.TailAddress);
+                    // start the service 
+                    var service = new NetheriteOrchestrationService(this.settings, this.loggerFactory);
+                    var orchestrationService = (IOrchestrationService)service;
+                    var orchestrationServiceClient = (IOrchestrationServiceClient)service;
+                    var orchestrationServiceQueryClient = (IOrchestrationServiceQueryClient)service;
+                    await orchestrationService.CreateAsync();
+                    await orchestrationService.StartAsync();
+                    var host = (TransportAbstraction.IHost)service;
+                    Assert.Equal(1u, service.NumberPartitions);
+                    var worker = new TaskHubWorker(service);
+                    var client = new TaskHubClient(service);
+                    worker.AddTaskOrchestrations(orchestrationType);
+                    worker.AddTaskOrchestrations(orchestrationType2);
+                    await worker.StartAsync();
 
-                    // read all instances using point queries to force copy to tail
-                    var tasks = instances.Select(instance => orchestrationServiceClient.GetOrchestrationStateAsync(instance.OrchestrationInstance.InstanceId, false));
-                    await Task.WhenAll(tasks);
+                    // create 100 instances
+                    var instance = await client.CreateOrchestrationInstanceAsync(orchestrationType, "parent", 99);
+                    await client.WaitForOrchestrationAsync(instance, TimeSpan.FromSeconds(40));
+                    var instances = await orchestrationServiceQueryClient.GetAllOrchestrationStatesAsync(CancellationToken.None);
+                    Assert.Equal(100, instances.Count);
+
+                    int numExtraEntries = 1;
+
+                    // repeat foldover and copy to tail to inflate the log
+                    for (int i = 0; i < 4; i++)
+                    {
+                        // take a foldover checkpoint
+                        var log2 = await checkpointInjector.InjectAsync(log => (Faster.StoreWorker.CheckpointTrigger.Idle, null));
+                        numExtraEntries += 1;
+                        Assert.Equal((200 + (100 * i)) * log2.FixedRecordSize + numExtraEntries * extraLogEntrySize, log2.TailAddress - log2.BeginAddress);
+                        Assert.Equal(log2.ReadOnlyAddress, log2.TailAddress);
+
+                        // read all instances using point queries to force copy to tail
+                        var tasks = instances.Select(instance => orchestrationServiceClient.GetOrchestrationStateAsync(instance.OrchestrationInstance.InstanceId, false));
+                        await Task.WhenAll(tasks);
+                    }
+
+                    // do log compaction
+                    var log = await checkpointInjector.InjectAsync(log =>
+                    {
+                        compactUntil = 500 * log.FixedRecordSize + log.BeginAddress + numExtraEntries * extraLogEntrySize;
+                        Assert.Equal(compactUntil, log.SafeReadOnlyAddress);
+                        return (Faster.StoreWorker.CheckpointTrigger.Compaction, compactUntil);
+                    });
+
+                    // check that the compaction had the desired effect
+                    numExtraEntries = 2;
+                    Assert.Equal(200 * log.FixedRecordSize + numExtraEntries * extraLogEntrySize, log.TailAddress - log.BeginAddress);
+                    Assert.Equal(compactUntil, log.BeginAddress);
+                    Assert.Equal(log.ReadOnlyAddress, log.TailAddress);
+
+                    // stop the service
+                    await orchestrationService.StopAsync();
                 }
-
-                // do log compaction
-                var log = await checkpointInjector.InjectAsync(log =>
                 {
-                    compactUntil = 500 * log.FixedRecordSize + log.BeginAddress + numExtraEntries * extraLogEntrySize;
-                    Assert.Equal(compactUntil, log.SafeReadOnlyAddress);
-                    return (Faster.StoreWorker.CheckpointTrigger.Compaction, compactUntil);
-                });
+                    // recover the service
+                    var service = new NetheriteOrchestrationService(this.settings, this.loggerFactory);
+                    var orchestrationService = (IOrchestrationService)service;
+                    var orchestrationServiceQueryClient = (IOrchestrationServiceQueryClient)service;
+                    await orchestrationService.StartAsync();
+                    var host = (TransportAbstraction.IHost)service;
+                    Assert.Equal(1u, service.NumberPartitions);
 
-                // check that the compaction had the desired effect
-                numExtraEntries = 2;
-                Assert.Equal(200 * log.FixedRecordSize + numExtraEntries * extraLogEntrySize, log.TailAddress - log.BeginAddress);
-                Assert.Equal(compactUntil, log.BeginAddress);
-                Assert.Equal(log.ReadOnlyAddress, log.TailAddress);
+                    int numExtraEntries = 2;
 
-                // stop the service
-                await orchestrationService.StopAsync();
-            }
-            {
-                // recover the service
-                var service = new NetheriteOrchestrationService(this.settings, this.loggerFactory);
-                var orchestrationService = (IOrchestrationService)service;
-                var orchestrationServiceQueryClient = (IOrchestrationServiceQueryClient)service;
-                await orchestrationService.StartAsync();
-                var host = (TransportAbstraction.IHost)service;
-                Assert.Equal(1u, service.NumberPartitions);
+                    // check the log positions
+                    var log = await checkpointInjector.InjectAsync(log => (Faster.StoreWorker.CheckpointTrigger.None, null));
+                    Assert.Equal(200 * log.FixedRecordSize + numExtraEntries * extraLogEntrySize, log.TailAddress - log.BeginAddress);
+                    Assert.Equal(compactUntil, log.BeginAddress);
+                    Assert.Equal(log.ReadOnlyAddress, log.TailAddress);
 
-                int numExtraEntries = 2;
+                    // check the instance count
+                    var instances = await orchestrationServiceQueryClient.GetAllOrchestrationStatesAsync(CancellationToken.None);
+                    Assert.Equal(100, instances.Count);
 
-                // check the log positions
-                var log = await checkpointInjector.InjectAsync(log => (Faster.StoreWorker.CheckpointTrigger.None, null));
-                Assert.Equal(200 * log.FixedRecordSize + numExtraEntries * extraLogEntrySize, log.TailAddress - log.BeginAddress);
-                Assert.Equal(compactUntil, log.BeginAddress);
-                Assert.Equal(log.ReadOnlyAddress, log.TailAddress);
-
-                // check the instance count
-                var instances = await orchestrationServiceQueryClient.GetAllOrchestrationStatesAsync(CancellationToken.None);
-                Assert.Equal(100, instances.Count);
-              
-                // stop the service
-                await orchestrationService.StopAsync();
-            }
+                    // stop the service
+                    await orchestrationService.StopAsync();
+                }
+            });
         }
 
         /// <summary>
         /// Test log compaction that fails right after compaction
         /// </summary>
         [Fact]
-        public async Task CompactThenFail()
+        public Task CompactThenFail()
         {
-            this.settings.PartitionCount = 1;
-            this.SetCheckpointFrequency(CheckpointFrequency.None);
-
-            var checkpointInjector = this.settings.TestHooks.CheckpointInjector = new Faster.CheckpointInjector(this.settings.TestHooks);
-
-            var orchestrationType = typeof(ScenarioTests.Orchestrations.SayHelloFanOutFanIn);
-            var orchestrationType2 = typeof(ScenarioTests.Orchestrations.SayHelloInline);
-
-            long currentTail = 0;
-            long currentBegin = 0;
-
-            long compactUntil = 0;
+            return Common.WithTimeoutAsync(DefaultTimeout, async () =>
             {
-                // start the service 
-                var service = new NetheriteOrchestrationService(this.settings, this.loggerFactory);
-                var orchestrationService = (IOrchestrationService)service;
-                var orchestrationServiceClient = (IOrchestrationServiceClient)service;
-                var orchestrationServiceQueryClient = (IOrchestrationServiceQueryClient)service;
-                await orchestrationService.CreateAsync();
-                await orchestrationService.StartAsync();
-                var host = (TransportAbstraction.IHost)service;
-                Assert.Equal(1u, service.NumberPartitions);
-                var worker = new TaskHubWorker(service);
-                var client = new TaskHubClient(service);
-                worker.AddTaskOrchestrations(orchestrationType);
-                worker.AddTaskOrchestrations(orchestrationType2);
-                await worker.StartAsync();
+                this.settings.PartitionCount = 1;
+                this.SetCheckpointFrequency(CheckpointFrequency.None);
 
-                // create 100 instances
-                var instance = await client.CreateOrchestrationInstanceAsync(orchestrationType, "parent", 99);
-                await client.WaitForOrchestrationAsync(instance, TimeSpan.FromSeconds(40));
-                var instances = await orchestrationServiceQueryClient.GetAllOrchestrationStatesAsync(CancellationToken.None);
-                Assert.Equal(100, instances.Count);
+                var checkpointInjector = this.settings.TestHooks.CheckpointInjector = new Faster.CheckpointInjector(this.settings.TestHooks);
 
-                int numExtraEntries = 1;
+                var orchestrationType = typeof(ScenarioTests.Orchestrations.SayHelloFanOutFanIn);
+                var orchestrationType2 = typeof(ScenarioTests.Orchestrations.SayHelloInline);
 
+                long currentTail = 0;
+                long currentBegin = 0;
 
-                // repeat foldover and copy to tail to inflate the log
-                for (int i = 0; i < 4; i++)
+                long compactUntil = 0;
                 {
-                    // take a foldover checkpoint
-                    var log2 = await checkpointInjector.InjectAsync(log => (Faster.StoreWorker.CheckpointTrigger.Idle, null));
-                    numExtraEntries += 1;
-                    Assert.Equal((200 + (100 * i)) * log2.FixedRecordSize + numExtraEntries * extraLogEntrySize, log2.TailAddress - log2.BeginAddress);
-                    Assert.Equal(log2.ReadOnlyAddress, log2.TailAddress);
+                    // start the service 
+                    var service = new NetheriteOrchestrationService(this.settings, this.loggerFactory);
+                    var orchestrationService = (IOrchestrationService)service;
+                    var orchestrationServiceClient = (IOrchestrationServiceClient)service;
+                    var orchestrationServiceQueryClient = (IOrchestrationServiceQueryClient)service;
+                    await orchestrationService.CreateAsync();
+                    await orchestrationService.StartAsync();
+                    var host = (TransportAbstraction.IHost)service;
+                    Assert.Equal(1u, service.NumberPartitions);
+                    var worker = new TaskHubWorker(service);
+                    var client = new TaskHubClient(service);
+                    worker.AddTaskOrchestrations(orchestrationType);
+                    worker.AddTaskOrchestrations(orchestrationType2);
+                    await worker.StartAsync();
 
-                    currentTail = log2.TailAddress;
-                    currentBegin = log2.BeginAddress;
+                    // create 100 instances
+                    var instance = await client.CreateOrchestrationInstanceAsync(orchestrationType, "parent", 99);
+                    await client.WaitForOrchestrationAsync(instance, TimeSpan.FromSeconds(40));
+                    var instances = await orchestrationServiceQueryClient.GetAllOrchestrationStatesAsync(CancellationToken.None);
+                    Assert.Equal(100, instances.Count);
 
-                    // read all instances using point queries to force copy to tail
-                    var tasks = instances.Select(instance => orchestrationServiceClient.GetOrchestrationStateAsync(instance.OrchestrationInstance.InstanceId, false));
-                    await Task.WhenAll(tasks);
+                    int numExtraEntries = 1;
+
+
+                    // repeat foldover and copy to tail to inflate the log
+                    for (int i = 0; i < 4; i++)
+                    {
+                        // take a foldover checkpoint
+                        var log2 = await checkpointInjector.InjectAsync(log => (Faster.StoreWorker.CheckpointTrigger.Idle, null));
+                        numExtraEntries += 1;
+                        Assert.Equal((200 + (100 * i)) * log2.FixedRecordSize + numExtraEntries * extraLogEntrySize, log2.TailAddress - log2.BeginAddress);
+                        Assert.Equal(log2.ReadOnlyAddress, log2.TailAddress);
+
+                        currentTail = log2.TailAddress;
+                        currentBegin = log2.BeginAddress;
+
+                        // read all instances using point queries to force copy to tail
+                        var tasks = instances.Select(instance => orchestrationServiceClient.GetOrchestrationStateAsync(instance.OrchestrationInstance.InstanceId, false));
+                        await Task.WhenAll(tasks);
+                    }
+
+                    // do log compaction
+                    var log = await checkpointInjector.InjectAsync(log =>
+                    {
+                        compactUntil = 500 * log.FixedRecordSize + log.BeginAddress + numExtraEntries * extraLogEntrySize;
+                        Assert.Equal(compactUntil, log.SafeReadOnlyAddress);
+                        return (Faster.StoreWorker.CheckpointTrigger.Compaction, compactUntil);
+                    },
+                    injectFailureAfterCompaction:true);
+
+                    await orchestrationService.StopAsync();
                 }
 
-                // do log compaction
-                var log = await checkpointInjector.InjectAsync(log =>
                 {
-                    compactUntil = 500 * log.FixedRecordSize + log.BeginAddress + numExtraEntries * extraLogEntrySize;
-                    Assert.Equal(compactUntil, log.SafeReadOnlyAddress);
-                    return (Faster.StoreWorker.CheckpointTrigger.Compaction, compactUntil);
-                },
-                injectFailureAfterCompaction:true);
+                    // recover the service 
+                    var service = new NetheriteOrchestrationService(this.settings, this.loggerFactory);
+                    var orchestrationService = (IOrchestrationService)service;
+                    var orchestrationServiceClient = (IOrchestrationServiceClient)service;
+                    await orchestrationService.StartAsync();
+                    Assert.Equal(this.settings.PartitionCount, (int)service.NumberPartitions);
+                    var worker = new TaskHubWorker(service);
+                    var client = new TaskHubClient(service);
+                    await worker.StartAsync();
 
-                await orchestrationService.StopAsync();
-            }
+                    // check that begin and tail are the same
+                    var log = await checkpointInjector.InjectAsync(log => (Faster.StoreWorker.CheckpointTrigger.None, null));
 
-            {
-                // recover the service 
-                var service = new NetheriteOrchestrationService(this.settings, this.loggerFactory);
-                var orchestrationService = (IOrchestrationService)service;
-                var orchestrationServiceClient = (IOrchestrationServiceClient)service;
-                await orchestrationService.StartAsync();
-                Assert.Equal(this.settings.PartitionCount, (int)service.NumberPartitions);
-                var worker = new TaskHubWorker(service);
-                var client = new TaskHubClient(service);
-                await worker.StartAsync();
-
-                // check that begin and tail are the same
-                var log = await checkpointInjector.InjectAsync(log => (Faster.StoreWorker.CheckpointTrigger.None, null));
-
-                Debug.Assert(log.BeginAddress == currentBegin);
-                Debug.Assert(log.TailAddress == currentTail);
-            }
+                    Debug.Assert(log.BeginAddress == currentBegin);
+                    Debug.Assert(log.TailAddress == currentTail);
+                }
+            });
         }
     }
 }

--- a/test/DurableTask.Netherite.Tests/OrchestrationServiceTests.cs
+++ b/test/DurableTask.Netherite.Tests/OrchestrationServiceTests.cs
@@ -28,21 +28,27 @@ namespace DurableTask.Netherite.Tests
         }
 
         [Fact]
-        public async Task StopAsync_IsIdempotent()
+        public Task StopAsync_IsIdempotent()
         {
-            int numStops = 3;
-            IOrchestrationService service = TestConstants.GetTestOrchestrationService(this.loggerFactory);
-            for (int i =0; i < numStops; i++)
+            return Common.WithTimeoutAsync(TimeSpan.FromMinutes(1), async () =>
             {
-                await service.StopAsync();
-            }
+                int numStops = 3;
+                IOrchestrationService service = TestConstants.GetTestOrchestrationService(this.loggerFactory);
+                for (int i = 0; i < numStops; i++)
+                {
+                    await service.StopAsync();
+                }
+            });
         }
 
         [Fact]
-        public async Task UnstartedService_CanBeSafelyStopped()
+        public Task UnstartedService_CanBeSafelyStopped()
         {
-            IOrchestrationService service = TestConstants.GetTestOrchestrationService(this.loggerFactory);
-            await service.StopAsync();
+            return Common.WithTimeoutAsync(TimeSpan.FromMinutes(1), async () =>
+            {
+                IOrchestrationService service = TestConstants.GetTestOrchestrationService(this.loggerFactory);
+                await service.StopAsync();
+            });
         }
     }
 }

--- a/test/DurableTask.Netherite.Tests/QueryTests.cs
+++ b/test/DurableTask.Netherite.Tests/QueryTests.cs
@@ -28,6 +28,8 @@ namespace DurableTask.Netherite.Tests
         readonly Action<string> output;
         ITestOutputHelper outputHelper;
 
+        static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(1);
+
         public QueryTests(HostFixture fixture, ITestOutputHelper outputHelper)
         {
             this.fixture = fixture;
@@ -54,7 +56,6 @@ namespace DurableTask.Netherite.Tests
 
             Assert.False(this.fixture.HasError(out var error), $"detected test failure: {error}");
 
-
             // purge all instances after each test
             // this helps to catch "bad states" (e.g. hung workers) caused by the tests
             if (!this.host.PurgeAllAsync().Wait(TimeSpan.FromMinutes(3)))
@@ -74,159 +75,170 @@ namespace DurableTask.Netherite.Tests
         /// Ported from AzureStorageScenarioTests
         /// </summary>
         [Fact]
-        public async Task QueryOrchestrationInstancesByDateRange()
+        public Task QueryOrchestrationInstancesByDateRange()
         {
-            const int numInstances = 3;
-            string getPrefix(int ii) => $"@inst{ii}@__";
-
-            // Start multiple orchestrations. Use 1-based to avoid confusion where we use explicit values in asserts.
-            for (var ii = 1; ii <= numInstances; ++ii)
+            return Common.WithTimeoutAsync(DefaultTimeout, async () =>
             {
-                var client = await this.host.StartOrchestrationAsync(typeof(Orchestrations.SayHelloInline), $"world {ii}", $"{getPrefix(ii)}__{Guid.NewGuid()}");
-                await Task.Delay(100);  // To ensure time separation for the date time range queries
-                await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
-            }
+                const int numInstances = 3;
+                string getPrefix(int ii) => $"@inst{ii}@__";
 
-            var results = await this.host.GetAllOrchestrationInstancesAsync();
-            Assert.Equal(numInstances, results.Count);
-            for (var ii = 1; ii <= numInstances; ++ii)
-            {
-                Assert.NotNull(results.SingleOrDefault(r => r.Output == $"\"Hello, world {ii}!\""));
-            }
+                // Start multiple orchestrations. Use 1-based to avoid confusion where we use explicit values in asserts.
+                for (var ii = 1; ii <= numInstances; ++ii)
+                {
+                    var client = await this.host.StartOrchestrationAsync(typeof(Orchestrations.SayHelloInline), $"world {ii}", $"{getPrefix(ii)}__{Guid.NewGuid()}");
+                    await Task.Delay(100);  // To ensure time separation for the date time range queries
+                    await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+                }
 
-            // Select the middle instance for the time range query.
-            var middleInstance = results.SingleOrDefault(r => r.Output == $"\"Hello, world 2!\"");
-            void assertIsMiddleInstance(IList<OrchestrationState> testStates)
-            {
-                Assert.Equal(1, testStates.Count);
-                Assert.Equal(testStates[0].OrchestrationInstance.InstanceId, middleInstance.OrchestrationInstance.InstanceId);
-            }
+                var results = await this.host.GetAllOrchestrationInstancesAsync();
+                Assert.Equal(numInstances, results.Count);
+                for (var ii = 1; ii <= numInstances; ++ii)
+                {
+                    Assert.NotNull(results.SingleOrDefault(r => r.Output == $"\"Hello, world {ii}!\""));
+                }
 
-            assertIsMiddleInstance(await this.host.GetOrchestrationStateAsync(CreatedTimeFrom: middleInstance.CreatedTime,
-                                                                            CreatedTimeTo: middleInstance.CreatedTime.AddMilliseconds(50)));
-            assertIsMiddleInstance(await this.host.GetOrchestrationStateAsync(InstanceIdPrefix: getPrefix(2)));
+                // Select the middle instance for the time range query.
+                var middleInstance = results.SingleOrDefault(r => r.Output == $"\"Hello, world 2!\"");
+                void assertIsMiddleInstance(IList<OrchestrationState> testStates)
+                {
+                    Assert.Equal(1, testStates.Count);
+                    Assert.Equal(testStates[0].OrchestrationInstance.InstanceId, middleInstance.OrchestrationInstance.InstanceId);
+                }
+
+                assertIsMiddleInstance(await this.host.GetOrchestrationStateAsync(CreatedTimeFrom: middleInstance.CreatedTime,
+                                                                                CreatedTimeTo: middleInstance.CreatedTime.AddMilliseconds(50)));
+                assertIsMiddleInstance(await this.host.GetOrchestrationStateAsync(InstanceIdPrefix: getPrefix(2)));
+            });
         }
 
         /// <summary>
         /// Validate query functions.
         /// </summary>
         [Fact]
-        public async Task QueryOrchestrationInstanceByRuntimeStatus()
+        public Task QueryOrchestrationInstanceByRuntimeStatus()
         {
-            // Reuse counter as it provides a wait for the actor to complete itself.
-            var client = await this.host.StartOrchestrationAsync(typeof(Orchestrations.Counter), 0);
-
-            // Need to wait for the instance to start before sending events to it.
-            // TODO: This requirement may not be ideal and should be revisited.
-            await client.WaitForStartupAsync(TimeSpan.FromSeconds(10));
-            Trace.TraceInformation($"TestProgress: Counter is running.");
-
-            // We should have one orchestration state
-            var instanceStates = await this.host.GetAllOrchestrationInstancesAsync();
-            Assert.Equal(1, instanceStates.Count);
-
-            var inProgressStatus = new[] { OrchestrationStatus.Running, OrchestrationStatus.ContinuedAsNew };
-            var completedStatus = new[] { OrchestrationStatus.Completed };
-
-            async Task assertCounts(int running, int completed)
+            return Common.WithTimeoutAsync(DefaultTimeout, async () =>
             {
-                var runningStates = await this.host.GetOrchestrationStateAsync(RuntimeStatus: inProgressStatus);
-                Assert.Equal(running, runningStates.Count);
-                var completedStates = await this.host.GetOrchestrationStateAsync(RuntimeStatus: completedStatus);
-                Assert.Equal(completed, completedStates.Count);
-            }
+                // Reuse counter as it provides a wait for the actor to complete itself.
+                var client = await this.host.StartOrchestrationAsync(typeof(Orchestrations.Counter), 0);
 
-            // Make sure the client and instance are still running and didn't complete early (or fail).
-            var status = await client.GetStateAsync();
-            Assert.NotNull(status);
-            Assert.Contains(status.OrchestrationStatus, inProgressStatus);
-            await assertCounts(1, 0);
+                // Need to wait for the instance to start before sending events to it.
+                // TODO: This requirement may not be ideal and should be revisited.
+                await client.WaitForStartupAsync(TimeSpan.FromSeconds(10));
+                Trace.TraceInformation($"TestProgress: Counter is running.");
 
-            // The end message will cause the actor to complete itself.
-            Trace.TraceInformation($"TestProgress: Sending event to Counter.");
-            await client.RaiseEventAsync(Orchestrations.Counter.OpEventName, Orchestrations.Counter.OpEnd);
-            status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
-            Trace.TraceInformation($"TestProgress: Counter completed.");
+                // We should have one orchestration state
+                var instanceStates = await this.host.GetAllOrchestrationInstancesAsync();
+                Assert.Equal(1, instanceStates.Count);
 
-            // The client and instance should be Completed
-            Assert.NotNull(status);
-            Assert.Contains(status.OrchestrationStatus, completedStatus);
-            await assertCounts(0, 1);
+                var inProgressStatus = new[] { OrchestrationStatus.Running, OrchestrationStatus.ContinuedAsNew };
+                var completedStatus = new[] { OrchestrationStatus.Completed };
+
+                async Task assertCounts(int running, int completed)
+                {
+                    var runningStates = await this.host.GetOrchestrationStateAsync(RuntimeStatus: inProgressStatus);
+                    Assert.Equal(running, runningStates.Count);
+                    var completedStates = await this.host.GetOrchestrationStateAsync(RuntimeStatus: completedStatus);
+                    Assert.Equal(completed, completedStates.Count);
+                }
+
+                // Make sure the client and instance are still running and didn't complete early (or fail).
+                var status = await client.GetStateAsync();
+                Assert.NotNull(status);
+                Assert.Contains(status.OrchestrationStatus, inProgressStatus);
+                await assertCounts(1, 0);
+
+                // The end message will cause the actor to complete itself.
+                Trace.TraceInformation($"TestProgress: Sending event to Counter.");
+                await client.RaiseEventAsync(Orchestrations.Counter.OpEventName, Orchestrations.Counter.OpEnd);
+                status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+                Trace.TraceInformation($"TestProgress: Counter completed.");
+
+                // The client and instance should be Completed
+                Assert.NotNull(status);
+                Assert.Contains(status.OrchestrationStatus, completedStatus);
+                await assertCounts(0, 1);
+            });
         }
 
         [Fact]
-        public async void NoInstancesCreated()
+        public Task NoInstancesCreated()
         {
-            var instanceStates = await this.host.GetAllOrchestrationInstancesAsync();
-            Assert.Equal(0, instanceStates.Count);
+            return Common.WithTimeoutAsync(DefaultTimeout, async () =>
+            {
+                var instanceStates = await this.host.GetAllOrchestrationInstancesAsync();
+                Assert.Equal(0, instanceStates.Count);
+            });
         }
 
-
         [Fact]
-        public async Task PurgeInstanceHistoryForTimePeriodDeletePartially()
+        public Task PurgeInstanceHistoryForTimePeriodDeletePartially()
         {
-            DateTime startDateTime = DateTime.Now;
-            string firstInstanceId = Guid.NewGuid().ToString();
-            TestOrchestrationClient client = await this.host.StartOrchestrationAsync(typeof(Orchestrations.FanOutFanIn), 50, firstInstanceId);
-            await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
-            DateTime endDateTime = DateTime.Now;
-            await Task.Delay(5000);
-            string secondInstanceId = Guid.NewGuid().ToString();
-            client = await this.host.StartOrchestrationAsync(typeof(Orchestrations.FanOutFanIn), 50, secondInstanceId);
-            await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
-            string thirdInstanceId = Guid.NewGuid().ToString();
-            client = await this.host.StartOrchestrationAsync(typeof(Orchestrations.FanOutFanIn), 50, thirdInstanceId);
-            await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+            return Common.WithTimeoutAsync(DefaultTimeout, async () =>
+            {
+                DateTime startDateTime = DateTime.Now;
+                string firstInstanceId = Guid.NewGuid().ToString();
+                TestOrchestrationClient client = await this.host.StartOrchestrationAsync(typeof(Orchestrations.FanOutFanIn), 50, firstInstanceId);
+                await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+                DateTime endDateTime = DateTime.Now;
+                await Task.Delay(5000);
+                string secondInstanceId = Guid.NewGuid().ToString();
+                client = await this.host.StartOrchestrationAsync(typeof(Orchestrations.FanOutFanIn), 50, secondInstanceId);
+                await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+                string thirdInstanceId = Guid.NewGuid().ToString();
+                client = await this.host.StartOrchestrationAsync(typeof(Orchestrations.FanOutFanIn), 50, thirdInstanceId);
+                await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
-            IList<OrchestrationState> results = await this.host.GetAllOrchestrationInstancesAsync();
-            Assert.Equal(3, results.Count);
-            Assert.Equal("\"Done\"", results[0].Output);
-            Assert.Equal("\"Done\"", results[1].Output);
-            Assert.Equal("\"Done\"", results[2].Output);
+                IList<OrchestrationState> results = await this.host.GetAllOrchestrationInstancesAsync();
+                Assert.Equal(3, results.Count);
+                Assert.Equal("\"Done\"", results[0].Output);
+                Assert.Equal("\"Done\"", results[1].Output);
+                Assert.Equal("\"Done\"", results[2].Output);
 
-            List<HistoryStateEvent> firstHistoryEvents = await client.GetOrchestrationHistoryAsync(firstInstanceId);
-            Assert.True(firstHistoryEvents.Count > 0);
+                List<HistoryStateEvent> firstHistoryEvents = await client.GetOrchestrationHistoryAsync(firstInstanceId);
+                Assert.True(firstHistoryEvents.Count > 0);
 
-            List<HistoryStateEvent> secondHistoryEvents = await client.GetOrchestrationHistoryAsync(secondInstanceId);
-            Assert.True(secondHistoryEvents.Count > 0);
+                List<HistoryStateEvent> secondHistoryEvents = await client.GetOrchestrationHistoryAsync(secondInstanceId);
+                Assert.True(secondHistoryEvents.Count > 0);
 
-            List<HistoryStateEvent> thirdHistoryEvents = await client.GetOrchestrationHistoryAsync(thirdInstanceId);
-            Assert.True(secondHistoryEvents.Count > 0);
+                List<HistoryStateEvent> thirdHistoryEvents = await client.GetOrchestrationHistoryAsync(thirdInstanceId);
+                Assert.True(secondHistoryEvents.Count > 0);
 
-            IList<OrchestrationState> firstOrchestrationStateList = await client.GetStateAsync(firstInstanceId);
-            Assert.Equal(1, firstOrchestrationStateList.Count);
-            Assert.Equal(firstInstanceId, firstOrchestrationStateList.First().OrchestrationInstance.InstanceId);
+                IList<OrchestrationState> firstOrchestrationStateList = await client.GetStateAsync(firstInstanceId);
+                Assert.Equal(1, firstOrchestrationStateList.Count);
+                Assert.Equal(firstInstanceId, firstOrchestrationStateList.First().OrchestrationInstance.InstanceId);
 
-            IList<OrchestrationState> secondOrchestrationStateList = await client.GetStateAsync(secondInstanceId);
-            Assert.Equal(1, secondOrchestrationStateList.Count);
-            Assert.Equal(secondInstanceId, secondOrchestrationStateList.First().OrchestrationInstance.InstanceId);
+                IList<OrchestrationState> secondOrchestrationStateList = await client.GetStateAsync(secondInstanceId);
+                Assert.Equal(1, secondOrchestrationStateList.Count);
+                Assert.Equal(secondInstanceId, secondOrchestrationStateList.First().OrchestrationInstance.InstanceId);
 
-            IList<OrchestrationState> thirdOrchestrationStateList = await client.GetStateAsync(thirdInstanceId);
-            Assert.Equal(1, thirdOrchestrationStateList.Count);
-            Assert.Equal(thirdInstanceId, thirdOrchestrationStateList.First().OrchestrationInstance.InstanceId);
+                IList<OrchestrationState> thirdOrchestrationStateList = await client.GetStateAsync(thirdInstanceId);
+                Assert.Equal(1, thirdOrchestrationStateList.Count);
+                Assert.Equal(thirdInstanceId, thirdOrchestrationStateList.First().OrchestrationInstance.InstanceId);
 
-            await client.PurgeInstanceHistoryByTimePeriod(startDateTime, endDateTime, new List<OrchestrationStatus> { OrchestrationStatus.Completed, OrchestrationStatus.Terminated, OrchestrationStatus.Failed, OrchestrationStatus.Running });
+                await client.PurgeInstanceHistoryByTimePeriod(startDateTime, endDateTime, new List<OrchestrationStatus> { OrchestrationStatus.Completed, OrchestrationStatus.Terminated, OrchestrationStatus.Failed, OrchestrationStatus.Running });
 
-            List<HistoryStateEvent> firstHistoryEventsAfterPurging = await client.GetOrchestrationHistoryAsync(firstInstanceId);
-            Assert.Empty(firstHistoryEventsAfterPurging);
+                List<HistoryStateEvent> firstHistoryEventsAfterPurging = await client.GetOrchestrationHistoryAsync(firstInstanceId);
+                Assert.Empty(firstHistoryEventsAfterPurging);
 
-            List<HistoryStateEvent> secondHistoryEventsAfterPurging = await client.GetOrchestrationHistoryAsync(secondInstanceId);
-            Assert.True(secondHistoryEventsAfterPurging.Count > 0);
+                List<HistoryStateEvent> secondHistoryEventsAfterPurging = await client.GetOrchestrationHistoryAsync(secondInstanceId);
+                Assert.True(secondHistoryEventsAfterPurging.Count > 0);
 
-            List<HistoryStateEvent> thirdHistoryEventsAfterPurging = await client.GetOrchestrationHistoryAsync(thirdInstanceId);
-            Assert.True(thirdHistoryEventsAfterPurging.Count > 0);
+                List<HistoryStateEvent> thirdHistoryEventsAfterPurging = await client.GetOrchestrationHistoryAsync(thirdInstanceId);
+                Assert.True(thirdHistoryEventsAfterPurging.Count > 0);
 
-            firstOrchestrationStateList = await client.GetStateAsync(firstInstanceId);
-            Assert.Equal(0, firstOrchestrationStateList.Count);
-            Assert.Null(firstOrchestrationStateList.FirstOrDefault());
+                firstOrchestrationStateList = await client.GetStateAsync(firstInstanceId);
+                Assert.Equal(0, firstOrchestrationStateList.Count);
+                Assert.Null(firstOrchestrationStateList.FirstOrDefault());
 
-            secondOrchestrationStateList = await client.GetStateAsync(secondInstanceId);
-            Assert.Equal(1, secondOrchestrationStateList.Count);
-            Assert.Equal(secondInstanceId, secondOrchestrationStateList.First().OrchestrationInstance.InstanceId);
+                secondOrchestrationStateList = await client.GetStateAsync(secondInstanceId);
+                Assert.Equal(1, secondOrchestrationStateList.Count);
+                Assert.Equal(secondInstanceId, secondOrchestrationStateList.First().OrchestrationInstance.InstanceId);
 
-            thirdOrchestrationStateList = await client.GetStateAsync(thirdInstanceId);
-            Assert.Equal(1, thirdOrchestrationStateList.Count);
-            Assert.Equal(thirdInstanceId, thirdOrchestrationStateList.First().OrchestrationInstance.InstanceId);
+                thirdOrchestrationStateList = await client.GetStateAsync(thirdInstanceId);
+                Assert.Equal(1, thirdOrchestrationStateList.Count);
+                Assert.Equal(thirdInstanceId, thirdOrchestrationStateList.First().OrchestrationInstance.InstanceId);
+            });
         }
     }
 


### PR DESCRIPTION
Added some timeouts to the tests since we are seeing issues with hangs in the CI pipeline.

There are no changes inside the tests themselves, they just get wrapped in a timeout tracker.

While doing this, I also found a data race that gets triggered when the service is started with the cancellation token already cancelled. Fixed that also.

