### PR TITLE
Fix yaml indentation for possible CI issue

### DIFF
--- a/eng/ci/code-mirror.yml
+++ b/eng/ci/code-mirror.yml
@@ -1,9 +1,9 @@
 trigger:
   branches:
     include:
-    # These are the branches we'll mirror to our internal ADO instance
-    # Keep this set limited as appropriate (don't mirror individual user branches).
-    - main
+      # These are the branches we'll mirror to our internal ADO instance
+      # Keep this set limited as appropriate (don't mirror individual user branches).
+      - main
 
 resources:
   repositories:


### PR DESCRIPTION
On our last commit to main the CI for code-mirror did not auto-trigger. Suspect a YAML indentation issue, this PR fixes it