### PR TITLE
Fix missing ProcessPartitionEventAsync handler

### DIFF
--- a/src/DurableTask.Netherite/TransportLayer/EventHubs/EventProcessorHost.cs
+++ b/src/DurableTask.Netherite/TransportLayer/EventHubs/EventProcessorHost.cs
@@ -43,6 +43,7 @@ namespace DurableTask.Netherite.EventHubsTransport
             this.factory = args.Factory;
             this.traceHelper = args.TraceHelper;
             this.PartitionInitializingAsync += this.OpenPartitionAsync;
+            this.ProcessEventAsync += this.ProcessPartitionEventAsync;
             this.PartitionClosingAsync += this.ClosePartitionAsync;
             this.ProcessErrorAsync += this.ErrorAsync;
         }


### PR DESCRIPTION
As observed in https://github.com/microsoft/durabletask-netherite/issues/430, the handler registration was missing.

This appears to be a simple copy-paste mistake but it was not caught by testing because the tests use the other constructor overload.