### PR TITLE
Implement detection and potential mitigation of recovery failure cycles

### DIFF
--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationServiceSettings.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationServiceSettings.cs
@@ -207,6 +207,11 @@ namespace DurableTask.Netherite
         public int PartitionStartupTimeoutMinutes { get; set; } = 15;
 
         /// <summary>
+        /// If true, disables the prefetching during replay.
+        /// </summary>
+        public bool DisablePrefetchDuringReplay { get; set; } = false;
+
+        /// <summary>
         /// Allows attaching additional checkers and debuggers during testing.
         /// </summary>
         [JsonIgnore]

--- a/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/BlobManager.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/BlobManager.cs
@@ -1140,10 +1140,14 @@ namespace DurableTask.Netherite.Faster
 
                 await this.WriteCheckpointMetadataAsync();
 
-                // we boost the tracing after three failed attempts. This boosting applies to the recovery part only.
-                // After thirty attempts, we stop boosting since it seems unlikely
-                // that there is any more information after that that cannot be found in the logs for the first 30 attempts.
-                if (this.CheckpointInfo.RecoveryAttempts > 3 && this.CheckpointInfo.RecoveryAttempts < 30)
+                // we start to boost the tracing after three failed attempts. This boosting applies to the recovery part only.
+                int StartBoostingAfter = 3;
+
+                // After some number of boosted attempts, we stop boosting since it seems unlikely that we will find new information.
+                int BoostFor = 10;
+
+                if (this.CheckpointInfo.RecoveryAttempts > StartBoostingAfter
+                    && this.CheckpointInfo.RecoveryAttempts <= StartBoostingAfter + BoostFor)
                 {
                     this.TraceHelper.BoostTracing = true;
                 }

--- a/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/BlobManager.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/BlobManager.cs
@@ -1140,6 +1140,9 @@ namespace DurableTask.Netherite.Faster
 
                 await this.WriteCheckpointMetadataAsync();
 
+                // we boost the tracing after three failed attempts. This boosting applies to the recovery part only.
+                // After thirty attempts, we stop boosting since it seems unlikely
+                // that there is any more information after that that cannot be found in the logs for the first 30 attempts.
                 if (this.CheckpointInfo.RecoveryAttempts > 3 && this.CheckpointInfo.RecoveryAttempts < 30)
                 {
                     this.TraceHelper.BoostTracing = true;

--- a/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/CheckpointInfo.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/AzureBlobs/CheckpointInfo.cs
@@ -10,25 +10,46 @@ namespace DurableTask.Netherite.Faster
     [JsonObject]
     class CheckpointInfo
     {
+        /// <summary>
+        /// The FasterKV token for the last index checkpoint taken before this checkpoint.
+        /// </summary>
         [JsonProperty]
         public Guid IndexToken { get; set; }
 
+        /// <summary>
+        /// The FasterKV token for this checkpoint.
+        /// </summary>
         [JsonProperty]
         public Guid LogToken { get; set; }
 
+        /// <summary>
+        /// The FasterLog position for this checkpoint.
+        /// </summary>
         [JsonProperty]
         public long CommitLogPosition { get; set; }
 
+        /// <summary>
+        /// The input queue (event hubs) position for this checkpoint.
+        /// </summary>
         [JsonProperty]
         public long InputQueuePosition { get; set; }
 
+        /// <summary>
+        /// If the input queue position is a batch, the position within the batch.
+        /// </summary>
         [JsonProperty]
         public int InputQueueBatchPosition { get; set; }
 
+        /// <summary>
+        /// The input queue fingerprint for this checkpoint.
+        /// </summary>
         [JsonProperty]
         public string InputQueueFingerprint { get; set; }
 
-        [JsonProperty]
-        public long NumberInstances { get; set; }
+        /// <summary>
+        /// The number of recovery attempts that have been made for this checkpoint.
+        /// </summary>
+        //[JsonProperty]
+        public int RecoveryAttempts { get; set; }
     }
 }

