### PR TITLE
Add explicit STJ reference for component governance

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,6 +20,7 @@
     <PackageVersion Include="Microsoft.FASTER.Core" Version="2.6.5" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageVersion Include="System.Text.Json" Version="6.0.10" />
   </ItemGroup>
 
   <!-- Tests dependencies -->

--- a/src/DurableTask.Netherite.AzureFunctions/DurableTask.Netherite.AzureFunctions.csproj
+++ b/src/DurableTask.Netherite.AzureFunctions/DurableTask.Netherite.AzureFunctions.csproj
@@ -47,6 +47,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.DurableTask.Core" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DurableTask.Netherite/DurableTask.Netherite.csproj
+++ b/src/DurableTask.Netherite/DurableTask.Netherite.csproj
@@ -59,6 +59,7 @@
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
There are no direct references to System.Text.Json in this repo, but indirect references point to System.Text.Json 6.0.9, which has a known vulnerability. This change adds an explicit reference and sets the version to 6.0.10.