### PR TITLE
Debug hangs in CI

### DIFF
--- a/src/DurableTask.Netherite/StorageLayer/Faster/CacheDebugger.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/CacheDebugger.cs
@@ -49,6 +49,7 @@ namespace DurableTask.Netherite.Faster
             PostCopyUpdate,
             SingleWriterUpsert,
             SingleWriterCopyToTail,
+            SingleWriterCopyToTailFromOutput,
             SingleWriterCopyToReadCache,
             SingleWriterCompaction,
             PostSingleWriterUpsert,

--- a/src/DurableTask.Netherite/StorageLayer/Faster/CacheDebugger.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/CacheDebugger.cs
@@ -425,7 +425,7 @@ namespace DurableTask.Netherite.Faster
             if (val.Version != versionOfObject)
             {
                 var info = this.GetObjectInfo(key);
-                this.Fail($"incorrect version: model=v{val.Version} actual=v{versionOfObject} obj={val.Val} cacheEvents={info.PrintCacheEvents()}");
+                this.Fail($"incorrect version: field=v{val.Version} object=v{versionOfObject} obj={val.Val} cacheEvents={info.PrintCacheEvents()}");
             }
         }
 

--- a/src/DurableTask.Netherite/StorageLayer/Faster/CheckpointInjector.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/CheckpointInjector.cs
@@ -32,50 +32,75 @@ namespace DurableTask.Netherite.Faster
             this.testHooks = testHooks;
         }
 
-        internal bool CheckpointDue(LogAccessor<FasterKV.Key, FasterKV.Value> log, out StoreWorker.CheckpointTrigger trigger, out long? compactUntil)
+        internal bool CheckpointDue(LogAccessor<FasterKV.Key, FasterKV.Value> log, out StoreWorker.CheckpointTrigger trigger, out long? compactUntil, FasterTraceHelper traceHelper)
         {
             if (this.handler != null)
             {
                 try
                 {
+                    traceHelper.FasterProgress("CheckpointInjector: running handler");
+
                     (trigger, compactUntil) = this.handler(log);
-                    this.handler = null;
+                    this.handler = null; // do not run the same handler again
+
+                    traceHelper.FasterProgress($"CheckpointInjector: trigger={trigger} compactUntil={compactUntil}");
 
                     if (trigger == StoreWorker.CheckpointTrigger.None)
                     {
-                        this.SequenceComplete(log);
+                        this.SequenceComplete(log, traceHelper);
                     }
-                } 
-                catch(Exception e)
-                {
-                    this.continuation.SetException(e);
-                    this.continuation = null;
-                    throw;
+
+                    return (trigger != StoreWorker.CheckpointTrigger.None);
                 }
+                catch (Exception e)
+                {
+                    traceHelper.FasterProgress($"CheckpointInjector: handler faulted: {e}");
+
+                    if (this.continuation.TrySetException(e))
+                    {
+                        traceHelper.FasterProgress("CheckpointInjector: handler continuation released with exception");
+                    }
+                    else
+                    {
+                        traceHelper.FasterProgress("CheckpointInjector: handler continuation already progressed");
+                    }
+                }
+            }
+
+            trigger = StoreWorker.CheckpointTrigger.None;
+            compactUntil = null;
+            return false;
+        }    
+                  
+        internal void SequenceComplete(LogAccessor<FasterKV.Key, FasterKV.Value> log, FasterTraceHelper traceHelper)
+        {
+            traceHelper.FasterProgress("CheckpointInjector: sequence complete");
+
+            if (this.continuation.TrySetResult(log))
+            {
+                traceHelper.FasterProgress("CheckpointInjector: handler continuation released");
             }
             else
             {
-                trigger = StoreWorker.CheckpointTrigger.None;
-                compactUntil = null;
+                traceHelper.FasterProgress("CheckpointInjector: handler continuation already progressed");
             }
-
-            return (trigger != StoreWorker.CheckpointTrigger.None);
         }
 
-        internal void SequenceComplete(LogAccessor<FasterKV.Key, FasterKV.Value> log)
-        {
-            this.continuation?.SetResult(log);
-            this.continuation = null;
-        }
-
-        internal void CompactionComplete(IPartitionErrorHandler errorHandler)
+        internal void CompactionComplete(IPartitionErrorHandler errorHandler, FasterTraceHelper traceHelper)
         {
             if (this.InjectFaultAfterCompaction)
             {
                 errorHandler.HandleError("CheckpointInjector", "inject failure after compaction", null, true, false);
-                this.InjectFaultAfterCompaction = false;
-                this.continuation?.SetResult(null);
-                this.continuation = null;
+                this.InjectFaultAfterCompaction = false; // do not do this again unless requested again
+
+                if (this.continuation.TrySetResult(null))
+                {
+                    traceHelper.FasterProgress("CheckpointInjector: handler continuation released");
+                }
+                else
+                {
+                    traceHelper.FasterProgress("CheckpointInjector: handler continuation already progressed");
+                }
             }
         }
 

--- a/src/DurableTask.Netherite/StorageLayer/Faster/FasterKV.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/FasterKV.cs
@@ -2081,7 +2081,10 @@ namespace DurableTask.Netherite.Faster
                         break;
 
                     case WriteReason.CopyToTail:
-                        takeValueFromOutput = (output.Val != null); // we have observed that src.Val is null sometimes, so if present, we use output instead
+                        // we have empirically observed that src does sometimes not contain the correct value (is null)
+                        // we are not sure if this is a bug in FASTER or intended behavior
+                        // as a workaround for those situations, we are passing the source value in the output parameter, which seems to work o.k.
+                        takeValueFromOutput = (output.Val != null);
                         if (takeValueFromOutput)
                         {
                             this.cacheDebugger?.Record(key.Val, CacheDebugger.CacheEvent.SingleWriterCopyToTailFromOutput, output.Version, default, info.Address);

--- a/test/DurableTask.Netherite.Tests/ConcurrentTestsFaster.cs
+++ b/test/DurableTask.Netherite.Tests/ConcurrentTestsFaster.cs
@@ -109,7 +109,7 @@ namespace DurableTask.Netherite.Tests
 
                     var tests = new List<(string, Task)>();
 
-                    foreach ((string name, Task task) in scenarios.StartAllScenarios(includeTimers: true, includeLarge: true))
+                    foreach ((string name, Task task) in scenarios.StartAllScenarios(includeTimers: false, includeLarge: true))
                     {
                         Trace.WriteLine($"TestProgress: Adding {name}");
                         tests.Add((name, task));


### PR DESCRIPTION
We have seen a lot of hangs recently in the CI, which seem to not be caused by recent changes but look a bit like errors in the test framework. I created this PR as a way to further investigate and hopefully fix these hangs.

In this first step, I am trying to understand hangs in the QueriesCopyToTail test which I have seen repeatedly in CI. The hangs seem to have something to do with the checkpoint injection mechanism used by the test. To narrow this down, we revise this state machine and add lots of tracing.