### PR TITLE
Bump azure-functions/dotnet from 3.0 to 3.0.15960 in /test/PerformanceTests

### DIFF
--- a/test/PerformanceTests/Dockerfile
+++ b/test/PerformanceTests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/azure-functions/dotnet:3.0.15960.15960
+FROM mcr.microsoft.com/azure-functions/dotnet:3.0.15960
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot WEBSITE_HOSTNAME=localhost:80
 

--- a/test/PerformanceTests/Dockerfile
+++ b/test/PerformanceTests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/azure-functions/dotnet:3.0
+FROM mcr.microsoft.com/azure-functions/dotnet:3.0.15960.15960
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot WEBSITE_HOSTNAME=localhost:80
 


### PR DESCRIPTION
Updating `mcr.microsoft.com/azure-functions/dotnet:3.0` to `mcr.microsoft.com/azure-functions/dotnet:3.0.15960`.

3.0.15960 is listed in [https://mcr.microsoft.com/v2/azure-functions/dotnet/tags/list](https://mcr.microsoft.com/v2/azure-functions/dotnet/tags/list)