--- a/src/DurableTask.Netherite/StorageLayer/Faster/FasterKV.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/FasterKV.cs
@@ -380,7 +380,7 @@ namespace DurableTask.Netherite.Faster
 
         public override async Task FinalizeCheckpointCompletedAsync(Guid guid)
         {
-            await this.blobManager.FinalizeCheckpointCompletedAsync();
+            await this.blobManager.WriteCheckpointMetadataAsync();
 
             if (this.cacheDebugger == null)
             {
@@ -739,7 +739,7 @@ namespace DurableTask.Netherite.Faster
             long lastReport = 0;
             void ReportProgress(int elapsedMillisecondsThreshold)
             {
-                if (stopwatch.ElapsedMilliseconds - lastReport >= elapsedMillisecondsThreshold)
+                if (stopwatch.ElapsedMilliseconds - lastReport >= elapsedMillisecondsThreshold || this.TraceHelper.BoostTracing)
                 {
                     this.blobManager.TraceHelper.FasterProgress(
                         $"FasterKV PrefetchSession {sessionId} elapsed={stopwatch.Elapsed.TotalSeconds:F2}s issued={numberIssued} pending={maxConcurrency - prefetchSemaphore.CurrentCount} hits={numberHits} misses={numberMisses}");

--- a/src/DurableTask.Netherite/StorageLayer/Faster/FasterTraceHelper.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/FasterTraceHelper.cs
@@ -25,7 +25,9 @@ namespace DurableTask.Netherite.Faster
             this.partitionId = (int) partitionId;
         }
 
-        public bool IsTracingAtMostDetailedLevel => this.logLevelLimit == LogLevel.Trace;
+        public bool IsTracingAtMostDetailedLevel => this.logLevelLimit == LogLevel.Trace || this.BoostTracing;
+
+        public bool BoostTracing { get; set; }
 
         // ----- faster storage layer events
 
@@ -139,7 +141,7 @@ namespace DurableTask.Netherite.Faster
 
         public void FasterStorageProgress(string details)
         {
-            if (this.logLevelLimit <= LogLevel.Trace)
+            if (this.logLevelLimit <= LogLevel.Trace || this.BoostTracing)
             {
                 this.logger.LogTrace("Part{partition:D2} {details}", this.partitionId, details);
                 EtwSource.Log.FasterStorageProgress(this.account, this.taskHub, this.partitionId, details, TraceUtils.AppName, TraceUtils.ExtensionVersion);

--- a/src/DurableTask.Netherite/StorageLayer/Faster/LogWorker.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/LogWorker.cs
@@ -207,7 +207,7 @@ namespace DurableTask.Netherite.Faster
             }
         }
 
-        public async Task ReplayCommitLog(long from, StoreWorker worker)
+        public async Task ReplayCommitLog(long from, StoreWorker worker, bool enablePrefetch)
         {
             // this procedure is called by StoreWorker during recovery. It replays all the events
             // that were committed to the log but are not reflected in the loaded store checkpoint.
@@ -220,7 +220,11 @@ namespace DurableTask.Netherite.Faster
 
                 var fetchTask = this.FetchEvents(from, replayChannel.Writer, prefetchChannel.Writer);
                 var replayTask = Task.Run(() => this.ReplayEvents(replayChannel.Reader, worker));
-                var prefetchTask = Task.Run(() => worker.RunPrefetchSession(prefetchChannel.Reader.ReadAllAsync(this.cancellationToken)));
+
+                if (enablePrefetch)
+                {
+                    var prefetchTask = Task.Run(() => worker.RunPrefetchSession(prefetchChannel.Reader.ReadAllAsync(this.cancellationToken)));
+                }
 
                 await fetchTask;
                 await replayTask;

--- a/src/DurableTask.Netherite/StorageLayer/Faster/PartitionStorage.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/PartitionStorage.cs
@@ -191,6 +191,8 @@ namespace DurableTask.Netherite.Faster
                     {
                         // replay log as the store checkpoint lags behind the log
 
+                        // disable prefetch if we have had many unsuccessful recovery attempts, or if the settings say so    
+                        // We choose 6 as the threshold since the tracing gets boosted after 3 attempts, and we want to see 3 attempts with boosted tracing before we disable prefetch
                         bool disablePrefetch = this.blobManager.CheckpointInfo.RecoveryAttempts > 6 || this.settings.DisablePrefetchDuringReplay;
 
                         await this.TerminationWrapper(this.storeWorker.ReplayCommitLog(this.logWorker, prefetch: !disablePrefetch));

--- a/src/DurableTask.Netherite/StorageLayer/Faster/PartitionStorage.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/PartitionStorage.cs
@@ -191,9 +191,11 @@ namespace DurableTask.Netherite.Faster
                     {
                         // replay log as the store checkpoint lags behind the log
 
-                        // disable prefetch if we have had many unsuccessful recovery attempts, or if the settings say so    
-                        // We choose 6 as the threshold since the tracing gets boosted after 3 attempts, and we want to see 3 attempts with boosted tracing before we disable prefetch
-                        bool disablePrefetch = this.blobManager.CheckpointInfo.RecoveryAttempts > 6 || this.settings.DisablePrefetchDuringReplay;
+                        // after six unsuccessful attempts, we start disabling prefetch on every other attempt, to see if this can remedy the problem
+                        int startDisablingPrefetchAfter = 6;
+
+                        bool disablePrefetch = this.settings.DisablePrefetchDuringReplay
+                            || (this.blobManager.CheckpointInfo.RecoveryAttempts > startDisablingPrefetchAfter && (this.blobManager.CheckpointInfo.RecoveryAttempts - startDisablingPrefetchAfter) % 2 == 1);
 
                         await this.TerminationWrapper(this.storeWorker.ReplayCommitLog(this.logWorker, prefetch: !disablePrefetch));
                     }

--- a/src/DurableTask.Netherite/StorageLayer/Faster/StoreWorker.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/StoreWorker.cs
@@ -684,7 +684,7 @@ namespace DurableTask.Netherite.Faster
         public async Task ReplayCommitLog(LogWorker logWorker, bool prefetch)
         {
             var startPosition = this.CommitLogPosition;
-            this.traceHelper.FasterProgress($"Replaying log from {startPosition} prefetch={prefetch}");
+            this.traceHelper.FasterProgress($"Replaying log from {startPosition} prefetch={prefetch} boostTracing={this.traceHelper.BoostTracing}");
 
             var stopwatch = new System.Diagnostics.Stopwatch();
             stopwatch.Start();

--- a/src/DurableTask.Netherite/StorageLayer/Faster/StoreWorker.cs
+++ b/src/DurableTask.Netherite/StorageLayer/Faster/StoreWorker.cs
@@ -681,16 +681,16 @@ namespace DurableTask.Netherite.Faster
             return target;
         }
 
-        public async Task ReplayCommitLog(LogWorker logWorker)
+        public async Task ReplayCommitLog(LogWorker logWorker, bool prefetch)
         {
             var startPosition = this.CommitLogPosition;
-            this.traceHelper.FasterProgress($"Replaying log from {startPosition}");
+            this.traceHelper.FasterProgress($"Replaying log from {startPosition} prefetch={prefetch}");
 
             var stopwatch = new System.Diagnostics.Stopwatch();
             stopwatch.Start();
 
             this.effectTracker.IsReplaying = true;
-            await logWorker.ReplayCommitLog(startPosition, this);
+            await logWorker.ReplayCommitLog(startPosition, this, prefetch);
             stopwatch.Stop();
             this.effectTracker.IsReplaying = false;
 


### PR DESCRIPTION
In light of recent issues with FASTER crashing repeatedly during recovery, while replaying the commit log, this PR implements several steps that should help us troubleshoot the issue (and possibly mitigate it).

1. We are adding a recovery attempt counter to the last-checkpoint.json file so we can detect if partition recovery is repeatedly failing.

2. If the number of recovery attempts is between 3 and 30, we are boosting the tracing for the duration of the recovery. This may help us investigate the location of where the crash happens.

3. If the number of recovery attempts is larger than 6, we are disabling the prefetch during the replay. This means FASTER is executing fetch operations sequentially during replay, which slows down the replay A LOT but makes it more deterministic so we can better pinpoint the failure. It is also possible that this may eliminate the failure (e.g. if the bug is a race condition). Slowing the replay down would be a bad idea in general but actually desirable in this situation since it will also reduce the frequency of crashes caused by the struggling partition.