### PR TITLE
Update the Accessibility of scaling and metrics-related services in DurableTask.Netherite

### DIFF
--- a/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
+++ b/src/DurableTask.Netherite/OrchestrationService/NetheriteOrchestrationService.cs
@@ -82,7 +82,7 @@ namespace DurableTask.Netherite
         Client client;
         Client checkedClient;
 
-        internal NetheriteOrchestrationServiceSettings Settings { get; private set; }
+        public NetheriteOrchestrationServiceSettings Settings { get; private set; }
         internal uint NumberPartitions { get; private set; }
         internal string PathPrefix { get; private set; }
         internal string ContainerName { get; private set; }
@@ -252,14 +252,14 @@ namespace DurableTask.Netherite
             return false;
         }
 
-        internal ILoadPublisherService GetLoadPublisher()
+        public ILoadPublisherService GetLoadPublisher()
         {
             return string.IsNullOrEmpty(this.Settings.LoadInformationAzureTableName) ?
                 new AzureBlobLoadPublisher(this.Settings.BlobStorageConnection, this.Settings.HubName, this.Settings.TaskhubParametersFilePath)
                 : new AzureTableLoadPublisher(this.Settings.TableStorageConnection, this.Settings.LoadInformationAzureTableName, this.Settings.HubName);
         }
 
-        internal NetheriteMetricsProvider GetNetheriteMetricsProvider(ILoadPublisherService loadPublisher, ConnectionInfo eventHubsConnection)
+        public NetheriteMetricsProvider GetNetheriteMetricsProvider(ILoadPublisherService loadPublisher, ConnectionInfo eventHubsConnection)
         {
             return new NetheriteMetricsProvider(loadPublisher, eventHubsConnection);
         }

--- a/src/DurableTask.Netherite/Scaling/AzureBlobLoadPublisher.cs
+++ b/src/DurableTask.Netherite/Scaling/AzureBlobLoadPublisher.cs
@@ -18,7 +18,7 @@ namespace DurableTask.Netherite.Scaling
     using System.Threading;
     using System.Threading.Tasks;
 
-    class AzureBlobLoadPublisher : ILoadPublisherService
+    public class AzureBlobLoadPublisher : ILoadPublisherService
     {
         readonly string taskHubName;
         readonly BlobContainerClient blobContainerClient;

--- a/src/DurableTask.Netherite/Scaling/AzureTableLoadPublisher.cs
+++ b/src/DurableTask.Netherite/Scaling/AzureTableLoadPublisher.cs
@@ -14,7 +14,7 @@ namespace DurableTask.Netherite.Scaling
     using System.Threading;
     using System.Threading.Tasks;
 
-    class AzureTableLoadPublisher : ILoadPublisherService
+    public class AzureTableLoadPublisher : ILoadPublisherService
     {
         readonly TableClient table;
         readonly string taskHubName;

--- a/src/common.props
+++ b/src/common.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
 	<MajorVersion>3</MajorVersion>
 	<MinorVersion>1</MinorVersion>
-	<PatchVersion>0</PatchVersion>
+	<PatchVersion>1</PatchVersion>
 	<VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
 	<VersionSuffix></VersionSuffix>
 	<AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>


### PR DESCRIPTION
This PR updates the accessibility of several metric-based services in DurableTask.Netherite for the updated scaling change in durable functions.

Related PR https://github.com/Azure/azure-functions-durable-extension/pull/3240

**Visibility improvements for scaling and metrics services:**

* Changed the `Settings` property in `NetheriteOrchestrationService` from `internal` to `public` to allow external access.
* Made the `GetLoadPublisher` and `GetNetheriteMetricsProvider` methods in `NetheriteOrchestrationService` public, enabling external code to instantiate these services.

**Class accessibility updates:**

* Changed the `AzureBlobLoadPublisher` and `AzureTableLoadPublisher` classes from `internal` to `public`, allowing them to be used outside the `Scaling` namespace. [[1]](diffhunk://#diff-b3e668f544f7c5de79bd972551a320edd2d997dce79f7f3f91142c04b315f7d8L21-R21) [[2]](diffhunk://#diff-69f04e861e5b74d610673de17c260a684a2e0987ed24ed8bd957492b44db3498L17-R17)

**Version update:**

* Bumped the patch version in `src/common.props` from `3.1.0` to `3.1.1`.