### PR TITLE
[SECURITY] Bump validator and durable-functions

### DIFF
--- a/samples/Hello_Netherite_with_TypeScript/package-lock.json
+++ b/samples/Hello_Netherite_with_TypeScript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "axios": "^1.12.1",
-        "durable-functions": "^3.1.0"
+        "durable-functions": "^3.3.0"
       },
       "devDependencies": {
         "@azure/functions": "^1.2.3",
@@ -29,6 +29,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/asynckit": {
@@ -111,17 +120,19 @@
       }
     },
     "node_modules/durable-functions": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/durable-functions/-/durable-functions-3.1.0.tgz",
-      "integrity": "sha512-baSkW45/VrVvl1e27qvxEZX2z5vApiINaGUTIxx0c4H5E2Lr22QnogZrebqIhyfspZ466XKhp245nyS0HSkAYg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/durable-functions/-/durable-functions-3.3.0.tgz",
+      "integrity": "sha512-x05zUsM1h1Mk2GB2DRC88xhwDL4WWnMberORU2E0HpqC0mL1+qQ7fhAnGvkL5NrisLa+ECVxaXYStz43gbXF0Q==",
+      "license": "MIT",
       "dependencies": {
         "@azure/functions": "^4.0.0",
-        "axios": "^1.6.1",
+        "@opentelemetry/api": "^1.9.0",
+        "axios": "^1.11.0",
         "debug": "~2.6.9",
         "lodash": "^4.17.15",
         "moment": "^2.29.2",
-        "uuid": "~3.3.2",
-        "validator": "~13.7.0"
+        "uuid": "^9.0.1",
+        "validator": "~13.15.20"
       },
       "engines": {
         "node": ">=18.0"
@@ -400,18 +411,23 @@
       }
     },
     "node_modules/uuid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/validator": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
-      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
+      "version": "13.15.23",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.23.tgz",
+      "integrity": "sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }

--- a/samples/Hello_Netherite_with_TypeScript/package.json
+++ b/samples/Hello_Netherite_with_TypeScript/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "axios": "^1.12.1",
-    "durable-functions": "^3.1.0"
+    "durable-functions": "^3.3.0"
   },
   "devDependencies": {
     "@azure/functions": "^1.2.3",


### PR DESCRIPTION
Bumps [validator](https://github.com/validatorjs/validator.js) to 13.15.23 and updates ancestor dependency [durable-functions](https://github.com/Azure/azure-functions-durable-js). These dependencies need to be updated together.


Updates `validator` from 13.7.0 to 13.15.23
- [Release notes](https://github.com/validatorjs/validator.js/releases)
- [Changelog](https://github.com/validatorjs/validator.js/blob/master/CHANGELOG.md)
- [Commits](https://github.com/validatorjs/validator.js/compare/13.7.0...13.15.23)

Updates `durable-functions` from 3.1.0 to 3.3.0
- [Release notes](https://github.com/Azure/azure-functions-durable-js/releases)
- [Commits](https://github.com/Azure/azure-functions-durable-js/compare/v3.1.0...v3.3.0)