### PR TITLE
Add settings to customize orchestration client timeouts (#427)

### DIFF
--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationServiceSettings.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationServiceSettings.cs
@@ -212,6 +212,21 @@ namespace DurableTask.Netherite
         public bool DisablePrefetchDuringReplay { get; set; } = false;
 
         /// <summary>
+        /// Time limit for orchestration client operations.
+        /// </summary>
+        public TimeSpan ClientTimeout { get; set; } = TimeSpan.FromMinutes(5);
+
+        /// <summary>
+        /// Time limit for CreateTaskOrchestration client operation.
+        /// </summary>
+        public TimeSpan? CreateOrchestrationTimeout { get; set; }
+
+        /// <summary>
+        /// Time limit for SendTaskOrchestrationMessage client operation.
+        /// </summary>
+        public TimeSpan? SendOrchestrationMessageTimeout { get; set; }
+
+        /// <summary>
         /// Allows attaching additional checkers and debuggers during testing.
         /// </summary>
         [JsonIgnore]


### PR DESCRIPTION
### Summary of changes

- Introduce new settings to control orchestration client timeouts
- Define individual timeouts for client operations that are most often used from http triggered functions / endpoints
- Modify timeout bucketing not to align short timeouts which would be materially adjusted by the alignment

### Key design choices

- New timeout fields use `TimeSpan` type. This does not align with existing `PartitonStartupTimeoutMinutes` field but does align with how timeouts are specified in [AzureStorageOrchestrationServiceSettings](https://github.com/Azure/durabletask/blob/cce2a91c2701f82877ac7ccb688e51e267bc592d/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs#L60)
- Define separate timeouts for orchestration creation and message passing calls which are expected to be used most in latency sensitive paths such as http endpoints

### Testing done

- Tested manually with an internal client application

### Feedback requested

Please review the use of `TimeSpan` type and overall fit and finish.
