### PR TITLE
Add a configuration parameter for specifying the task hub parameters file

### DIFF
--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
@@ -226,7 +226,7 @@ namespace DurableTask.Netherite
                 try
                 {
                     ILoadPublisherService loadPublisher = string.IsNullOrEmpty(this.Settings.LoadInformationAzureTableName) ?
-                        new AzureBlobLoadPublisher(this.Settings.BlobStorageConnection, this.Settings.HubName)
+                        new AzureBlobLoadPublisher(this.Settings.BlobStorageConnection, this.Settings.HubName, this.Settings.TaskhubParametersFilePath)
                         : new AzureTableLoadPublisher(this.Settings.TableStorageConnection, this.Settings.LoadInformationAzureTableName, this.Settings.HubName);
 
                     monitor = new ScalingMonitor(

--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationServiceSettings.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationServiceSettings.cs
@@ -119,6 +119,11 @@ namespace DurableTask.Netherite
         public string PartitionManagementParameters { get; set; } = null;
 
         /// <summary>
+        /// The path to the file containing the taskhub parameters.
+        /// </summary>
+        public string TaskhubParametersFilePath { get; set; } = "taskhubparameters.json";
+
+        /// <summary>
         /// Gets or sets the activity scheduler option
         /// </summary>
         [JsonConverter(typeof(StringEnumConverter))]

--- a/src/DurableTask.Netherite/Scaling/AzureBlobLoadPublisher.cs
+++ b/src/DurableTask.Netherite/Scaling/AzureBlobLoadPublisher.cs
@@ -19,6 +19,7 @@ namespace DurableTask.Netherite.Scaling
     {
         readonly string taskHubName;
         readonly Task<CloudBlobContainer> blobContainer;
+        readonly string taskhubParametersFilePath;      
         TaskhubParameters parameters;
 
         readonly static JsonSerializerSettings serializerSettings = new JsonSerializerSettings() 
@@ -27,10 +28,11 @@ namespace DurableTask.Netherite.Scaling
             MissingMemberHandling = MissingMemberHandling.Ignore,
         };
 
-        public AzureBlobLoadPublisher(ConnectionInfo connectionInfo, string taskHubName)
+        public AzureBlobLoadPublisher(ConnectionInfo connectionInfo, string taskHubName, string taskHubParametersFilePath)
         {
             this.blobContainer = this.GetBlobContainer(connectionInfo, taskHubName);
             this.taskHubName = taskHubName;
+            this.taskhubParametersFilePath = taskHubParametersFilePath;
         }
 
         async Task<CloudBlobContainer> GetBlobContainer(ConnectionInfo connectionInfo, string taskHubName)
@@ -54,7 +56,7 @@ namespace DurableTask.Netherite.Scaling
             if (this.parameters == null)
             {
                 this.parameters = await this.ReadJsonBlobAsync<Netherite.Abstractions.TaskhubParameters>(
-                    (await this.blobContainer).GetBlockBlobReference("taskhubparameters.json"),
+                    (await this.blobContainer).GetBlockBlobReference(this.taskhubParametersFilePath),
                     throwIfNotFound: throwIfNotFound,
                     throwOnParseError: throwIfNotFound,
                     cancellationToken).ConfigureAwait(false);

--- a/src/DurableTask.Netherite/StorageLayer/Faster/FasterStorageProvider.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/FasterStorageProvider.cs
@@ -73,7 +73,7 @@ namespace DurableTask.Netherite.Faster
             async Task<CloudBlockBlob> GetTaskhubParametersAsync()
             {
                 var cloudBlobContainer = await this.cloudBlobContainer;
-                return cloudBlobContainer.GetBlockBlobReference("taskhubparameters.json");
+                return cloudBlobContainer.GetBlockBlobReference(settings.TaskhubParametersFilePath);
             }
 
             this.traceHelper.TraceProgress("Creating LoadPublisher Service");
@@ -83,7 +83,7 @@ namespace DurableTask.Netherite.Faster
             }
             else
             {
-                this.LoadPublisher = new AzureBlobLoadPublisher(settings.BlobStorageConnection, settings.HubName);
+                this.LoadPublisher = new AzureBlobLoadPublisher(settings.BlobStorageConnection, settings.HubName, settings.TaskhubParametersFilePath);
             }
         }
 

--- a/test/PerformanceTests/host.json
+++ b/test/PerformanceTests/host.json
@@ -100,6 +100,8 @@
         // "PartitionManagement": "RecoveryTester",
         // "PartitionManagementParameters": "7",
 
+        //"TaskhubParametersFilePath": "preserved-hub.json",
+
         // set this to "Local" to disable the global activity distribution algorithm
         // options: "Local", "Static", "Locavore"
         "ActivityScheduler": "Locavore",


### PR DESCRIPTION
Adds a new parameter to the `NetheriteOrchestrationServiceSettings`:

```csharp
/// <summary>
/// The path to the file containing the taskhub parameters.
/// </summary>
public string TaskhubParametersFilePath { get; set; } = "taskhubparameters.json";
```

This allows us to keep multiple "versions" of a taskhub in storage by using different task hub parameters files. Specifically, we intend to use this to debug potential corruptions in FASTER, by using this parameter in conjunction with the RecoveryTester feature.